### PR TITLE
Stop boundary linestrings from relations being used

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -975,7 +975,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and admin_level in ('0','1','2','3','4')\n       ) as admin_01234",
+        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and admin_level in ('0','1','2','3','4')\n         and osm_id > 0\n       ) as admin_01234",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
@@ -998,7 +998,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and admin_level in ('5','6','7','8')\n       ) as admin_5678",
+        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and admin_level in ('5','6','7','8')\n         and osm_id > 0\n       ) as admin_5678",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
@@ -1021,7 +1021,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and (admin_level is null or admin_level not in ('0','1','2','3','4','5','6','7','8'))\n       ) as admin_other",
+        "table": "(select way,admin_level\n       from planet_osm_roads\n       where \"boundary\"='administrative'\n         and (admin_level is null or admin_level not in ('0','1','2','3','4','5','6','7','8'))\n         and osm_id > 0\n       ) as admin_other",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",


### PR DESCRIPTION
I have yet to do full tests, but this fixes #344 at the Canada/US border, which is one of the worse borders for overlapping edges of admin areas.

At z14

New
![image](https://f.cloud.github.com/assets/1190866/2228523/0899388c-9add-11e3-8104-02a71b1ee5b4.png)

Old
![image](https://f.cloud.github.com/assets/1190866/2228535/670b989c-9add-11e3-9e5d-72536876b082.png)

Names are still an issue on z15+ as they're coming from the fallbacks, but one problem at a time
