### PR TITLE
Use shield-clip: false to avoid shield artifacts

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2162,6 +2162,7 @@
       shield-spacing: 750;
       shield-min-distance: 30;
       shield-face-name: @bold-fonts;
+      shield-clip: false;
       [length = 7] { shield-file: url('symbols/mot_shield6.png'); }
       [length = 8] { shield-file: url('symbols/mot_shield7.png'); }
     }
@@ -2176,6 +2177,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
+    shield-clip: false;
   }
 
   [highway = 'primary'][zoom >= 11][zoom < 13] {
@@ -2187,6 +2189,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
+    shield-clip: false;
   }
 
   [highway = 'secondary'][zoom >= 12][zoom < 13] {
@@ -2198,6 +2201,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
+    shield-clip: false;
   }
 }
 
@@ -2212,7 +2216,7 @@
       shield-spacing: 750;
       shield-min-distance: 30;
       shield-face-name: @bold-fonts;
-      shield-avoid-edges: true;
+      shield-clip: false;
       [length = 7] { shield-file: url('symbols/mot_shield6.png'); }
       [length = 8] { shield-file: url('symbols/mot_shield7.png'); }
     }
@@ -2227,7 +2231,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
-    shield-avoid-edges: true;
+    shield-clip: false;
   }
 
   [highway = 'primary'][zoom >= 13] {
@@ -2239,7 +2243,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
-    shield-avoid-edges: true;
+    shield-clip: false;
   }
 
   [highway = 'secondary'][bridge = 'no'][zoom >= 13] {
@@ -2251,7 +2255,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
-    shield-avoid-edges: true;
+    shield-clip: false;
   }
 
   [highway = 'tertiary'][bridge = 'no'][zoom >= 13] {
@@ -2263,7 +2267,7 @@
     shield-spacing: 750;
     shield-min-distance: 30;
     shield-face-name: @bold-fonts;
-    shield-avoid-edges: true;
+    shield-clip: false;
   }
 
   [highway = 'unclassified'],


### PR DESCRIPTION
Fixes #202 #146

Shields are now placed consistently across MT boundaries

See also http://www.mapbox.com/carto/api/2.1.0/#buffer-size which says not to combine buffer-size and avoid-edges
