### PR TITLE
Show name for motels, as with hotels (fixes trac 4011)

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -624,6 +624,7 @@
   }
 
   [tourism = 'hotel']::tourism,
+  [tourism = 'motel']::tourism,
   [tourism = 'hostel']::tourism,
   [tourism = 'chalet']::tourism {
     [zoom >= 17] {


### PR DESCRIPTION
This fixes an issue pointed out on the "newbies" mailing list, and which is listed in [trac issue number 4011](https://trac.openstreetmap.org/ticket/4011) - motels show the symbol but not the name, which is inconsistent with how hotels/hostels/etc are shown.
