### PR TITLE
force UTF8 encoding on ogr2ogr

### DIFF
--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -46,7 +46,7 @@ unzip $UNZIP_OPTS data/land-polygons-split-3857.zip -d data/
 #process populated places
 echo "processing ne_10m_populated_places..."
 rm -f data/ne_10m_populated_places/ne_10m_populated_places_fixed.*
-ogr2ogr data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/ne_10m_populated_places/ne_10m_populated_places.shp
+ogr2ogr --config SHAPE_ENCODING UTF8 data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/ne_10m_populated_places/ne_10m_populated_places.shp
 
 #index
 echo "indexing shapefiles"


### PR DESCRIPTION
leaving out --config SHAPE_ENCODING UTF8 breaks some special characters which is not a big deal since the name column isn't used by the style anyway, but we don't want people to be irritated by an ogr2ogr warning.
