### PR TITLE
Increase text spacing for pharmacies

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -834,7 +834,7 @@
   [amenity = 'pharmacy'][zoom >= 17]::amenity {
     text-name: "[name]";
     text-size: 8;
-    text-dy: 9;
+    text-dy: 10;
     text-fill: #da0092;
     text-face-name: @book-fonts;
     text-halo-radius: 1;


### PR DESCRIPTION
Pharmacies names weren't rendereding as they were pushed too close to the icons

Fixes #176

It's actually a mystery to me why the text in #176 rendered at all.
