### PR TITLE
Display SCALERANK=0 and fix positioning on natural earth layer

### DIFF
--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -6,13 +6,15 @@
 }
 
 #nepopulated {
-  [SCALERANK = 1][zoom >= 3][zoom < 5] {
-    text-name: "[NAME]";
-    text-size: 8;
-    text-fill: grey;
-    text-face-name: @book-fonts;
-    text-halo-radius: 1;
-    text-dy: 2;
+  [zoom >= 3][zoom < 5] {
+    [SCALERANK = 0],
+    [SCALERANK = 1] {
+      text-name: "[NAME]";
+      text-size: 8;
+      text-fill: grey;
+      text-face-name: @book-fonts;
+      text-halo-radius: 1;
+    }
   }
 }
 


### PR DESCRIPTION
SCALERANK=0 is cities like London, Paris, New York, etc. It's wrong to
be showing Denver, Atlanta, etc but not New York, LA, etc.

Fixes #246, labels are now positioned correctly
