### PR TITLE
Disable polygon clipping for buildings

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -1,5 +1,6 @@
 #buildings-lz {
   [zoom >= 10] {
+    polygon-clip: false;
     [railway = 'station']::railway,
     [building = 'station'] {
       polygon-fill: #d4aaaa;
@@ -27,10 +28,12 @@
   [building = 'INT-light'][zoom >= 12] {
     polygon-fill: #bca9a9;
     polygon-opacity: 0.7;
+    polygon-clip: false;
   }
   [building != 'INT-light'][building != ''][zoom >= 12] {
     polygon-fill: #bca9a9;
     polygon-opacity: 0.9;
+    polygon-clip: false;
     [zoom >= 16] {
       line-color: #330066;
       line-width: 0.2;
@@ -38,6 +41,7 @@
   }
   [aeroway = 'terminal'][zoom >= 12]::aeroway {
     polygon-fill: #cc99ff;
+    polygon-clip: false;
     [zoom >= 14] {
       line-color: #330066;
       line-width: 0.2;


### PR DESCRIPTION
Buildings tend to be smaller than tiles, meaning its cheaper to render the occasional building  outside the meta-tile that matches && than to check all of them.

On my test EC2 setup it increased rendering rate by 3.5% for the benchmarking workload which fit into ram caches.

The increase in speed is dependent on zoom with the greatest time decrease of 2.6%-3.0% from z16-z18, an decrease of 0.6%-1.3% for z13-z15 and insufficient tiles rendered for higher zooms. Note: speed and rate are not inverses of each other due to multi-threading issues.

For the larger benchmarking workload which involved disk accesses it increased rate by 0.5%.
