### PR TITLE
Increase ele/text-dy to fix #342

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -516,7 +516,7 @@
       ele/text-halo-radius: 1;
       ele/text-placement: interior;
       [name != ''] {
-        ele/text-dy: 18;
+        ele/text-dy: 19;
       }
     }
   }


### PR DESCRIPTION
The 'p' descender in the middle of 'Kvarntorpshögen' revealed that these texts are too close together.
