### PR TITLE
Define colors for paths etc. in beginning of file

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -999,7 +999,7 @@
 
   [feature = 'highway_steps'][zoom >= 15] {
     line-width: 5.0;
-    line-color: @footway-fill;
+    line-color: @steps-fill;
     line-dasharray: 2,1;
   }
 
@@ -1277,7 +1277,7 @@
 
   [feature = 'aeroway_taxiway'][bridge = 'no'][zoom >= 14] {
     line-width: 4;
-    line-color: @helipad-fill;
+    line-color: @taxiway-fill;
     [zoom >= 15] {
       line-width: 6;
     }


### PR DESCRIPTION
Colors for paths, footways, tracks, aeroways etc. are now defined in the
beginning of the file.
This should make it easier to adapt the style, and prevent the risk of errors.
