### PR TITLE
Clarify names of three layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -733,12 +733,12 @@
         "geometry_field": "way",
         "dbname": "gis"
       },
-      "id": "minor-roads-casing",
+      "id": "roads-casing",
       "class": "",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
-      "name": "minor-roads-casing"
+      "name": "roads-casing"
     },
     {
       "extent": [
@@ -845,12 +845,12 @@
         "geometry_field": "way",
         "dbname": "gis"
       },
-      "id": "minor-roads-fill",
+      "id": "roads-fill",
       "class": "",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
-      "name": "minor-roads-fill"
+      "name": "roads-fill"
     },
     {
       "geometry": "point",
@@ -937,12 +937,12 @@
         "geometry_field": "way",
         "dbname": "gis"
       },
-      "id": "roads",
+      "id": "roads-low-zoom",
       "class": "",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
-      "name": "roads"
+      "name": "roads-low-zoom"
     },
     {
       "geometry": "linestring",

--- a/roads.mss
+++ b/roads.mss
@@ -492,7 +492,7 @@
   }
 }
 
-#minor-roads-casing::links {
+#roads-casing::links {
   [highway = 'raceway'] {
     [zoom >= 12] {
       line-color: pink;
@@ -561,7 +561,7 @@
   }
 }
 
-#minor-roads-casing {
+#roads-casing {
   [highway = 'motorway'][tunnel != 'yes'] {
     [zoom >= 12] {
       line-width: @motorway-width-z12 + 1;
@@ -690,7 +690,7 @@
   }
 }
 
-#minor-roads-fill::links {
+#roads-fill::links {
   [feature = 'highway_motorway_link'][tunnel != 'yes'] {
     [zoom >= 12] {
       line-width: @motorway-width-z12 - 1.5;
@@ -752,7 +752,7 @@
   }
 }
 
-#minor-roads-fill {
+#roads-fill {
 
   /*
    * The construction rules for small roads are strange, since if construction is null its assumed that
@@ -2087,7 +2087,7 @@
   }
 }
 
-#roads {
+#roads-low-zoom {
   [feature = 'highway_motorway'],
   [feature = 'highway_motorway_link'] {
     [zoom >= 5][zoom < 12] {


### PR DESCRIPTION
- Correct names of layers that have unclear names for historical reasons:
  - Rename #roads to #roads-low-zoom
  - Rename #minor-roads-casing to #roads-casing
  - Rename #minor-roads-fill to #roads-fill 

This pull request solves the following problem:
- The layers #roads and #minor_roads are confusingly named. 

This pull request changes the rendering as follows:
- No change.
