### PR TITLE
Remove halos from highway link names

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2305,7 +2305,9 @@
 
 #roads-text-name {
   [highway = 'trunk'],
-  [highway = 'primary'] {
+  [highway = 'trunk_link'],
+  [highway = 'primary'],
+  [highway = 'primary_link'] {
     [zoom >= 13] {
       text-name: "[name]";
       text-size: 8;
@@ -2323,7 +2325,8 @@
       text-size: 10;
     }
   }
-  [highway = 'secondary'] {
+  [highway = 'secondary'],
+  [highway = 'secondary_link'] {
     [zoom >= 13] {
       text-name: "[name]";
       text-size: 8;
@@ -2341,7 +2344,8 @@
       text-size: 10;
     }
   }
-  [highway = 'tertiary'] {
+  [highway = 'tertiary'],
+  [highway = 'tertiary_link'] {
     [zoom >= 15] {
       text-name: "[name]";
       text-size: 9;


### PR DESCRIPTION
Part of #1 and #168. The halos came from the catchall at the end of
# roads-text-name.
