### PR TITLE
Add Southeast Asia fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If a font is missing, it will skip to the next available font which contains tho
 ### Southeast Asia
 * Arundina Sans, for Thai (``fonts-sipa-arundina``)
 * Padauk, for Burmese (``fonts-sil-padauk``)
+* Khmer OS Metal Chrieng Regular, for Khmer (``fonts-khmeros``)
 
 ## Dependencies
 

--- a/style.mss
+++ b/style.mss
@@ -2,9 +2,11 @@ Map {
   background-color: @water-color;
 }
 
-@book-fonts: "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Droid Sans Fallback Regular", "unifont Medium";
-@bold-fonts: "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Droid Sans Fallback Regular", "unifont Medium";
-@oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Droid Sans Fallback Regular", "unifont Medium";
+@book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
+@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", 
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
+@oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", 
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
 
 @water-color: #b5d0d0;
 @land-color: #f2efe9;


### PR DESCRIPTION
**Work in progress, do not merge yet**

Based on issues raised in #294, but I'm not yet tackling East Asia and CJK fonts with the Han Unification issues.

See the [Unicode Font Guide](http://www.unifont.org/fontguide/) for what I am considering S.E. Asia
- [x] Add readme section
- [x] Add Droid Sans as penultimate fallback
- [ ] Khmer
- [ ] ~~Lao~~ [_DejaVu supported_]
- [x] Burmese (Myanmar)
- [ ] ~~Tai Nüa (Myanmar)~~
- [ ] ~~Tagalog~~, ~~Hanunoo~~, ~~Buhid~~ (Philippines)
- [ ] ~~Tagbanwa (Philippines)~~
- [x] Thai
- [ ] ~~Vietnamese~~ [_DejaVu supported_]
