### PR TITLE
Change 'beirgarten' to 'biergarten' to fix a typo

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -377,7 +377,7 @@
   [amenity = 'restaurant']::amenity,
   [amenity = 'cafe']::amenity,
   [amenity = 'fast_food']::amenity,
-  [amenity = 'beirgarten']::amenity {
+  [amenity = 'biergarten']::amenity {
     [zoom >= 17] {
       text-name: "[name]";
       text-fill: #734a08;


### PR DESCRIPTION
Noticed a typo while playing with the stylesheets, this change fixes it and should result in the names of amenities tagged as 'biergarten' to be rendered again.
