### PR TITLE
Add type:shape to project.mml layer references for shapefiles

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -46,7 +46,8 @@
       "id": "world",
       "class": "",
       "Datasource": {
-        "file": "data/shoreline_300/shoreline_300.shp"
+        "file": "data/shoreline_300/shoreline_300.shp",
+        "type": "shape"
       },
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
@@ -64,7 +65,8 @@
       "id": "coast-poly",
       "class": "",
       "Datasource": {
-        "file": "data/processed_p/processed_p.shp"
+        "file": "data/processed_p/processed_p.shp",
+        "type": "shape"
       },
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
@@ -82,7 +84,8 @@
       "id": "builtup",
       "class": "",
       "Datasource": {
-        "file": "data/world_boundaries/builtup_area.shp"
+        "file": "data/world_boundaries/builtup_area.shp",
+        "type": "shape"
       },
       "srs-name": "mercator",
       "srs": "+proj=merc +datum=WGS84 +over",
@@ -100,7 +103,8 @@
       "id": "necountries",
       "class": "",
       "Datasource": {
-        "file": "data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp"
+        "file": "data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp",
+        "type": "shape"
       },
       "srs-name": "WGS84",
       "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
@@ -118,7 +122,8 @@
       "id": "nepopulated",
       "class": "",
       "Datasource": {
-        "file": "data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp"
+        "file": "data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp",
+        "type": "shape"
       },
       "srs-name": "WGS84",
       "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",


### PR DESCRIPTION
Be explicit about the mapnik datasource plugin name to be used to read shapefiles - this avoids needing millstone to touch the stylesheet at all and removes the potential WTF moment when millstone does something odd from the perspective of carto command line usage.

See also mapbox/tilemill#1884 and mapbox/carto#243
