### PR TITLE
wind turbines: do not show at zooms 15/16/17 unless towers

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -82,7 +82,10 @@
   [power = 'generator']['generator:source' = 'wind']::power,
   [power = 'generator'][power_source = 'wind']::power,
   [man_made = 'power_wind'] {
-    [zoom >= 15] {
+    [zoom >= 18],
+    [man_made = 'tower'][zoom = 17],
+    [man_made = 'tower'][zoom = 16],
+    [man_made = 'tower'][zoom = 15] {
       point-file: url('symbols/power_wind.png');
       point-placement: interior;
     }


### PR DESCRIPTION
This pull-request suggests that we don't want to render all wind-turbines at zoom 15/16/17, only those marked `man_made=tower`.

Wind-turbines are sometimes significant landmarks (usually standlone towers) and sometimes not (small building-mounted turbines). The carto style currently errs on the side of eagerly showing wind turbines, which for some examples of tiny turbines in the city is undue prominence. Here's an example in Birmingham:

![birmingham-turbine](https://f.cloud.github.com/assets/202965/1416106/a21698da-3f37-11e3-9d67-2846a41701c3.png)
http://www.openstreetmap.org/#map=15/52.4836/-1.8881

Here's an example in London:
![highbury-turbine](https://f.cloud.github.com/assets/202965/1416107/a807465e-3f37-11e3-98d8-6aadb48664b8.png)
http://www.openstreetmap.org/#map=15/51.5439/-0.1037

I asked on the "tagging" mailing list if anyone had suggestions. There wasn't much controversy, but not much definite direction. One suggestion was that `landmark=yes` could disambiguate. Seemed OK to me, but searching actual use, I don't see this actually used for wind turbines.

However, in Europe there are 427 wind turbines also marked with `man_made=*`, of which 133 are `man_made=tower`. (Other values include things not encouraged by the wiki such as `man_made=wind_turbine`, and things not relevant to landmarkness such as `man_made=power`.)

I've not chatted about this rendering suggestion, so please consider this an RFC.

Edit: markdown fixes
