### PR TITLE
Added rendering of Neighbourhood Place names, at same level as Hamlet

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -131,6 +131,7 @@
 #placenames-small::hamlet {
   [place = 'hamlet'],
   [place = 'locality'],
+  [place = 'neighbourhood'],
   [place = 'isolated_dwelling'],
   [place = 'farm'] {
     [zoom >= 14] {

--- a/project.mml
+++ b/project.mml
@@ -1644,7 +1644,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,place,name\n      from planet_osm_point\n      where place in ('suburb','village','large_village','hamlet','locality','isolated_dwelling','farm')\n      ) as placenames",
+        "table": "(select way,place,name\n      from planet_osm_point\n      where place in ('suburb','village','large_village','hamlet','neighbourhood','locality','isolated_dwelling','farm')\n      ) as placenames",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",


### PR DESCRIPTION
The plan here is to add the rendering of neighbourhood place names. Because these aren't currently show often there are duplicate name nodes, for example locality= and neighbourhood= where neighbourhood is a better tag.
