### PR TITLE
Fix dark place_of_worship at low zoom

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -1,19 +1,21 @@
 #buildings-lz {
   [zoom >= 10] {
-    polygon-clip: false;
     [railway = 'station']::railway,
     [building = 'station'] {
       polygon-fill: #d4aaaa;
+      polygon-clip: false;
     }
 
     [building = 'supermarket'] {
       polygon-fill: pink;
       polygon-opacity: 0.5;
+      polygon-clip: false;
     }
 
     [amenity = 'place_of_worship']::amenity {
       polygon-opacity: 0.5;
       polygon-fill: #777;
+      polygon-clip: false;
       [zoom >= 15] {
         polygon-opacity: 0.9;
         polygon-fill: #aaa;


### PR DESCRIPTION
Fixes #93.

polygon-clip in the outer scope creates an unintended PolygonSymbolizer with default gray fill. This causes the non-opaque amenity attachment to blend with gray. It's especially noticeable at zooms 10-14, which has lower opacity.
