### PR TITLE
Use DejaVu Sans Book as a fallback for bold/italics

### DIFF
--- a/style.mss
+++ b/style.mss
@@ -3,8 +3,8 @@ Map {
 }
 
 @book-fonts: "DejaVu Sans Book", "unifont Medium";
-@bold-fonts: "DejaVu Sans Bold", "unifont Medium";
-@oblique-fonts: "DejaVu Sans Oblique", "unifont Medium";
+@bold-fonts: "DejaVu Sans Bold", "DejaVu Sans Book", "unifont Medium";
+@oblique-fonts: "DejaVu Sans Oblique", "DejaVu Sans Book", "unifont Medium";
 
 @water-color: #b5d0d0;
 @land-color: #f2efe9;


### PR DESCRIPTION
DejaVu Sans Book has 5942 glyphs while bold and italic have 5868 and 5155 glyphs.

They may not quite match, but unifont doesn't have bold or italic glyphs at all so it's still closer.

Glyph counts 

```
  5085  /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans-BoldOblique.ttf
  5155  /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans-Oblique.ttf
  5868  /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans-Bold.ttf
  5942  /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
 63449  /usr/share/fonts/truetype/unifont/unifont.ttf
```

This is the small improvement mentioned in #294
