### PR TITLE
Fixed typo in cyclepath definition

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1617,7 +1617,7 @@
     }
 
     [feature = 'highway_cycleway'],
-    [feature = 'highway_path'][foot = 'designated'] {
+    [feature = 'highway_path'][bicycle = 'designated'] {
       [zoom >= 14] {
         line-width: 5.5;
         line-color: black;


### PR DESCRIPTION
I think this is a typo in the file.
