### PR TITLE
Unify road definitions for bridges, tunnels, and normal roads

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -420,14 +420,14 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,highway,horse,foot,bicycle,tracktype from planet_osm_line where highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','bridleway','footway','cycleway','path','track') and tunnel='yes' order by z_order) as tunnels",
+        "table": "(select way,coalesce(('highway_' || highway), ('railway_' ||(case when railway='preserved' and service in ('spur','siding','yard') then 'INT-preserved-ssy'::text when railway in ('spur','siding') or (railway='rail' and service in ('spur','siding','yard'))  then 'INT-spur-siding-yard' when railway in ('light_rail', 'narrow_gauge', 'funicular', 'rail', 'subway', 'tram', 'spur', 'siding', 'monorail', 'platform', 'preserved', 'disused', 'abandoned', 'construction', 'miniature', 'turntable') then railway else null end)), ('aeroway_' || aeroway)) as feature, horse, foot, bicycle, tracktype, case when access in ('permissive') then 'permissive'::text when access in ('destination') then 'destination'::text when access in ('no', 'private') then 'no'::text else null end as access, construction, case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service, case when oneway in ('yes', '-1') and highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street','construction') then oneway else null end as oneway, case when layer is null then '0' else layer end as layernotnull from planet_osm_line where (highway in ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'residential', 'road', 'unclassified', 'service', 'pedestrian', 'living_street', 'raceway', 'bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'platform', 'proposed', 'construction')  or aeroway in ('runway','taxiway') or railway in ('light_rail', 'subway', 'narrow_gauge',  'rail', 'spur', 'siding', 'disused', 'abandoned', 'construction')) and tunnel='yes' order by z_order) as tunnels",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
         "dbname": "gis"
       },
       "id": "tunnels",
-      "class": "",
+      "class": "tunnels-fill tunnels-casing access directions",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
@@ -673,21 +673,20 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,highway,tunnel,\n       case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service\n       from planet_osm_line\n       where highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street')\n       order by z_order) as roads_casing",
+        "table": "      (select way,coalesce(('highway_' || highway), ('railway_' ||(case when railway='preserved' and service in ('spur','siding','yard') then 'INT-preserved-ssy'::text when railway in ('spur','siding') or (railway='rail' and service in ('spur','siding','yard'))  then 'INT-spur-siding-yard' when railway in ('light_rail', 'narrow_gauge', 'funicular', 'rail', 'subway', 'tram', 'spur', 'siding', 'monorail', 'platform', 'preserved', 'disused', 'abandoned', 'construction', 'miniature', 'turntable') then railway else null end)), ('aeroway_' || aeroway)) as feature, horse, foot, bicycle, tracktype, case when access in ('permissive') then 'permissive'::text when access in ('destination') then 'destination'::text when access in ('no', 'private') then 'no'::text else null end as access, construction, case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service, case when oneway in ('yes','true','1') then 'yes'::text else oneway end as oneway, case when layer is null then '0' else layer end as layernotnull from planet_osm_line where (highway in ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'residential', 'road', 'unclassified', 'service', 'pedestrian', 'living_street', 'raceway', 'bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'platform', 'proposed', 'construction')  or aeroway in ('runway','taxiway') or railway in ('light_rail', 'subway', 'narrow_gauge',  'rail', 'spur', 'siding', 'disused', 'abandoned', 'construction')) and (tunnel is null or not tunnel in ('yes','true','1')) and (bridge is null or not bridge in ('yes','true','1','viaduct')) order by z_order)  as roads",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
         "dbname": "gis"
       },
       "id": "roads-casing",
-      "class": "",
+      "class": "roads-casing",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
       "name": "roads-casing"
     },
     {
-      "geometry": "polygon",
       "extent": [
         -179.99999692067183,
         -84.96651228427099,
@@ -765,14 +764,14 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,tracktype,\n       coalesce(('highway_' || (case when highway is not null then highway else null end)), ('railway_' ||(case when railway='preserved' and service in ('spur','siding','yard') then 'INT-preserved-ssy'::text\n            when railway in ('spur','siding')\n              or (railway='rail' and service in ('spur','siding','yard'))\n            then 'spur-siding-yard'\n            when railway in ('light_rail','narrow_gauge','funicular','rail','subway','tram','spur','siding','monorail','platform','preserved','disused','abandoned','construction','miniature','turntable')\n then railway else null end)), ('aeroway_' || (case when aeroway in ('runway', 'taxiway') then aeroway else null end))) as feature,\n       horse,bicycle,foot,construction,tunnel,\n       case when bridge in ('yes','true','1','viaduct') then 'yes'::text else 'no'::text end as bridge,\n       case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service, access \n       from planet_osm_line\n       where highway is not null\n          or aeroway in ('runway','taxiway')\n          or railway in ('light_rail','narrow_gauge','funicular','rail','subway','tram','spur','siding','monorail','platform','preserved','disused','abandoned','construction','miniature','turntable')\n       order by z_order) as roads_fill\n",
+        "table": "      (select way,coalesce(('highway_' || highway), ('railway_' ||(case when railway='preserved' and service in ('spur','siding','yard') then 'INT-preserved-ssy'::text when railway in ('spur','siding') or (railway='rail' and service in ('spur','siding','yard'))  then 'INT-spur-siding-yard' when railway in ('light_rail', 'narrow_gauge', 'funicular', 'rail', 'subway', 'tram', 'spur', 'siding', 'monorail', 'platform', 'preserved', 'disused', 'abandoned', 'construction', 'miniature', 'turntable') then railway else null end)), ('aeroway_' || aeroway)) as feature, horse, foot, bicycle, tracktype, case when access in ('permissive') then 'permissive'::text when access in ('destination') then 'destination'::text when access in ('no', 'private') then 'no'::text else null end as access, construction, case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service, case when oneway in ('yes', '-1') and highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street','construction') then oneway else null end as oneway, case when layer is null then '0' else layer end as layernotnull from planet_osm_line where (highway in ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'residential', 'road', 'unclassified', 'service', 'pedestrian', 'living_street', 'raceway', 'bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'platform', 'proposed', 'construction')  or aeroway in ('runway','taxiway') or railway in ('light_rail', 'subway', 'narrow_gauge',  'rail', 'spur', 'siding', 'disused', 'abandoned', 'construction')) and (tunnel is null or not tunnel in ('yes','true','1')) and (bridge is null or not bridge in ('yes','true','1','viaduct')) order by z_order)  as roads_fill",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
         "dbname": "gis"
       },
       "id": "roads-fill",
-      "class": "access",
+      "class": "roads-fill access directions",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
@@ -800,29 +799,6 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
       "name": "turning-circle-fill"
-    },
-    {
-      "geometry": "linestring",
-      "extent": [
-        -179.99999692067183,
-        -84.96651228427099,
-        179.99999692067183,
-        84.96651228427098
-      ],
-      "Datasource": {
-        "type": "postgis",
-        "table": "(select way, oneway\n       from planet_osm_line\n       where oneway in ('yes', '-1')\n         and highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street','construction')\n         and (bridge is null or bridge not in ('yes','true','1','viaduct'))\n      ) as directions_pre_bridges",
-        "extent": "-20037508,-19929239,20037508,19929239",
-        "key_field": "",
-        "geometry_field": "way",
-        "dbname": "gis"
-      },
-      "id": "direction-pre-bridges",
-      "class": "directions",
-      "srs-name": "900913",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "advanced": {},
-      "name": "direction-pre-bridges"
     },
     {
       "geometry": "linestring",
@@ -903,20 +879,20 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "(select way,coalesce(('highway_' || (case when highway is not null then highway else null end)), ('railway_' || (case when railway in ('spur', 'siding') or (railway='rail' and service in ('spur','siding','yard')) then 'INT-spur-siding-yard' when railway in ('light_rail','subway','narrow_gauge','rail','spur','siding','disused','abandoned','construction') then railway else null end)), ('aeroway_' || (case when aeroway in ('runway', 'taxiway') then aeroway else null end))) as feature, case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service,horse,bicycle,foot,tracktype,access,case when oneway in ('yes', '-1') and highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street','construction') then oneway else null end as oneway, case when layer is null then '0' else layer end as layerfixed \n from planet_osm_line\n       where (highway is not null\n              or aeroway in ('runway','taxiway')\n              or railway in ('light_rail','subway','narrow_gauge','rail','spur','siding','disused','abandoned','construction'))\n         and bridge in ('yes','true','1','viaduct')\n         and (layer is null or layer in ('0','1','2','3','4','5')) \n       order by layerfixed, z_order\n      ) as bridges",
+        "table": "(select way,coalesce(('highway_' || highway), ('railway_' ||(case when railway='preserved' and service in ('spur','siding','yard') then 'INT-preserved-ssy'::text when railway in ('spur','siding') or (railway='rail' and service in ('spur','siding','yard'))  then 'INT-spur-siding-yard' when railway in ('light_rail', 'narrow_gauge', 'funicular', 'rail', 'subway', 'tram', 'spur', 'siding', 'monorail', 'platform', 'preserved', 'disused', 'abandoned', 'construction', 'miniature', 'turntable') then railway else null end)), ('aeroway_' || aeroway)) as feature, horse, foot, bicycle, tracktype, case when access in ('permissive') then 'permissive'::text when access in ('destination') then 'destination'::text when access in ('no', 'private') then 'no'::text else null end as access, construction, case when service in ('parking_aisle','drive-through','driveway') then 'INT-minor'::text else 'INT-normal'::text end as service, case when oneway in ('yes', '-1') and highway in ('motorway','motorway_link','trunk','trunk_link','primary','primary_link','secondary','secondary_link','tertiary','tertiary_link','residential','unclassified','road','service','pedestrian','raceway','living_street','construction') then oneway else null end as oneway, case when layer is null then '0' else layer end as layernotnull from planet_osm_line where (highway in ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'residential', 'road', 'unclassified', 'service', 'pedestrian', 'living_street', 'raceway', 'bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'platform', 'proposed', 'construction')  or aeroway in ('runway','taxiway') or railway in ('light_rail', 'subway', 'narrow_gauge',  'rail', 'spur', 'siding', 'disused', 'abandoned', 'construction')) and bridge in ('yes','true','1','viaduct') and (layer is null or (layer in ('0','1','2','3','4','5'))) order by layernotnull, z_order) as bridges",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",
         "dbname": "gis"
       },
       "id": "bridges",
-      "class": "bridges access directions",
+      "class": "bridges-fill bridges-casing access directions",
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
       "name": "bridges",
       "properties": {
-        "group-by": "layerfixed"
+        "group-by": "layernotnull"
       }
     },
     {

--- a/roads.mss
+++ b/roads.mss
@@ -90,6 +90,2009 @@
 @tertiary-width-z17: 13;
 @residential-width-z17: 13;
 
+.roads-casing, .bridges-casing, .tunnels-casing {
+  ::casing_links {
+    [feature = 'highway_raceway'] {
+      [zoom >= 12] {
+        line-color: pink;
+        line-width: 1.2;
+        line-join: round;
+        line-cap: round;
+      }
+      [zoom >= 13] { line-width: 4; }
+      [zoom >= 15] { line-width: 7; }
+    }
+
+    [feature = 'highway_motorway_link'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @motorway-width-z12 - 1.5 + 1;
+          line-color: @motorway-casing;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @motorway-width-z13 - 2 + 1.5; }
+        [zoom >= 15] { line-width: @motorway-width-z15 - 2.5 + 1.8; }
+        [zoom >= 17] { line-width: @motorway-width-z17 - 2 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @motorway-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 10; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @motorway-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 6.5;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+    }
+
+    [feature = 'highway_trunk_link'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @trunk-width-z12 + 1;
+          line-color: @trunk-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @trunk-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @trunk-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @trunk-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @trunk-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @trunk-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 8;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_primary_link'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @primary-width-z12 + 1;
+          line-color: @primary-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @primary-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @primary-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @primary-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @primary-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @primary-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 8;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_secondary_link'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @secondary-width-z12 + 1;
+          line-color: @secondary-casing;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @secondary-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @secondary-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @secondary-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-dasharray: 4,2;
+          line-color: @secondary-casing;
+        }
+        [zoom >= 13] { line-width: 10; }
+        [zoom >= 15] { line-width: 12; }
+        [zoom >= 17] { line-width: 17; }
+      }
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 10;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 15] { line-width: 12; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_tertiary_link'] {
+      .roads-casing {
+        [zoom >= 13] {
+          line-width: 6;
+          line-color: @tertiary-casing;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 14] { line-width: 7.5; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+      .tunnels-casing {
+        [zoom >= 13] {
+          line-width: 6;
+          line-dasharray: 4,2;
+          line-color: @tertiary-casing;
+        } 
+        [zoom >= 14] { line-width: 7.5; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 7.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+  }
+
+  ::casing {
+    [feature = 'highway_motorway'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @motorway-width-z12 + 1;
+          line-color: @motorway-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @motorway-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @motorway-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @motorway-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @motorway-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 10; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @motorway-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 6.5;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+    }
+
+    [feature = 'highway_trunk'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @trunk-width-z12 + 1;
+          line-color: @trunk-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @trunk-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @trunk-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @trunk-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @trunk-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @trunk-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 8;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_primary'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @primary-width-z12 + 1;
+          line-color: @primary-casing;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @primary-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @primary-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @primary-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @primary-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-color: @primary-casing;
+          line-join: round;
+        }
+        [zoom >= 13] {
+          line-width: 8;
+          line-color: @bridge-casing;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_secondary'] {
+      .roads-casing {
+        [zoom >= 12] {
+          line-width: @secondary-width-z12 + 1;
+          line-color: @secondary-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @secondary-width-z13 + 1.5; }
+        [zoom >= 15] { line-width: @secondary-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @secondary-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 4;
+          line-dasharray: 4,2;
+          line-color: @secondary-casing;
+        }
+        [zoom >= 13] { line-width: 10; }
+        [zoom >= 15] { line-width: 12; }
+        [zoom >= 17] { line-width: 17; }
+      }
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 10;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 15] { line-width: 12; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_tertiary'] {
+      .roads-casing {
+        [zoom >= 13] {
+          line-width: @tertiary-width-z13 + 1.5;
+          line-color: @tertiary-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: @tertiary-width-z14 + 1.5; }
+        [zoom >= 15] { line-width: @tertiary-width-z15 + 1.8; }
+        [zoom >= 17] { line-width: @tertiary-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 13] {
+          line-width: 6;
+          line-dasharray: 4,2;
+          line-color: @tertiary-casing;
+        } 
+        [zoom >= 14] { line-width: 7.5; }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 7.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 15] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    [feature = 'highway_residential'],
+    [feature = 'highway_unclassified'],
+    [feature = 'highway_road'] {
+      .roads-casing {
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: @residential-casing;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: @residential-width-z14 + 1.5; }
+        [zoom >= 15] { line-width: @residential-width-z15 + 1.8; }
+        [zoom >= 16] { line-width: @residential-width-z16 + 1.8; }
+        [zoom >= 17] { line-width: @residential-width-z17 + 2.5; }
+      }
+      .tunnels-casing {
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: @residential-casing;
+          line-dasharray: 4,2;
+        }
+        [zoom >= 14] { line-width: 4.5; }
+        [zoom >= 15] { line-width: 8; }
+        [zoom >= 16] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 16] { line-width: 11; }
+        [zoom >= 17] { line-width: 16; }
+      }
+    }
+
+    /* This needs refactoring! Minor services shouldn't appear at z14
+     * simply because of a tunnel tag. Also rationalise joins and caps
+     */
+    [feature = 'highway_service'] {
+      .roads-casing {
+        [service = 'INT-normal'] {
+          [zoom >= 14] {
+            line-color: @service-casing;
+            line-width: 2.5;
+            line-cap: round;
+            line-join: round;
+          }
+          [zoom >= 16] { line-width: 7; }
+        }
+        [service = 'INT-minor'] {
+          [zoom >= 16] {
+            line-color: @service-casing;
+            line-width: 4;
+            line-cap: round;
+            line-join: round;
+          }
+        }
+      }
+      .tunnels-casing {
+        [zoom >= 14] {
+          line-color: @service-casing;
+          line-width: 2.5;
+          line-dasharray: 4,2;
+          [zoom >= 16] { line-width: 7; }
+        }
+      }
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 3;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 16] { line-width: 8; }
+      }
+    }
+
+    [feature = 'highway_pedestrian'] {
+      .roads-casing, .tunnels-casing {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: @pedestrian-casing;
+          line-cap: round;
+          line-join: round;
+          [zoom >= 14] { line-width: 3.6; }
+          [zoom >= 15] { line-width: 6.5; }
+          [zoom >= 16] { line-width: 9; }
+          .tunnels-casing {
+            line-dasharray: 4,2;
+          }
+        }
+      }
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 2.2;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+        [zoom >= 14] { line-width: 3.8; }
+        [zoom >= 15] { line-width: 7; }
+        [zoom >= 16] { line-width: 9.5; }
+      }
+    }
+
+    [feature = 'highway_living_street'] {
+      .roads-casing, .tunnels-casing {
+        [zoom >= 12] {
+          line-width: 2.5;
+          line-color: @living-street-casing;
+          line-cap: round;
+          line-join: round;
+          [zoom >= 14] { line-width: 4; }
+          [zoom >= 15] { line-width: 6; }
+          [zoom >= 16] { line-width: 9; }
+          [zoom >= 17] { line-width: 14.5; }
+        }
+      }
+    }
+    [feature = 'highway_bridleway'],
+    [feature = 'highway_path'][horse = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 5.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'highway_footway'],
+    [feature = 'highway_path'][foot = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 6;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'highway_cycleway'],
+    [feature = 'highway_path'][bicycle = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 5.5;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'highway_path'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: @bridge-casing;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'highway_track'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4.5;
+          line-color: @bridge-casing;
+          line-join: round;
+          [tracktype = 'grade1'] {
+            line-width: 5;
+          }
+        }
+      }
+    }
+
+    [feature = 'railway_subway'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 5.5;
+          line-color: black;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_narrow_gauge'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 5.5;
+          line-color: #555;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_rail'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 6.5;
+          line-color: black;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_INT-spur-siding-yard'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 5.7;
+          line-color: black;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_disused'],
+    [feature = 'railway_abandoned'],
+    [feature = 'railway_construction'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 6;
+          line-color: black;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'aeroway_runway'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 19;
+          line-color: black;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'aeroway_taxiway'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 5;
+          line-color: black;
+          line-join: round;
+          [zoom >= 15] { line-width: 7; }
+        }
+      } 
+    }
+  }
+
+  ::casing2 {
+    [feature = 'highway_bridleway'],
+    [feature = 'highway_path'][horse = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: @bridleway-casing;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'highway_footway'],
+    [feature = 'highway_path'][foot = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4.5;
+          line-color: @footway-casing;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'highway_cycleway'],
+    [feature = 'highway_path'][bicycle = 'designated'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: @cycleway-casing;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'highway_path'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 2.5;
+          line-color: @path-casing;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'highway_track'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 3;
+          line-color: @track-casing;
+          line-join: round;
+          line-cap: round;
+          [tracktype = 'grade1'] { line-width: 3.5; }
+        }
+      }
+    }
+
+    [feature = 'railway_rail'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 5;
+          line-color: white;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_INT-spur-siding-yard'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 4;
+          line-color: white;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'railway_disused'],
+    [feature = 'railway_abandoned'],
+    [feature = 'railway_construction'] {
+      .bridges-casing {
+        [zoom >= 13] {
+          line-width: 4.5;
+          line-color: white;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'railway_subway'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: white;
+        }
+      }
+    }
+
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_narrow_gauge'] {
+      .bridges-casing {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: white;
+        }
+      }
+    }
+  }
+}
+
+.roads-fill,.bridges-fill,.tunnels-fill {
+  ::fill_links {
+    [feature = 'highway_motorway_link'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @motorway-width-z12 - 1.5;
+          line-color: @motorway-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @motorway-width-z13 - 2; }
+        [zoom >= 15] { line-width: @motorway-width-z15 - 2.5; }
+        [zoom >= 17] { line-width: @motorway-width-z17 - 2; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @motorway-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 5; }
+        [zoom >= 15] { line-width: 8.5; }
+        [zoom >= 17] { line-width: 11; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @motorway-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: 5.5; }
+        [zoom >= 15] { line-width: 7.5; }
+        [zoom >= 17] { line-width: 10; }
+      }
+    }
+
+    [feature = 'highway_trunk_link'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @trunk-width-z12;
+          line-color: @trunk-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @trunk-width-z13; }
+        [zoom >= 15] { line-width: @trunk-width-z15; }
+        [zoom >= 17] { line-width: @trunk-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2.5;
+          line-color: @trunk-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @trunk-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 7; }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_primary_link'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @primary-width-z12;
+          line-color: @primary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @primary-width-z13; }
+        [zoom >= 15] { line-width: @primary-width-z15; }
+        [zoom >= 17] { line-width: @primary-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2.5;
+          line-color: @primary-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @primary-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 7; }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_secondary_link'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @secondary-width-z12;
+          line-color: @secondary-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @secondary-width-z13; }
+        [zoom >= 15] { line-width: @secondary-width-z15; }
+        [zoom >= 17] { line-width: @secondary-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @secondary-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 10; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 9;
+          line-color: @secondary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 10.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_tertiary_link'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: @tertiary-width-z13;
+          line-color: @tertiary-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 14] { line-width: @tertiary-width-z14; }
+        [zoom >= 15] { line-width: @tertiary-width-z15; }
+        [zoom >= 17] { line-width: @tertiary-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5;
+          line-color: @tertiary-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9.4; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 6;
+          line-color: @tertiary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14; }
+      }
+    }
+  }
+
+  ::fill {
+
+    /*
+     * The construction rules for small roads are strange, since if construction is null its assumed that
+     * it's a more major road. The line-width = 0 could be removed by playing with the query to set a construction
+     * string for non-small roads.
+     *
+     * Also note that these rules are quite sensitive to re-ordering, since the instances end up swapping round
+     * (and then the dashes appear below the fills). See
+     * https://github.com/gravitystorm/openstreetmap-carto/issues/23
+     * https://github.com/mapbox/carto/issues/235
+     * https://github.com/mapbox/carto/issues/237
+     */
+    [feature = 'highway_proposed'],
+    [feature = 'highway_construction'] {
+      [zoom >= 12] {
+        line-width: 2;
+        line-color: #9cc;
+
+        [construction = 'motorway'],
+        [construction = 'motorway_link'] {
+          line-color: @motorway-fill;
+        }
+        [construction = 'trunk'],
+        [construction = 'trunk_link'] {
+          line-color: @trunk-fill;
+        }
+        [construction = 'primary'],
+        [construction = 'primary_link'] {
+          line-color: @primary-fill;
+        }
+        [construction = 'secondary'],
+        [construction = 'secondary_link'] {
+          line-color: @secondary-fill;
+        }
+        [construction = 'tertiary'],
+        [construction = 'tertiary_link'] {
+          line-color: @tertiary-fill;
+          [zoom < 13] {
+            line-width: 0;
+            b/line-width: 0;
+          }
+        }
+        [construction = 'residential'],
+        [construction = 'unclassified'],
+        [construction = 'living_street'] {
+          line-color: @residential-construction;
+          [zoom < 13] {
+            line-width: 0;
+            b/line-width: 0;
+          }
+        }
+        [construction = 'service'] {
+          line-color: @service-construction;
+          [zoom < 14] {
+            line-width: 0;
+            b/line-width: 0;
+          }
+        }
+        b/line-width: 2;
+        b/line-dasharray: 4,2;
+        b/line-color: white;
+        [zoom >= 13] {
+          line-width: 4;
+          b/line-width: 3.5;
+          b/line-dasharray: 6,4;
+        }
+        [zoom >= 16] {
+          line-width: 8;
+          b/line-width: 7;
+          b/line-dasharray: 8,6;
+        }
+        [construction = 'cycleway'] {
+          [zoom < 14] {
+            line-width: 0;
+            b/line-width: 0;
+          }
+          line-color: white;
+          line-width: 3;
+          line-opacity: 0.4;
+          b/line-width: 1.2;
+          b/line-color: #69f;
+          b/line-dasharray: 2,6;
+        }
+      }
+    }
+
+
+    [feature = 'highway_motorway'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @motorway-width-z12;
+          line-color: @motorway-fill;
+        }
+        [zoom >= 13] {
+          line-width: @motorway-width-z13;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: @motorway-width-z15; }
+        [zoom >= 17] { line-width: @motorway-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @motorway-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 5; }
+        [zoom >= 15] { line-width: 8.5; }
+        [zoom >= 17] { line-width: 11; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @motorway-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: 5.5; }
+        [zoom >= 15] { line-width: 7.5; }
+        [zoom >= 17] { line-width: 10; }
+      }
+    }
+
+    [feature = 'highway_trunk'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @trunk-width-z12;
+          line-cap: round;
+          line-join: round;
+          line-color: @trunk-fill;
+        }
+        [zoom >= 13] { line-width: @trunk-width-z13; }
+        [zoom >= 15] { line-width: @trunk-width-z15; }
+        [zoom >= 17] { line-width: @trunk-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2.5;
+          line-color: @trunk-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @trunk-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 7; }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_primary'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @primary-width-z12;
+          line-color: @primary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 13] { line-width: @primary-width-z13; }
+        [zoom >= 15] { line-width: @primary-width-z15; }
+        [zoom >= 17] { line-width: @primary-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2.5;
+          line-color: @primary-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9; }
+        [zoom >= 17] { line-width: 12; }
+      }
+      .bridges-fill {
+        [zoom >= 12] {
+          line-width: 3;
+          line-color: @primary-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 7; }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_secondary'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: @secondary-width-z12;
+          line-color: @secondary-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: @secondary-width-z13; }
+        [zoom >= 15] { line-width: @secondary-width-z15; }
+        [zoom >= 17] { line-width: @secondary-width-z17; }
+      }
+      .tunnels-fill {
+        [zoom >= 12] {
+          line-width: 2;
+          line-color: @secondary-tunnel-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 13] { line-width: 8; }
+        [zoom >= 15] { line-width: 10; }
+        [zoom >= 17] { line-width: 14; }
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 9;
+          line-color: @secondary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 10.5; }
+        [zoom >= 17] { line-width: 14.5; }
+      }
+    }
+
+    [feature = 'highway_tertiary'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: @tertiary-width-z13;
+          line-color: @tertiary-fill;
+          line-join: round;
+          line-cap: round;
+          [zoom >= 14] { line-width: @tertiary-width-z14; }
+          [zoom >= 15] { line-width: @tertiary-width-z15; }
+          [zoom >= 17] { line-width: @tertiary-width-z17; }
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5;
+          line-color: @tertiary-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: 6.5; }
+        [zoom >= 15] { line-width: 9.4; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 6;
+          line-color: @tertiary-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14; }
+      }
+    }
+
+    [feature = 'highway_residential'],
+    [feature = 'highway_unclassified'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: @residential-width-z13;
+          line-color: @residential-fill;
+          line-cap: round;
+          line-join: round;
+          [zoom >= 14] { line-width: @residential-width-z14; }
+          [zoom >= 15] { line-width: @residential-width-z15; }
+          [zoom >= 16] { line-width: @residential-width-z16; }
+          [zoom >= 17] { line-width: @residential-width-z17; }
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: @residential-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: 3; }
+        [zoom >= 15] { line-width: 6.5; }
+        [zoom >= 16] { line-width: 9.4; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 3.5;
+          line-color: @residential-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 7.5; }
+        [zoom >= 16] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14; }
+      }
+    }
+
+    [feature = 'highway_tertiary'],
+    [feature = 'highway_residential'],
+    [feature = 'highway_unclassified'],
+    [feature = 'highway_road'] {
+      [zoom >= 10][zoom < 13] {
+        line-width: 1;
+        line-color: @residential-casing;
+      }
+    }
+
+    [feature = 'highway_road'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: @road-fill;
+          line-join: round;
+          line-cap: round;
+          [zoom >= 14] { line-width: 3; }
+          [zoom >= 15] { line-width: 6.5; }
+          [zoom >= 16] { line-width: 9.4; }
+          [zoom >= 17] { line-width: @residential-width-z17; }
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: @residential-tunnel-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: 3; }
+        [zoom >= 15] { line-width: 6.5; }
+        [zoom >= 16] { line-width: 9.4; }
+        [zoom >= 17] { line-width: 13; }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 3.5;
+          line-color: @road-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 15] { line-width: 9.5; }
+        [zoom >= 17] { line-width: 14; }
+      }
+    }
+
+    [feature = 'highway_living_street'] {
+      .roads-fill {
+        [zoom >= 12] {
+          line-width: 1.5;
+          line-color: @living-street-fill;
+          line-join: round;
+          line-cap: round;
+          [zoom >= 14] { line-width: 3; }
+          [zoom >= 15] { line-width: 4.7; }
+          [zoom >= 16] { line-width: 7.4; }
+          [zoom >= 17] { line-width: 13; }
+        }
+      }
+    }
+
+    [feature = 'highway_service'] {
+      .roads-fill {
+        [service = 'INT-normal'] {
+          [zoom >= 13] {
+            line-width: 1;
+            line-color: @residential-casing;
+            [zoom >= 14] {
+              line-join: round;
+              line-cap: round;
+              line-width: 2;
+              line-color: @residential-fill;
+            }
+            [zoom >= 16] { line-width: 6; }
+          }
+        }
+        [service = 'INT-minor'] {
+          [zoom >= 16] {
+            line-width: 3;
+            line-color: @residential-fill;
+            line-join: round;
+            line-cap: round;
+          }
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 2;
+          line-color: @service-fill;
+          line-cap: round;
+          line-join: round;
+        }
+        [zoom >= 16] { line-width: 6; }
+      }
+    }
+
+    [feature = 'highway_pedestrian'] {
+      [zoom >= 13] {
+        line-width: 1.5;
+        line-color: @pedestrian-fill;
+        line-join: round;
+        line-cap: round;
+        [zoom >= 14] { line-width: 3; }
+        [zoom >= 15] { line-width: 5.5; }
+        [zoom >= 16] { line-width: 8; }
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 1.5;
+          line-color: @pedestrian-fill;
+          line-join: round;
+          line-cap: round;
+        }
+        [zoom >= 14] { line-width: 3; }
+        [zoom >= 15] { line-width: 5.5; }
+        [zoom >= 16] { line-width: 8; }
+      }
+    }
+
+    [feature = 'highway_platform'] {
+      [zoom >= 16] {
+        line-join: round;
+        line-width: 6;
+        line-color: grey;
+        line-cap: round;
+        b/line-width: 4;
+        b/line-color: #bbbbbb;
+        b/line-cap: round;
+        b/line-join: round;
+      }
+    }
+
+    [feature = 'highway_steps'] {
+      [zoom >= 13][zoom < 15] {
+        line-width: 6;
+        line-color: @steps-casing;
+        line-opacity: 0.4;
+        b/line-width: 2;
+        b/line-color: @steps-fill;
+        b/line-dasharray: 1,3;
+        b/line-cap: round;
+        b/line-join: round;
+      }
+    }
+
+    [feature = 'highway_steps'] {
+      [zoom >= 15] {
+        line-width: 5.0;
+        line-color: @steps-fill;
+        line-dasharray: 2,1;
+      }
+    }
+
+    [feature = 'highway_bridleway'],
+    [feature = 'highway_path'][horse = 'designated'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: @bridleway-casing;
+          line-cap: round;
+          line-join: round;
+          line-opacity: 0.4;
+          b/line-color: @bridleway-fill;
+          b/line-width: 1.2;
+          b/line-dasharray: 4,2;
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5;
+          line-color: @tunnel-casing;
+          line-dasharray: 4,2;
+          b/line-width: 3;
+          b/line-color: @bridleway-casing;
+          b/line-cap: round;
+          b/line-join: round;
+          c/line-width: 2;
+          c/line-color: @bridleway-fill;
+          c/line-opacity: 0.5;
+          c/line-dasharray: 4,2;
+          c/line-join: round;
+          c/line-cap: round;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 1.5;
+          line-color: @bridleway-fill;
+          line-dasharray: 4,2;
+        }
+      }
+    }
+
+    [feature = 'highway_footway'],
+    [feature = 'highway_path'][foot = 'designated'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: 4;
+          line-color: @footway-casing;
+          line-opacity: 0.4;
+          line-cap: round;
+          line-join: round;
+          b/line-width: 1.5;
+          b/line-color: @footway-fill;
+          b/line-dasharray: 1,3;
+          b/line-cap: round;
+          b/line-join: round;
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5.5;
+          line-color: @tunnel-casing;
+          line-dasharray: 4,2;
+          b/line-width: 3.5;
+          b/line-color: @footway-casing;
+          b/line-join: round;
+          b/line-cap: round;
+          c/line-width: 2.5;
+          c/line-color: @footway-fill;
+          c/line-dasharray: 1,3;
+          c/line-opacity: 0.5;
+          c/line-join: round;
+          c/line-cap: round;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 2;
+          line-color: @footway-fill;
+          line-dasharray: 1,3;
+          line-cap: round;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'highway_cycleway'],
+    [feature = 'highway_path'][bicycle = 'designated'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: @cycleway-casing;
+          line-join: round;
+          line-cap: round;
+          line-opacity: 0.4;
+          b/line-width: 1.2;
+          b/line-dasharray: 1,3;
+          b/line-color: @cycleway-fill;
+          b/line-join: round;
+          b/line-cap: round;
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5;
+          line-color: @tunnel-casing;
+          line-dasharray: 4,2;
+          b/line-width: 3;
+          b/line-color: @cycleway-casing;
+          b/line-join: round;
+          b/line-cap: round;
+          c/line-width: 2;
+          c/line-color: @cycleway-fill;
+          c/line-opacity: 0.5;
+          c/line-dasharray: 1,3;
+          c/line-join: round;
+          c/line-cap: round;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 1.5;
+          line-color: @cycleway-fill;
+          line-dasharray: 1,3;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    /*
+    * The above defininitions should override this when needed
+    * given the specitivity precedence.
+    */
+    [feature = 'highway_path'] {
+      .roads-fill {
+        [zoom >= 13] {
+          line-width: 1.0;
+          line-color: @path-casing;
+          line-opacity: 0.4;
+          line-cap: round;
+          line-join: round;
+          b/line-width: 0.5;
+          b/line-dasharray: 6,3;
+          b/line-color: @path-fill;
+          b/line-join: round;
+          b/line-cap: round;
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 5.5;
+          line-color: @tunnel-casing;
+          line-dasharray: 4,2;
+          b/line-width: 1;
+          b/line-color: @path-casing;
+          b/line-opacity: 0.4;
+          b/line-join: round;
+          b/line-cap: round;
+          c/line-width: 0.5;
+          c/line-color: @path-fill;
+          c/line-dasharray: 6,3;
+          c/line-cap: round;
+          c/line-join: round;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 0.5;
+          line-color: @path-fill;
+          line-dasharray: 6,3;
+          line-join: round;
+          line-cap: round;
+        }
+      }
+    }
+
+    [feature = 'highway_track'] {
+      [zoom >= 13] {
+        line-color: @track-casing;
+        line-join: round;
+        line-cap: round;
+        line-opacity: 0.4;
+        b/line-color: @track-fill;
+        b/line-cap: round;
+        b/line-join: round;
+        b/line-dasharray: 3,4;
+        [zoom >= 13][zoom < 14] {
+          line-width: 2.5;
+          b/line-width: 1.2;
+        }
+        [zoom >= 14] {
+          line-width: 3;
+          b/line-width: 1.5;
+          [tracktype = 'grade1'] {
+            line-width: 3.5;
+            b/line-width: 2;
+            b/line-color: @track-grade1-fill;
+            b/line-dasharray: 100,0; /* i.e. none, see https://github.com/mapbox/carto/issues/214 */
+            b/line-opacity: 0.7;
+          }
+          [tracktype = 'grade2'] {
+            line-width: 3;
+            b/line-color: @track-grade2-fill;
+            b/line-width: 1.5;
+            b/line-dasharray: 9,4;
+            b/line-opacity: 0.8;
+          }
+          [tracktype = 'grade3'] {
+            line-width: 3;
+            b/line-width: 1.5;
+            b/line-dasharray: 3,4;
+            b/line-opacity: 0.8;
+          }
+          [tracktype = 'grade4'] {
+            line-width: 3;
+            b/line-width: 2;
+            b/line-dasharray: 4,7,1,5;
+            b/line-opacity: 0.8;
+           }
+          [tracktype = 'grade5'] {
+            line-width: 3;
+            b/line-width: 2;
+            b/line-dasharray: 1,5;
+            b/line-opacity: 0.8;
+          }
+        }
+      }
+      .tunnels-fill {
+        [zoom >= 14] {
+          line-width: 4.5;
+          line-color: @tunnel-casing;
+          line-dasharray: 4,2;
+          b/line-width: 3;
+          b/line-color: @track-casing;
+          b/line-cap: round;
+          b/line-join: round;
+          c/line-width: 1.5;
+          c/line-color: @track-fill;
+          c/line-dasharray: 3,4;
+          c/line-opacity: 0.5;
+          c/line-join: round;
+          c/line-cap: round;
+          [tracktype = 'grade1'] {
+            line-width: 4;
+            b/line-width: 3.5;
+            c/line-width: 2;
+            c/line-color: @track-grade1-fill;
+            c/line-dasharray: 100,0; /* i.e. none, see https://github.com/mapbox/carto/issues/214 */
+          }
+          [tracktype = 'grade2'] {
+            c/line-color: @track-grade2-fill;
+          }
+          [tracktype = 'grade3'] {
+            b/line-width: 3.5;
+            c/line-width: 2;
+            c/line-dasharray: 100,0; /* yes, weird but true */
+          }
+          [tracktype = 'grade4'] {
+            c/line-width: 2;
+            c/line-dasharray: 4,7,1,5;
+          }
+          [tracktype = 'grade5'] {
+            c/line-width: 2;
+            c/line-dasharray: 1,5;
+          }
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 1.5;
+          line-color: @track-fill;
+          line-dasharray: 3,4;
+          line-join: round;
+          line-cap: round;
+          [tracktype = 'grade1'] {
+            line-width: 2;
+            line-color: @track-grade1-fill;
+            line-dasharray: 100,0; /* i.e. none */
+            line-opacity: 0.7;
+          }
+          [tracktype = 'grade2'] {
+            line-color: @track-grade2-fill;
+            line-opacity: 0.8;
+          }
+          [tracktype = 'grade3'] {
+            line-width: 2;
+            line-opacity: 0.7;
+            line-dasharray: 100,0; /* strange but true */
+          }
+          [tracktype = 'grade4'] {
+            line-width: 2;
+            line-dasharray: 4,7,1,5;
+            line-opacity: 0.8;
+          }
+          [tracktype = 'grade5'] {
+            line-width: 2;
+            line-dasharray: 1,5;
+            line-opacity: 0.8;
+          }
+        }
+      }
+    }
+
+    [feature = 'railway_rail'],
+    [feature = 'railway_INT-spur-siding-yard'] {
+      .tunnels-fill {
+        [zoom >= 13] {
+          a/line-width: 3;
+          b/line-width: 3;
+          c/line-width: 3;
+          d/line-width: 3;
+          e/line-width: 3;
+          f/line-width: 3;
+          g/line-width: 3;
+          a/line-color: #ffffff;
+          b/line-color: #fdfdfd;
+          c/line-color: #ececec;
+          d/line-color: #cacaca;
+          e/line-color: #afafaf;
+          f/line-color: #a1a1a1;
+          g/line-color: #9b9b9b;
+          a/line-dasharray: 1,9;
+          b/line-dasharray: 0,1,1,8;
+          c/line-dasharray: 0,2,1,7;
+          d/line-dasharray: 0,3,1,6;
+          e/line-dasharray: 0,4,1,5;
+          f/line-dasharray: 0,5,1,4;
+          g/line-dasharray: 0,6,1,3;
+          a/line-join: round;
+          b/line-join: round;
+          c/line-join: round;
+          d/line-join: round;
+          e/line-join: round;
+          f/line-join: round;
+          g/line-join: round;
+          [feature = 'railway_INT-spur-siding-yard'] {
+            a/line-width: 2;
+            b/line-width: 2;
+            c/line-width: 2;
+            d/line-width: 2;
+            e/line-width: 2;
+            f/line-width: 2;
+            g/line-width: 2;
+          }
+        }
+      }
+    }
+
+    [feature = 'railway_rail'] {
+      .roads-fill,.bridges-fill {
+        [zoom >= 13] {
+          a/line-width: 3;
+          a/line-color: #999999;
+          a/line-join: round;
+          b/line-width: 1;
+          b/line-color: white;
+          b/line-dasharray: 8,12;
+          b/line-join: round;
+          [zoom >= 14] {
+            b/line-dasharray: 0,11,8,1;
+          }
+        } 
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: #999999;
+          line-join: round;
+          b/line-width: 1;
+          b/line-color: white;
+          b/line-dasharray: 8,12;
+          b/line-join: round;
+          [zoom >= 14] {
+            b/line-dasharray: 0,11,8,1;
+          }
+        }
+      }
+    }
+
+    [feature = 'railway_INT-spur-siding-yard'] {
+      [zoom >= 11] {
+        a/line-width: 1;
+        a/line-color: #aaa;
+        a/line-join: round;
+        [zoom >= 13] {
+          .tunnels-fill {
+            a/line-color: #999999;
+            a/line-width: 2;
+            b/line-width: 0.8;
+            b/line-dasharray: 0,8,11,1;
+            b/line-color: white;
+            b/line-join: round;
+          }
+        }
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: #999999;
+          line-join: round;
+          b/line-width: 0.8;
+          b/line-color: white;
+          b/line-dasharray: 0,8,11,1;
+          b/line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_narrow_gauge'] {
+      [zoom >= 13] {
+        a/line-width: 2;
+        a/line-color: #666;
+        .tunnels-fill {
+          a/line-width: 5;
+          a/line-dasharray: 5,3;
+          b/line-color: #fff;
+          b/line-width: 4;
+          c/line-color: #aaa;
+          c/line-width: 1.5;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 2;
+          line-color: #666;
+        }
+      }
+    }
+
+    [feature = 'railway_funicular'] {
+      [zoom >= 13] {
+        a/line-width: 2;
+        a/line-color: #666;
+        .tunnels-fill {
+          a/line-width: 5;
+          a/line-dasharray: 5,3;
+          b/line-color: #fff;
+          b/line-width: 4;
+          c/line-color: #aaa;
+          c/line-width: 1.5;
+        }
+      }
+    }
+
+    [feature = 'railway_miniature'] {
+      [zoom >= 15] {
+        a/line-width: 1.2;
+        a/line-color: #999;
+        b/line-width: 3;
+        b/line-color: #999;
+        b/line-dasharray: 1,10;
+      }
+    }
+
+    [feature = 'railway_tram'] {
+      .tunnels-fill {
+        [zoom >= 13] {
+          line-width: 1;
+          line-dasharray: 5,3;
+          line-color: #444;
+          [zoom >= 15] { line-width: 2; }
+        }
+      }
+    }
+
+    [feature = 'railway_light_rail'] {
+      [zoom >= 13] {
+        line-width: 2;
+        line-color: #666;
+        .tunnels-fill {
+          line-dasharray: 5,3;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 2;
+          line-color: #666;
+        }
+      }
+    }
+
+    [feature = 'railway_subway'] {
+      [zoom >= 12] {
+        line-width: 2;
+        line-color: #999;
+        .tunnels-fill {
+          line-dasharray: 5,3;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 2;
+          line-color: #999;
+        }
+      }
+    }
+
+    [feature = 'railway_preserved'] {
+      [zoom >= 12] {
+        line-width: 1.5;
+        line-color: #aaa;
+        line-join: round;
+        [zoom >= 13] {
+          line-width: 3;
+          line-color: #999999;
+          b/line-width: 1;
+          b/line-color: white;
+          b/line-dasharray: 0,1,8,1;
+          b/line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_INT-preserved-ssy'] {
+      [zoom >= 12] {
+        line-width: 1;
+        line-color: #aaa;
+        line-join: round;
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: #999999;
+          b/line-width: 0.8;
+          b/line-color: white;
+          b/line-dasharray: 0,1,8,1;
+          b/line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_monorail'] {
+      [zoom >= 14] {
+        line-width: 4;
+        line-color: #fff;
+        line-opacity: 0.4;
+        line-cap: round;
+        line-join: round;
+        b/line-width: 3;
+        b/line-color: #777;
+        b/line-dasharray: 2,3;
+        b/line-cap: round;
+        b/line-join: round;
+      }
+    }
+
+    [feature = 'railway_disused'],
+    [feature = 'railway_abandoned'],
+    [feature = 'railway_construction'] {
+      [zoom >= 13] {
+        line-color: grey;
+        line-width: 2;
+        line-dasharray: 2,4;
+        line-join: round;
+      }
+      .bridges-fill {
+        [zoom >= 13] {
+          line-width: 2;
+          line-color: grey;
+          line-dasharray: 2,4;
+          line-join: round;
+        }
+      }
+    }
+
+    [feature = 'railway_platform'] {
+      [zoom >= 16] {
+        line-join: round;
+        line-width: 6;
+        line-color: grey;
+        line-cap: round;
+        b/line-width: 4;
+        b/line-color: #bbbbbb;
+        b/line-cap: round;
+        b/line-join: round;
+      }
+    }
+
+    [feature = 'railway_turntable'] {
+      [zoom >= 16] {
+        line-width: 1.5;
+        line-color: #999;
+      }
+    }
+
+    [feature = 'aeroway_runway'] {
+      [zoom >= 11][zoom < 14] {
+        line-width: 2;
+        line-color: @runway-fill;
+        [zoom >= 12] { line-width: 4; }
+        [zoom >= 13] { line-width: 7; }
+      }
+      .roads-fill,.tunnels-fill {
+        [zoom >= 14] {
+          line-width: 18;
+          line-color: @runway-fill;
+        }
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 18;
+          line-color: @runway-fill;
+        }
+      }
+    }
+
+    [feature = 'aeroway_taxiway'] {
+      [zoom >= 11][zoom < 14] {
+        line-width: 1;
+        line-color: @taxiway-fill;
+      }
+      .roads-fill,.tunnels-fill {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: @taxiway-fill;
+          [zoom >= 15] {
+            line-width: 6;
+          }
+        } 
+      }
+      .bridges-fill {
+        [zoom >= 14] {
+          line-width: 4;
+          line-color: @taxiway-fill;
+          [zoom >= 15] { line-width: 6; }
+        }
+      }
+    }
+  }
+}
+
 #turning-circle-casing {
   [int_tc_type = 'tertiary'][zoom >= 15] {
     marker-width: @tertiary-width-z15 * 1.8 + 1.8;
@@ -220,8 +2223,6 @@
   }
 }
 
-
-
 #highway-area-casing {
   [feature = 'highway_residential'],
   [feature = 'highway_unclassified'] {
@@ -318,7 +2319,7 @@
       name/text-fill: #6666ff;
       name/text-dy: -9;
       name/text-face-name: @oblique-fonts;
-      name/text-halo-radius: 1.5;
+      name/text-halo-radius: 1;
       name/text-wrap-character: ";";
       name/text-wrap-width: 2;
       name/text-min-distance: 2;
@@ -331,1654 +2332,7 @@
   }
 }
 
-
-#tunnels::casing {
-  [highway = 'motorway'],
-  [highway = 'motorway_link'] {
-    [zoom >= 12] {
-      line-width: 3;
-      line-color: @motorway-casing;
-      line-dasharray: 4,2;
-    }
-    [zoom >= 13] { line-width: 6.5; }
-    [zoom >= 15] { line-width: 10; }
-    [zoom >= 17] { line-width: 13; }
-  }
-
-  [highway = 'trunk'],
-  [highway = 'trunk_link'] {
-    [zoom >= 12] {
-      line-width: 4;
-      line-color: @trunk-casing;
-      line-dasharray: 4,2;
-    }
-    [zoom >= 13] { line-width: 8; }
-    [zoom >= 15] { line-width: 11; }
-    [zoom >= 17] { line-width: 14; }
-  }
-
-  [highway = 'primary'],
-  [highway = 'primary_link'] {
-    [zoom >= 12] {
-      line-width: 4;
-      line-color: @primary-casing;
-      line-dasharray: 4,2;
-    }
-    [zoom >= 13] { line-width: 8; }
-    [zoom >= 15] { line-width: 11; }
-    [zoom >= 17] { line-width: 14; }
-  }
-
-  [highway = 'secondary'],
-  [highway = 'secondary_link'] {
-    [zoom >= 12] {
-      line-width: 4;
-      line-dasharray: 4,2;
-      line-color: @secondary-casing;
-    }
-    [zoom >= 13] { line-width: 10; }
-    [zoom >= 15] { line-width: 12; }
-    [zoom >= 17] { line-width: 17; }
-  }
-
-  [highway = 'tertiary'],
-  [highway = 'tertiary_link'] {
-    [zoom >= 13] {
-      line-width: 6;
-      line-dasharray: 4,2;
-      line-color: @tertiary-casing;
-    }
-    [zoom >= 14] { line-width: 7.5; }
-    [zoom >= 15] { line-width: 11; }
-    [zoom >= 17] { line-width: 16; }
-  }
-
-  [highway = 'residential'],
-  [highway = 'unclassified'],
-  [highway = 'road'] {
-    [zoom >= 13] {
-      line-width: 3;
-      line-color: @residential-casing;
-      line-dasharray: 4,2;
-    }
-    [zoom >= 14] { line-width: 4.5; }
-    [zoom >= 15] { line-width: 8; }
-    [zoom >= 16] { line-width: 11; }
-    [zoom >= 17] { line-width: 16; }
-  }
-}
-
-#tunnels::fill {
-  [highway = 'motorway'],
-  [highway = 'motorway_link'] {
-    [zoom >= 12] {
-      line-width: 2;
-      line-color: @motorway-tunnel-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: 5; }
-    [zoom >= 15] { line-width: 8.5; }
-    [zoom >= 17] { line-width: 11; }
-  }
-
-  [highway = 'trunk'],
-  [highway = 'trunk_link'] {
-    [zoom >= 12] {
-      line-width: 2.5;
-      line-color: @trunk-tunnel-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 13] { line-width: 6.5; }
-    [zoom >= 15] { line-width: 9; }
-    [zoom >= 17] { line-width: 12; }
-  }
-
-  [highway = 'primary'],
-  [highway = 'primary_link'] {
-    [zoom >= 12] {
-      line-width: 2.5;
-      line-color: @primary-tunnel-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: 6.5; }
-    [zoom >= 15] { line-width: 9; }
-    [zoom >= 17] { line-width: 12; }
-  }
-
-  [highway = 'secondary'],
-  [highway = 'secondary_link'] {
-    [zoom >= 12] {
-      line-width: 2;
-      line-color: @secondary-tunnel-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: 8; }
-    [zoom >= 15] { line-width: 10; }
-    [zoom >= 17] { line-width: 14; }
-  }
-
-  [highway = 'tertiary'],
-  [highway = 'tertiary_link'] {
-    [zoom >= 13] {
-      line-width: 5;
-      line-color: @tertiary-tunnel-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 14] { line-width: 6.5; }
-    [zoom >= 15] { line-width: 9.4; }
-    [zoom >= 17] { line-width: 13; }
-  }
-
-  [highway = 'residential'],
-  [highway = 'unclassified'],
-  [highway = 'road'] {
-    [zoom >= 13] {
-      line-width: 2;
-      line-color: @residential-tunnel-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 14] { line-width: 3; }
-    [zoom >= 15] { line-width: 6.5; }
-    [zoom >= 16] { line-width: 9.4; }
-    [zoom >= 17] { line-width: 13; }
-  }
-
-  [highway = 'bridleway'],
-  [highway = 'path'][horse = 'designated'] {
-    [zoom >= 13] {
-      line-width: 5;
-      line-color: @tunnel-casing;
-      line-dasharray: 4,2;
-      b/line-width: 3;
-      b/line-color: @bridleway-casing;
-      b/line-cap: round;
-      b/line-join: round;
-      c/line-width: 2;
-      c/line-color: @bridleway-fill;
-      c/line-opacity: 0.5;
-      c/line-dasharray: 4,2;
-      c/line-join: round;
-      c/line-cap: round;
-    }
-  }
-
-  [highway = 'footway'],
-  [highway = 'path'][foot = 'designated'] {
-    [zoom >= 13] {
-      line-width: 5.5;
-      line-color: @tunnel-casing;
-      line-dasharray: 4,2;
-      b/line-width: 3.5;
-      b/line-color: @footway-casing;
-      b/line-join: round;
-      b/line-cap: round;
-      c/line-width: 2.5;
-      c/line-color: @footway-fill;
-      c/line-dasharray: 1,3;
-      c/line-opacity: 0.5;
-      c/line-join: round;
-      c/line-cap: round;
-    }
-  }
-
-  [highway = 'cycleway'],
-  [highway = 'path'][bicycle = 'designated'] {
-    [zoom >= 13] {
-      line-width: 5;
-      line-color: @tunnel-casing;
-      line-dasharray: 4,2;
-      b/line-width: 3;
-      b/line-color: @cycleway-casing;
-      b/line-join: round;
-      b/line-cap: round;
-      c/line-width: 2;
-      c/line-color: @cycleway-fill;
-      c/line-opacity: 0.5;
-      c/line-dasharray: 1,3;
-      c/line-join: round;
-      c/line-cap: round;
-    }
-  }
-
-  /*
-  * The above defininitions should override this when needed
-  * given the specitivity precedence.
-  */
-  [highway = 'path'][zoom >= 13] {
-    line-width: 5.5;
-    line-color: @tunnel-casing;
-    line-dasharray: 4,2;
-    b/line-width: 1;
-    b/line-color: @path-casing;
-    b/line-opacity: 0.4;
-    b/line-join: round;
-    b/line-cap: round;
-    c/line-width: 0.5;
-    c/line-color: @path-fill;
-    c/line-dasharray: 6,3;
-    c/line-cap: round;
-    c/line-join: round;
-  }
-
-  [highway = 'track'][zoom >= 14] {
-    line-width: 4.5;
-    line-color: @tunnel-casing;
-    line-dasharray: 4,2;
-    b/line-width: 3;
-    b/line-color: @track-casing;
-    b/line-cap: round;
-    b/line-join: round;
-    c/line-width: 1.5;
-    c/line-color: @track-fill;
-    c/line-dasharray: 3,4;
-    c/line-opacity: 0.5;
-    c/line-join: round;
-    c/line-cap: round;
-    [tracktype = 'grade1'] {
-      line-width: 4;
-      b/line-width: 3.5;
-      c/line-width: 2;
-      c/line-color: @track-grade1-fill;
-      c/line-dasharray: 100,0; /* i.e. none, see https://github.com/mapbox/carto/issues/214 */
-    }
-    [tracktype = 'grade2'] {
-      c/line-color: @track-grade2-fill;
-    }
-    [tracktype = 'grade3'] {
-      b/line-width: 3.5;
-      c/line-width: 2;
-      c/line-dasharray: 100,0; /* yes, weird but true */
-    }
-    [tracktype = 'grade4'] {
-      c/line-width: 2;
-      c/line-dasharray: 4,7,1,5;
-    }
-    [tracktype = 'grade5'] {
-      c/line-width: 2;
-      c/line-dasharray: 1,5;
-    }
-  }
-}
-
-#roads-casing::links {
-  [highway = 'raceway'] {
-    [zoom >= 12] {
-      line-color: pink;
-      line-width: 1.2;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: 4; }
-    [zoom >= 15] { line-width: 7; }
-  }
-
-  [highway = 'motorway_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @motorway-width-z12 - 1.5 + 1;
-      line-color: @motorway-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @motorway-width-z13 - 2 + 1.5; }
-    [zoom >= 15] { line-width: @motorway-width-z15 - 2.5 + 1.8; }
-    [zoom >= 17] { line-width: @motorway-width-z17 - 2 + 2.5; }
-  }
-
-  [highway = 'trunk_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @trunk-width-z12 + 1;
-      line-color: @trunk-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @trunk-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @trunk-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @trunk-width-z17 + 2.5; }
-  }
-
-  [highway = 'primary_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @primary-width-z12 + 1;
-      line-color: @primary-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @primary-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @primary-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @primary-width-z17 + 2.5; }
-  }
-
-  [highway = 'secondary_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @secondary-width-z12 + 1;
-      line-color: @secondary-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @secondary-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @secondary-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @secondary-width-z17 + 2.5; }
-  }
-
-  [highway = 'tertiary_link'][tunnel != 'yes'] {
-    [zoom >= 13] {
-      line-width: 6;
-      line-color: @tertiary-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 14] { line-width: 7.5; }
-    [zoom >= 15] { line-width: 11; }
-    [zoom >= 17] { line-width: 16; }
-  }
-}
-
-#roads-casing {
-  [highway = 'motorway'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @motorway-width-z12 + 1;
-      line-color: @motorway-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @motorway-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @motorway-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @motorway-width-z17 + 2.5; }
-  }
-
-  [highway = 'trunk'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @trunk-width-z12 + 1;
-      line-color: @trunk-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @trunk-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @trunk-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @trunk-width-z17 + 2.5; }
-  }
-
-  [highway = 'primary'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @primary-width-z12 + 1;
-      line-color: @primary-casing;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @primary-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @primary-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @primary-width-z17 + 2.5; }
-  }
-
-  [highway = 'secondary'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @secondary-width-z12 + 1;
-      line-color: @secondary-casing;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 13] { line-width: @secondary-width-z13 + 1.5; }
-    [zoom >= 15] { line-width: @secondary-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @secondary-width-z17 + 2.5; }
-  }
-
-  [highway = 'tertiary'][tunnel != 'yes'] {
-    [zoom >= 13] {
-      line-width: @tertiary-width-z13 + 1.5;
-      line-color: @tertiary-casing;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 14] { line-width: @tertiary-width-z14 + 1.5; }
-    [zoom >= 15] { line-width: @tertiary-width-z15 + 1.8; }
-    [zoom >= 17] { line-width: @tertiary-width-z17 + 2.5; }
-  }
-
-  [highway = 'residential'],
-  [highway = 'unclassified'],
-  [highway = 'road'] {
-    [tunnel != 'yes'] {
-      [zoom >= 13] {
-        line-width: 3;
-        line-color: @residential-casing;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 14] { line-width: @residential-width-z14 + 1.5; }
-      [zoom >= 15] { line-width: @residential-width-z15 + 1.8; }
-      [zoom >= 16] { line-width: @residential-width-z16 + 1.8; }
-      [zoom >= 17] { line-width: @residential-width-z17 + 2.5; }
-    }
-  }
-
-  /* This needs refactoring! Minor services shouldn't appear at z14
-   * simply because of a tunnel tag. Also rationalise joins and caps
-   */
-  [highway = 'service'] {
-    [service = 'INT-normal'][tunnel != 'yes'] {
-      [zoom >= 14] {
-        line-color: @service-casing;
-        line-width: 2.5;
-        line-cap: round;
-        line-join: round;
-      }
-      [zoom >= 16] { line-width: 7; }
-    }
-    [service = 'INT-minor'][tunnel != 'yes'] {
-      [zoom >= 16] {
-        line-color: @service-casing;
-        line-width: 4;
-        line-cap: round;
-        line-join: round;
-      }
-    }
-    [tunnel = 'yes'][zoom >= 14] {
-      line-color: @service-casing;
-      line-width: 2.5;
-      line-dasharray: 4,2;
-      [zoom >= 16] { line-width: 7; }
-    }
-  }
-
-  [highway = 'pedestrian'][zoom >= 13] {
-    line-width: 2;
-    line-color: @pedestrian-casing;
-    line-cap: round;
-    line-join: round;
-    [zoom >= 14] { line-width: 3.6; }
-    [zoom >= 15] { line-width: 6.5; }
-    [zoom >= 16] { line-width: 9; }
-    [tunnel = 'yes'] {
-      line-dasharray: 4,2;
-    }
-  }
-
-  [highway = 'living_street'][zoom >= 12] {
-    line-width: 2.5;
-    line-color: @living-street-casing;
-    line-cap: round;
-    line-join: round;
-    [zoom >= 14] { line-width: 4; }
-    [zoom >= 15] { line-width: 6; }
-    [zoom >= 16] { line-width: 9; }
-    [zoom >= 17] { line-width: 14.5; }
-  }
-}
-
-#roads-fill::links {
-  [feature = 'highway_motorway_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @motorway-width-z12 - 1.5;
-      line-color: @motorway-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @motorway-width-z13 - 2; }
-    [zoom >= 15] { line-width: @motorway-width-z15 - 2.5; }
-    [zoom >= 17] { line-width: @motorway-width-z17 - 2; }
-  }
-
-  [feature = 'highway_trunk_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @trunk-width-z12;
-      line-color: @trunk-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 13] { line-width: @trunk-width-z13; }
-    [zoom >= 15] { line-width: @trunk-width-z15; }
-    [zoom >= 17] { line-width: @trunk-width-z17; }
-  }
-
-  [feature = 'highway_primary_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @primary-width-z12;
-      line-color: @primary-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 13] { line-width: @primary-width-z13; }
-    [zoom >= 15] { line-width: @primary-width-z15; }
-    [zoom >= 17] { line-width: @primary-width-z17; }
-  }
-
-  [feature = 'highway_secondary_link'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @secondary-width-z12;
-      line-color: @secondary-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @secondary-width-z13; }
-    [zoom >= 15] { line-width: @secondary-width-z15; }
-    [zoom >= 17] { line-width: @secondary-width-z17; }
-  }
-
-  [feature = 'highway_tertiary_link'][tunnel != 'yes'] {
-    [zoom >= 13] {
-      line-width: @tertiary-width-z13;
-      line-color: @tertiary-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 14] { line-width: @tertiary-width-z14; }
-    [zoom >= 15] { line-width: @tertiary-width-z15; }
-    [zoom >= 17] { line-width: @tertiary-width-z17; }
-  }
-}
-
-#roads-fill {
-
-  /*
-   * The construction rules for small roads are strange, since if construction is null its assumed that
-   * it's a more major road. The line-width = 0 could be removed by playing with the query to set a construction
-   * string for non-small roads.
-   *
-   * Also note that these rules are quite sensitive to re-ordering, since the instances end up swapping round
-   * (and then the dashes appear below the fills). See
-   * https://github.com/gravitystorm/openstreetmap-carto/issues/23
-   * https://github.com/mapbox/carto/issues/235
-   * https://github.com/mapbox/carto/issues/237
-   */
-  [feature = 'highway_proposed'],
-  [feature = 'highway_construction'] {
-    [zoom >= 12] {
-      line-width: 2;
-      line-color: #9cc;
-
-      [construction = 'motorway'],
-      [construction = 'motorway_link'] {
-        line-color: @motorway-fill;
-      }
-      [construction = 'trunk'],
-      [construction = 'trunk_link'] {
-        line-color: @trunk-fill;
-      }
-      [construction = 'primary'],
-      [construction = 'primary_link'] {
-        line-color: @primary-fill;
-      }
-      [construction = 'secondary'],
-      [construction = 'secondary_link'] {
-        line-color: @secondary-fill;
-      }
-      [construction = 'tertiary'],
-      [construction = 'tertiary_link'] {
-        line-color: @tertiary-fill;
-        [zoom < 13] {
-          line-width: 0;
-          b/line-width: 0;
-        }
-      }
-      [construction = 'residential'],
-      [construction = 'unclassified'],
-      [construction = 'living_street'] {
-        line-color: @residential-construction;
-        [zoom < 13] {
-          line-width: 0;
-          b/line-width: 0;
-        }
-      }
-      [construction = 'service'] {
-        line-color: @service-construction;
-        [zoom < 14] {
-          line-width: 0;
-          b/line-width: 0;
-        }
-      }
-      b/line-width: 2;
-      b/line-dasharray: 4,2;
-      b/line-color: white;
-      [zoom >= 13] {
-        line-width: 4;
-        b/line-width: 3.5;
-        b/line-dasharray: 6,4;
-      }
-      [zoom >= 16] {
-        line-width: 8;
-        b/line-width: 7;
-        b/line-dasharray: 8,6;
-      }
-      [construction = 'cycleway'] {
-        [zoom < 14] {
-          line-width: 0;
-          b/line-width: 0;
-        }
-        line-color: white;
-        line-width: 3;
-        line-opacity: 0.4;
-        b/line-width: 1.2;
-        b/line-color: #69f;
-        b/line-dasharray: 2,6;
-      }
-    }
-  }
-
-  [feature = 'highway_motorway'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @motorway-width-z12;
-      line-color: @motorway-fill;
-    }
-    [zoom >= 13] {
-      line-width: @motorway-width-z13;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 15] { line-width: @motorway-width-z15; }
-    [zoom >= 17] { line-width: @motorway-width-z17; }
-  }
-
-  [feature = 'highway_trunk'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @trunk-width-z12;
-      line-cap: round;
-      line-join: round;
-      line-color: @trunk-fill;
-    }
-    [zoom >= 13] { line-width: @trunk-width-z13; }
-    [zoom >= 15] { line-width: @trunk-width-z15; }
-    [zoom >= 17] { line-width: @trunk-width-z17; }
-  }
-
-  [feature = 'highway_primary'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @primary-width-z12;
-      line-color: @primary-fill;
-      line-join: round;
-      line-cap: round;
-    }
-    [zoom >= 13] { line-width: @primary-width-z13; }
-    [zoom >= 15] { line-width: @primary-width-z15; }
-    [zoom >= 17] { line-width: @primary-width-z17; }
-  }
-
-  [feature = 'highway_secondary'][tunnel != 'yes'] {
-    [zoom >= 12] {
-      line-width: @secondary-width-z12;
-      line-color: @secondary-fill;
-      line-cap: round;
-      line-join: round;
-    }
-    [zoom >= 13] { line-width: @secondary-width-z13; }
-    [zoom >= 15] { line-width: @secondary-width-z15; }
-    [zoom >= 17] { line-width: @secondary-width-z17; }
-  }
-
-  [feature = 'highway_tertiary'],
-  [feature = 'highway_residential'],
-  [feature = 'highway_unclassified'],
-  [feature = 'highway_road'] {
-    [zoom >= 10][zoom < 13] {
-      line-width: 1;
-      line-color: @residential-casing;
-    }
-  }
-
-  [feature = 'highway_road'][zoom >= 13] {
-    line-width: 2;
-    line-color: @road-fill;
-    line-join: round;
-    line-cap: round;
-    [zoom >= 14] { line-width: 3; }
-    [zoom >= 15] { line-width: 6.5; }
-    [zoom >= 16] { line-width: 9.4; }
-    [zoom >= 17] { line-width: @residential-width-z17; }
-  }
-
-  [feature = 'highway_residential'],
-  [feature = 'highway_unclassified'] {
-    [zoom >= 13][tunnel != 'yes'] {
-      line-width: @residential-width-z13;
-      line-color: @residential-fill;
-      line-cap: round;
-      line-join: round;
-      [zoom >= 14] { line-width: @residential-width-z14; }
-      [zoom >= 15] { line-width: @residential-width-z15; }
-      [zoom >= 16] { line-width: @residential-width-z16; }
-      [zoom >= 17] { line-width: @residential-width-z17; }
-    }
-  }
-
-  [feature = 'highway_living_street'][zoom >= 12] {
-    line-width: 1.5;
-    line-color: @living-street-fill;
-    line-join: round;
-    line-cap: round;
-    [zoom >= 14] { line-width: 3; }
-    [zoom >= 15] { line-width: 4.7; }
-    [zoom >= 16] { line-width: 7.4; }
-    [zoom >= 17] { line-width: 13; }
-  }
-
-  [feature = 'highway_tertiary'][tunnel != 'yes'][zoom >= 13] {
-    line-width: @tertiary-width-z13;
-    line-color: @tertiary-fill;
-    line-join: round;
-    line-cap: round;
-    [zoom >= 14] { line-width: @tertiary-width-z14; }
-    [zoom >= 15] { line-width: @tertiary-width-z15; }
-    [zoom >= 17] { line-width: @tertiary-width-z17; }
-  }
-
-  [feature = 'highway_service'][service = 'INT-normal'][zoom >= 13] {
-    line-width: 1;
-    line-color: @residential-casing;
-    [zoom >= 14] {
-      line-join: round;
-      line-cap: round;
-      line-width: 2;
-      line-color: @residential-fill;
-    }
-    [zoom >= 16] { line-width: 6; }
-  }
-
-  [feature = 'highway_service'][service = 'INT-minor'][zoom >= 16] {
-    line-width: 3;
-    line-color: @residential-fill;
-    line-join: round;
-    line-cap: round;
-  }
-
-  [feature = 'highway_pedestrian'][zoom >= 13] {
-    line-width: 1.5;
-    line-color: @pedestrian-fill;
-    line-join: round;
-    line-cap: round;
-    [zoom >= 14] { line-width: 3; }
-    [zoom >= 15] { line-width: 5.5; }
-    [zoom >= 16] { line-width: 8; }
-  }
-
-  [feature = 'highway_platform'] {
-    [zoom >= 16] {
-      line-join: round;
-      line-width: 6;
-      line-color: grey;
-      line-cap: round;
-      b/line-width: 4;
-      b/line-color: #bbbbbb;
-      b/line-cap: round;
-      b/line-join: round;
-    }
-  }
-
-  [feature = 'highway_steps'][zoom >= 13][zoom < 15] {
-    line-width: 6;
-    line-color: @steps-casing;
-    line-opacity: 0.4;
-    b/line-width: 2;
-    b/line-color: @steps-fill;
-    b/line-dasharray: 1,3;
-    b/line-cap: round;
-    b/line-join: round;
-  }
-
-  [feature = 'highway_steps'][zoom >= 15] {
-    line-width: 5.0;
-    line-color: @steps-fill;
-    line-dasharray: 2,1;
-  }
-
-  [feature = 'highway_bridleway'],
-  [feature = 'highway_path'][horse = 'designated'] {
-    [zoom >= 13][tunnel != 'yes'] {
-      line-width: 3;
-      line-color: @bridleway-casing;
-      line-cap: round;
-      line-join: round;
-      line-opacity: 0.4;
-      b/line-color: @bridleway-fill;
-      b/line-width: 1.2;
-      b/line-dasharray: 4,2;
-    }
-  }
-
-  [feature = 'highway_footway'],
-  [feature = 'highway_path'][foot = 'designated'] {
-    [zoom >= 13][tunnel != 'yes'] {
-      line-width: 4;
-      line-color: @footway-casing;
-      line-opacity: 0.4;
-      line-cap: round;
-      line-join: round;
-      b/line-width: 1.5;
-      b/line-color: @footway-fill;
-      b/line-dasharray: 1,3;
-      b/line-cap: round;
-      b/line-join: round;
-    }
-  }
-
-  [feature = 'highway_cycleway'],
-  [feature = 'highway_path'][bicycle = 'designated'] {
-    [zoom >= 13][tunnel != 'yes'] {
-      line-width: 3;
-      line-color: @cycleway-casing;
-      line-join: round;
-      line-cap: round;
-      line-opacity: 0.4;
-      b/line-width: 1.2;
-      b/line-dasharray: 1,3;
-      b/line-color: @cycleway-fill;
-      b/line-join: round;
-      b/line-cap: round;
-    }
-  }
-
-  /*
-   * The above defininitions should override this when needed
-   * given the specitivity precedence.
-   */
-  [feature = 'highway_path'][tunnel != 'yes'] {
-    [zoom >= 13] {
-      line-width: 1.0;
-      line-color: @path-casing;
-      line-opacity: 0.4;
-      line-cap: round;
-      line-join: round;
-      b/line-width: 0.5;
-      b/line-dasharray: 6,3;
-      b/line-color: @path-fill;
-      b/line-join: round;
-      b/line-cap: round;
-    }
-  }
-
-  [feature = 'highway_track'] {
-    [zoom >= 13] {
-      line-color: @track-casing;
-      line-join: round;
-      line-cap: round;
-      line-opacity: 0.4;
-      b/line-color: @track-fill;
-      b/line-cap: round;
-      b/line-join: round;
-      b/line-dasharray: 3,4;
-      [zoom >= 13][zoom < 14] {
-        line-width: 2.5;
-        b/line-width: 1.2;
-      }
-      [zoom >= 14] {
-        line-width: 3;
-        b/line-width: 1.5;
-        [tracktype = 'grade1'] {
-          line-width: 3.5;
-          b/line-width: 2;
-          b/line-color: @track-grade1-fill;
-          b/line-dasharray: 100,0; /* i.e. none, see https://github.com/mapbox/carto/issues/214 */
-          b/line-opacity: 0.7;
-        }
-        [tracktype = 'grade2'] {
-          line-width: 3;
-          b/line-color: @track-grade2-fill;
-          b/line-width: 1.5;
-          b/line-dasharray: 9,4;
-          b/line-opacity: 0.8;
-        }
-        [tracktype = 'grade3'] {
-          line-width: 3;
-          b/line-width: 1.5;
-          b/line-dasharray: 3,4;
-          b/line-opacity: 0.8;
-        }
-        [tracktype = 'grade4'] {
-          line-width: 3;
-          b/line-width: 2;
-          b/line-dasharray: 4,7,1,5;
-          b/line-opacity: 0.8;
-         }
-        [tracktype = 'grade5'] {
-          line-width: 3;
-          b/line-width: 2;
-          b/line-dasharray: 1,5;
-          b/line-opacity: 0.8;
-        }
-      }
-    }
-  }
-
-    [feature = 'railway_rail'][tunnel = 'yes'][zoom >= 13],
-    [feature = 'railway_spur-siding-yard'][tunnel = 'yes'][zoom >= 13] {
-      a/line-width: 3;
-      b/line-width: 3;
-      c/line-width: 3;
-      d/line-width: 3;
-      e/line-width: 3;
-      f/line-width: 3;
-      g/line-width: 3;
-      a/line-color: #ffffff;
-      b/line-color: #fdfdfd;
-      c/line-color: #ececec;
-      d/line-color: #cacaca;
-      e/line-color: #afafaf;
-      f/line-color: #a1a1a1;
-      g/line-color: #9b9b9b;
-      a/line-dasharray: 1,9;
-      b/line-dasharray: 0,1,1,8;
-      c/line-dasharray: 0,2,1,7;
-      d/line-dasharray: 0,3,1,6;
-      e/line-dasharray: 0,4,1,5;
-      f/line-dasharray: 0,5,1,4;
-      g/line-dasharray: 0,6,1,3;
-      a/line-join: round;
-      b/line-join: round;
-      c/line-join: round;
-      d/line-join: round;
-      e/line-join: round;
-      f/line-join: round;
-      g/line-join: round;
-      [feature = 'railway_spur-siding-yard'] {
-        a/line-width: 2;
-        b/line-width: 2;
-        c/line-width: 2;
-        d/line-width: 2;
-        e/line-width: 2;
-        f/line-width: 2;
-        g/line-width: 2;
-      }
-    }
-
-    [feature = 'railway_rail'][tunnel != 'yes'][zoom >= 13] {
-      a/line-width: 3;
-      a/line-color: #999999;
-      a/line-join: round;
-      b/line-width: 1;
-      b/line-color: white;
-      b/line-dasharray: 8,12;
-      b/line-join: round;
-      [zoom >= 14] {
-        b/line-dasharray: 0,11,8,1;
-      }
-    }
-
-    [feature = 'railway_spur-siding-yard'][zoom >= 11] {
-      a/line-width: 1;
-      a/line-color: #aaa;
-      a/line-join: round;
-      [zoom >= 13][tunnel != 'yes'] {
-        a/line-color: #999999;
-        a/line-width: 2;
-        b/line-width: 0.8;
-        b/line-dasharray: 0,8,11,1;
-        b/line-color: white;
-        b/line-join: round;
-      }
-    }
-
-    [feature = 'railway_narrow_gauge'],
-    [feature = 'railway_funicular'] {
-      [zoom >= 13] {
-        a/line-width: 2;
-        a/line-color: #666;
-        [tunnel = 'yes'] {
-          a/line-width: 5;
-          a/line-dasharray: 5,3;
-          b/line-color: #fff;
-          b/line-width: 4;
-          c/line-color: #aaa;
-          c/line-width: 1.5;
-        }
-      }
-    }
-
-    [feature = 'railway_miniature'][zoom >= 15] {
-      a/line-width: 1.2;
-      a/line-color: #999;
-      b/line-width: 3;
-      b/line-color: #999;
-      b/line-dasharray: 1,10;
-    }
-
-    [feature = 'railway_tram'][tunnel = 'yes'][zoom >= 13] {
-      line-width: 1;
-      line-dasharray: 5,3;
-      line-color: #444;
-      [zoom >= 15] { line-width: 2; }
-    }
-
-    [feature = 'railway_light_rail'][zoom >= 13] {
-      line-width: 2;
-      line-color: #666;
-      [tunnel = 'yes'] {
-        line-dasharray: 5,3;
-      }
-    }
-
-    [feature = 'railway_subway'][zoom >= 12] {
-      line-width: 2;
-      line-color: #999;
-      [tunnel = 'yes'] {
-        line-dasharray: 5,3;
-      }
-    }
-
-
-    [feature = 'railway_preserved'][zoom >= 12] {
-      line-width: 1.5;
-      line-color: #aaa;
-      line-join: round;
-      [zoom >= 13] {
-        line-width: 3;
-        line-color: #999999;
-        b/line-width: 1;
-        b/line-color: white;
-        b/line-dasharray: 0,1,8,1;
-        b/line-join: round;
-      }
-    }
-
-    [feature = 'railway_INT-preserved-ssy'][zoom >= 12] {
-      line-width: 1;
-      line-color: #aaa;
-      line-join: round;
-      [zoom >= 13] {
-        line-width: 2;
-        line-color: #999999;
-        b/line-width: 0.8;
-        b/line-color: white;
-        b/line-dasharray: 0,1,8,1;
-        b/line-join: round;
-      }
-    }
-
-    [feature = 'railway_monorail'][zoom >= 14] {
-      line-width: 4;
-      line-color: #fff;
-      line-opacity: 0.4;
-      line-cap: round;
-      line-join: round;
-      b/line-width: 3;
-      b/line-color: #777;
-      b/line-dasharray: 2,3;
-      b/line-cap: round;
-      b/line-join: round;
-    }
-
-    [feature = 'railway_disused'],
-    [feature = 'railway_abandoned'],
-    [feature = 'railway_construction'] {
-      [zoom >= 13] {
-        line-color: grey;
-        line-width: 2;
-        line-dasharray: 2,4;
-        line-join: round;
-      }
-    }
-
-    [feature = 'railway_platform'] {
-      [zoom >= 16] {
-        line-join: round;
-        line-width: 6;
-        line-color: grey;
-        line-cap: round;
-        b/line-width: 4;
-        b/line-color: #bbbbbb;
-        b/line-cap: round;
-        b/line-join: round;
-      }
-    }
-
-    [feature = 'railway_turntable'][zoom >= 16] {
-      line-width: 1.5;
-      line-color: #999;
-    }
-
-  [feature = 'aeroway_runway'][zoom >= 11][zoom < 14] {
-    line-width: 2;
-    line-color: @runway-fill;
-    [zoom >= 12] { line-width: 4; }
-    [zoom >= 13] { line-width: 7; }
-  }
-
-  [feature = 'aeroway_runway'][bridge = 'no'][zoom >= 14] {
-    line-width: 18;
-    line-color: @runway-fill;
-  }
-
-  [feature = 'aeroway_taxiway'][zoom >= 11][zoom < 14] {
-    line-width: 1;
-    line-color: @taxiway-fill;
-  }
-
-  [feature = 'aeroway_taxiway'][bridge = 'no'][zoom >= 14] {
-    line-width: 4;
-    line-color: @taxiway-fill;
-    [zoom >= 15] {
-      line-width: 6;
-    }
-  }
-}
-
-.bridges {
-  ::bridges_casing {
-    [feature = 'highway_motorway'],
-    [feature = 'highway_motorway_link'] {
-      [zoom >= 12] {
-        line-width: 3;
-        line-color: @motorway-casing;
-        line-join: round;
-      }
-      [zoom >= 13] {
-        line-width: 6.5;
-        line-color: @bridge-casing;
-      }
-      [zoom >= 15] { line-width: 9; }
-      [zoom >= 17] { line-width: 12; }
-    }
-
-    [feature = 'highway_trunk'],
-    [feature = 'highway_trunk_link'] {
-      [zoom >= 12] {
-        line-width: 4;
-        line-color: @trunk-casing;
-        line-join: round;
-      }
-      [zoom >= 13] {
-        line-width: 8;
-        line-color: @bridge-casing;
-      }
-      [zoom >= 15] { line-width: 11; }
-      [zoom >= 17] { line-width: 16; }
-    }
-
-    [feature = 'highway_primary'],
-    [feature = 'highway_primary_link'] {
-      [zoom >= 12] {
-        line-width: 4;
-        line-color: @primary-casing;
-        line-join: round;
-      }
-      [zoom >= 13] {
-        line-width: 8;
-        line-color: @bridge-casing;
-      }
-      [zoom >= 15] { line-width: 11; }
-      [zoom >= 17] { line-width: 16; }
-    }
-
-    [feature = 'highway_secondary'],
-    [feature = 'highway_secondary_link'] {
-      [zoom >= 13] {
-        line-width: 10;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-      [zoom >= 15] { line-width: 12; }
-      [zoom >= 17] { line-width: 16; }
-    }
-
-    [feature = 'highway_tertiary'],
-    [feature = 'highway_tertiary_link'] {
-      [zoom >= 14] {
-        line-width: 7.5;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-      [zoom >= 15] { line-width: 11; }
-      [zoom >= 17] { line-width: 16; }
-    }
-
-    [feature = 'highway_residential'],
-    [feature = 'highway_unclassified'],
-    [feature = 'highway_road'] {
-      [zoom >= 14] {
-        line-width: 4.5;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-      [zoom >= 15] { line-width: 9; }
-      [zoom >= 16] { line-width: 11; }
-      [zoom >= 17] { line-width: 16; }
-    }
-
-    [feature = 'highway_service'] {
-      [zoom >= 14] {
-        line-width: 3;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-      [zoom >= 16] { line-width: 8; }
-    }
-
-    [feature = 'highway_pedestrian'] {
-      [zoom >= 13] {
-        line-width: 2.2;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-      [zoom >= 14] { line-width: 3.8; }
-      [zoom >= 15] { line-width: 7; }
-      [zoom >= 16] { line-width: 9.5; }
-    }
-
-    [feature = 'highway_bridleway'],
-    [feature = 'highway_path'][horse = 'designated'] {
-      [zoom >= 14] {
-        line-width: 5.5;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-    }
-
-    [feature = 'highway_footway'],
-    [feature = 'highway_path'][foot = 'designated'] {
-      [zoom >= 14] {
-        line-width: 6;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-    }
-
-    [feature = 'highway_cycleway'],
-    [feature = 'highway_path'][bicycle = 'designated'] {
-      [zoom >= 14] {
-        line-width: 5.5;
-        line-color: @bridge-casing;
-        line-join: round;
-      }
-    }
-
-    [feature = 'highway_path'][zoom >= 14] {
-      line-width: 4;
-      line-color: @bridge-casing;
-      line-join: round;
-    }
-
-    [feature = 'highway_track'][zoom >= 14] {
-      line-width: 4.5;
-      line-color: @bridge-casing;
-      line-join: round;
-      [tracktype = 'grade1'] {
-        line-width: 5;
-      }
-    }
-
-      [feature = 'railway_subway'][zoom >= 14] {
-        line-width: 5.5;
-        line-color: black;
-        line-join: round;
-      }
-
-      [feature = 'railway_light_rail'],
-      [feature = 'railway_narrow_gauge'] {
-        [zoom >= 14] {
-          line-width: 5.5;
-          line-color: #555;
-          line-join: round;
-        }
-      }
-
-      [feature = 'railway_rail'][zoom >= 13] {
-        line-width: 6.5;
-        line-color: black;
-        line-join: round;
-      }
-
-      [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
-        line-width: 5.7;
-        line-color: black;
-        line-join: round;
-      }
-
-      [feature = 'railway_disused'],
-      [feature = 'railway_abandoned'],
-      [feature = 'railway_construction'] {
-        [zoom >= 13] {
-          line-width: 6;
-          line-color: black;
-          line-join: round;
-        }
-      }
-
-    [feature = 'aeroway_runway'][zoom >= 14] {
-      line-width: 19;
-      line-color: black;
-      line-join: round;
-    }
-
-    [feature = 'aeroway_taxiway'][zoom >= 14] {
-      line-width: 5;
-      line-color: black;
-      line-join: round;
-      [zoom >= 15] { line-width: 7; }
-    }
-  }
-
-  ::bridges-casing2 {
-    [feature = 'highway_bridleway'],
-    [feature = 'highway_path'][horse = 'designated'] {
-      [zoom >= 14] {
-        line-width: 4;
-        line-color: @bridleway-casing;
-        line-join: round;
-        line-cap: round;
-      }
-    }
-
-    [feature = 'highway_footway'],
-    [feature = 'highway_path'][foot = 'designated'] {
-      [zoom >= 14] {
-        line-width: 4.5;
-        line-color: @footway-casing;
-        line-join: round;
-        line-cap: round;
-      }
-    }
-
-    [feature = 'highway_cycleway'],
-    [feature = 'highway_path'][bicycle = 'designated'] {
-      [zoom >= 14] {
-        line-width: 4;
-        line-color: @cycleway-casing;
-        line-join: round;
-        line-cap: round;
-      }
-    }
-
-    [feature = 'highway_path'] {
-      [zoom >= 14] {
-        line-width: 2.5;
-        line-color: @path-casing;
-        line-join: round;
-        line-cap: round;
-      }
-    }
-
-    [feature = 'highway_track'][zoom >= 14] {
-      line-width: 3;
-      line-color: @track-casing;
-      line-join: round;
-      line-cap: round;
-      [tracktype = 'grade1'] { line-width: 3.5; }
-    }
-
-      [feature = 'railway_rail'][zoom >= 13] {
-        line-width: 5;
-        line-color: white;
-        line-join: round;
-      }
-
-      [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
-        line-width: 4;
-        line-color: white;
-        line-join: round;
-        line-cap: round;
-      }
-
-      [feature = 'railway_disused'],
-      [feature = 'railway_abandoned'],
-      [feature = 'railway_construction'] {
-        [zoom >= 13] {
-          line-width: 4.5;
-          line-color: white;
-          line-join: round;
-          line-cap: round;
-        }
-      }
-
-      [feature = 'railway_subway'][zoom >= 14] {
-        line-width: 4;
-        line-color: white;
-      }
-
-      [feature = 'railway_light_rail'],
-      [feature = 'railway_narrow_gauge'] {
-        [zoom >= 14] {
-          line-width: 4;
-          line-color: white;
-        }
-      }
-  }
-
-  ::bridges_fill {
-    [feature = 'highway_motorway'],
-    [feature = 'highway_motorway_link'] {
-      [zoom >= 12] {
-        line-width: 2;
-        line-color: @motorway-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 13] { line-width: 5.5; }
-      [zoom >= 15] { line-width: 7.5; }
-      [zoom >= 17] { line-width: 10; }
-    }
-
-    [feature = 'highway_trunk'],
-    [feature = 'highway_trunk_link'] {
-      [zoom >= 12] {
-        line-width: 3;
-        line-color: @trunk-fill;
-        line-cap: round;
-        line-join: round;
-      }
-      [zoom >= 13] { line-width: 7; }
-      [zoom >= 15] { line-width: 9.5; }
-      [zoom >= 17] { line-width: 14.5; }
-    }
-
-    [feature = 'highway_primary'],
-    [feature = 'highway_primary_link'] {
-      [zoom >= 12] {
-        line-width: 3;
-        line-color: @primary-fill;
-        line-cap: round;
-        line-join: round;
-      }
-      [zoom >= 13] { line-width: 7; }
-      [zoom >= 15] { line-width: 9.5; }
-      [zoom >= 17] { line-width: 14.5; }
-    }
-
-    [feature = 'highway_secondary'],
-    [feature = 'highway_secondary_link'] {
-      [zoom >= 13] {
-        line-width: 9;
-        line-color: @secondary-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 15] { line-width: 10.5; }
-      [zoom >= 17] { line-width: 14.5; }
-    }
-
-    [feature = 'highway_tertiary'],
-    [feature = 'highway_tertiary_link'] {
-      [zoom >= 14] {
-        line-width: 6;
-        line-color: @tertiary-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 15] { line-width: 9.5; }
-      [zoom >= 17] { line-width: 14; }
-    }
-
-    [feature = 'highway_road'] {
-      [zoom >= 14] {
-        line-width: 3.5;
-        line-color: @road-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 15] { line-width: 9.5; }
-      [zoom >= 17] { line-width: 14; }
-    }
-
-    [feature = 'highway_residential'],
-    [feature = 'highway_unclassified'] {
-      [zoom >= 14] {
-        line-width: 3.5;
-        line-color: @residential-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 15] { line-width: 7.5; }
-      [zoom >= 16] { line-width: 9.5; }
-      [zoom >= 17] { line-width: 14; }
-    }
-
-    [feature = 'highway_service'] {
-      [zoom >= 14] {
-        line-width: 2;
-        line-color: @service-fill;
-        line-cap: round;
-        line-join: round;
-      }
-      [zoom >= 16] { line-width: 6; }
-    }
-
-    [feature = 'highway_pedestrian'] {
-      [zoom >= 13] {
-        line-width: 1.5;
-        line-color: @pedestrian-fill;
-        line-join: round;
-        line-cap: round;
-      }
-      [zoom >= 14] { line-width: 3; }
-      [zoom >= 15] { line-width: 5.5; }
-      [zoom >= 16] { line-width: 8; }
-    }
-
-    [feature = 'highway_bridleway'],
-    [feature = 'highway_path'][horse = 'designated'] {
-      [zoom >= 14] {
-        line-width: 1.5;
-        line-color: @bridleway-fill;
-        line-dasharray: 4,2;
-      }
-    }
-
-    [feature = 'highway_footway'],
-    [feature = 'highway_path'][foot = 'designated'] {
-      [zoom >= 14] {
-        line-width: 2;
-        line-color: @footway-fill;
-        line-dasharray: 1,3;
-        line-cap: round;
-        line-join: round;
-      }
-    }
-
-    [feature = 'highway_cycleway'],
-    [feature = 'highway_path'][bicycle = 'designated'] {
-      [zoom >= 14] {
-        line-width: 1.5;
-        line-color: @cycleway-fill;
-        line-dasharray: 1,3;
-        line-join: round;
-        line-cap: round;
-      }
-    }
-
-    [feature = 'highway_path'][zoom >= 14] {
-      line-width: 0.5;
-      line-color: @path-fill;
-      line-dasharray: 6,3;
-      line-join: round;
-      line-cap: round;
-    }
-
-    [feature = 'highway_track'][zoom >= 14] {
-      line-width: 1.5;
-      line-color: @track-fill;
-      line-dasharray: 3,4;
-      line-join: round;
-      line-cap: round;
-      [tracktype = 'grade1'] {
-        line-width: 2;
-        line-color: @track-grade1-fill;
-        line-dasharray: 100,0; /* i.e. none */
-        line-opacity: 0.7;
-      }
-      [tracktype = 'grade2'] {
-        line-color: @track-grade2-fill;
-        line-opacity: 0.8;
-      }
-      [tracktype = 'grade3'] {
-        line-width: 2;
-        line-opacity: 0.7;
-        line-dasharray: 100,0; /* strange but true */
-      }
-      [tracktype = 'grade4'] {
-        line-width: 2;
-        line-dasharray: 4,7,1,5;
-        line-opacity: 0.8;
-      }
-      [tracktype = 'grade5'] {
-        line-width: 2;
-        line-dasharray: 1,5;
-        line-opacity: 0.8;
-      }
-    }
-
-      [feature = 'railway_rail'][zoom >= 13] {
-        line-width: 3;
-        line-color: #999999;
-        line-join: round;
-        b/line-width: 1;
-        b/line-color: white;
-        b/line-dasharray: 8,12;
-        b/line-join: round;
-        [zoom >= 14] {
-          b/line-dasharray: 0,11,8,1;
-        }
-      }
-
-      [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
-        line-width: 2;
-        line-color: #999999;
-        line-join: round;
-        b/line-width: 0.8;
-        b/line-color: white;
-        b/line-dasharray: 0,8,11,1;
-        b/line-join: round;
-      }
-
-      [feature = 'railway_disused'],
-      [feature = 'railway_abandoned'],
-      [feature = 'railway_construction'] {
-        [zoom >= 13] {
-          line-width: 2;
-          line-color: grey;
-          line-dasharray: 2,4;
-          line-join: round;
-        }
-      }
-
-      [feature = 'railway_subway'][zoom >= 14] {
-        line-width: 2;
-        line-color: #999;
-      }
-
-      [feature = 'railway_light_rail'],
-      [feature = 'railway_narrow_gauge'] {
-        [zoom >= 14] {
-          line-width: 2;
-          line-color: #666;
-        }
-      }
-
-    [feature = 'aeroway_runway'][zoom >= 14] {
-      line-width: 18;
-      line-color: @runway-fill;
-    }
-
-    [feature = 'aeroway_taxiway'][zoom >= 14] {
-      line-width: 4;
-      line-color: @taxiway-fill;
-      [zoom >= 15] { line-width: 6; }
-    }
-  }
-}
-
-.access {
+.access::fill {
   [access = 'permissive'] {
     [feature = 'highway_unclassified'],
     [feature = 'highway_residential'],
@@ -2026,9 +2380,20 @@
       [zoom >= 16] { access/line-width: 6; }
     }
   }
-  [access = 'private'],
   [access = 'no'] {
-    [feature != 'highway_service'] {
+    [feature = 'highway_motorway'],
+    [feature = 'highway_trunk'],
+    [feature = 'highway_primary'],
+    [feature = 'highway_secondary'],
+    [feature = 'highway_tertiary'],
+    [feature = 'highway_unclassified'],
+    [feature = 'highway_residential'],
+    [feature = 'highway_road'],
+    [feature = 'highway_track'],
+    [feature = 'highway_path'],
+    [feature = 'highway_footway'],
+    [feature = 'highway_cycleway'],
+    [feature = 'highway_bridleway'] {
       [zoom >= 15] {
         access/line-width: 6;
         access/line-color: @private-marking;
@@ -2098,26 +2463,28 @@
     }
   }
 
-    [feature = 'railway_rail'][zoom >= 6][zoom < 13] {
+  [feature = 'railway_rail'] {
+    [zoom >= 6][zoom < 13] {
       line-width: 0.6;
       line-color: #aaa;
       [zoom >= 9] { line-width: 1; }
       [zoom >= 10] { line-width: 2; }
-      [tunnel = 'yes'] {
+      .tunnels-casing {
         line-dasharray: 5,2;
       }
     }
+  }
 
-    [feature = 'railway_tram'],
-    [feature = 'railway_light_rail'],
-    [feature = 'railway_funicular'],
-    [feature = 'railway_narrow_gauge'] {
-      [zoom >= 8][zoom < 13] {
-        line-width: 1;
-        line-color: #ccc;
-        [zoom >= 10] { line-color: #aaa }
-      }
+  [feature = 'railway_tram'],
+  [feature = 'railway_light_rail'],
+  [feature = 'railway_funicular'],
+  [feature = 'railway_narrow_gauge'] {
+    [zoom >= 8][zoom < 13] {
+      line-width: 1;
+      line-color: #ccc;
+      [zoom >= 10] { line-color: #aaa }
     }
+  }
 }
 
 #trams {
@@ -2392,51 +2759,51 @@
   }
 }
 
-.directions {
+.directions::directions {
   [zoom >= 16] {
     [oneway = 'yes'] {
-      a/line-width: 1;
-      a/line-dasharray: 0,12,10,152;
-      a/line-color: #6c70d5;
-      a/line-join: bevel;
-      a/line-clip: false;
-      b/line-width: 2;
-      b/line-dasharray: 0,12,9,153;
-      b/line-color: #6c70d5;
-      b/line-join: bevel;
-      b/line-clip: false;
-      c/line-width: 3;
-      c/line-dasharray: 0,18,2,154;
-      c/line-color: #6c70d5;
-      c/line-join: bevel;
-      c/line-clip: false;
-      d/line-width: 4;
-      d/line-dasharray: 0,18,1,155;
-      d/line-color: #6c70d5;
-      d/line-join: bevel;
-      d/line-clip: false;
+      dira/line-width: 1;
+      dira/line-dasharray: 0,12,10,152;
+      dira/line-color: #6c70d5;
+      dira/line-join: bevel;
+      dira/line-clip: false;
+      dirb/line-width: 2;
+      dirb/line-dasharray: 0,12,9,153;
+      dirb/line-color: #6c70d5;
+      dirb/line-join: bevel;
+      dirb/line-clip: false;
+      dirc/line-width: 3;
+      dirc/line-dasharray: 0,18,2,154;
+      dirc/line-color: #6c70d5;
+      dirc/line-join: bevel;
+      dirc/line-clip: false;
+      dird/line-width: 4;
+      dird/line-dasharray: 0,18,1,155;
+      dird/line-color: #6c70d5;
+      dird/line-join: bevel;
+      dird/line-clip: false;
     }
     [oneway = '-1'] {
-      a/line-width: 1;
-      a/line-dasharray: 0,12,10,152;
-      a/line-color: #6c70d5;
-      a/line-join: bevel;
-      a/line-clip: false;
-      b/line-width: 2;
-      b/line-dasharray: 0,13,9,152;
-      b/line-color: #6c70d5;
-      b/line-join: bevel;
-      b/line-clip: false;
-      c/line-width: 3;
-      c/line-dasharray: 0,14,2,158;
-      c/line-color: #6c70d5;
-      c/line-join: bevel;
-      c/line-clip: false;
-      d/line-width: 4;
-      d/line-dasharray: 0,15,1,158;
-      d/line-color: #6c70d5;
-      d/line-join: bevel;
-      d/line-clip: false;
+      dira/line-width: 1;
+      dira/line-dasharray: 0,12,10,152;
+      dira/line-color: #6c70d5;
+      dira/line-join: bevel;
+      dira/line-clip: false;
+      dirb/line-width: 2;
+      dirb/line-dasharray: 0,13,9,152;
+      dirb/line-color: #6c70d5;
+      dirb/line-join: bevel;
+      dirb/line-clip: false;
+      dirc/line-width: 3;
+      dirc/line-dasharray: 0,14,2,158;
+      dirc/line-color: #6c70d5;
+      dirc/line-join: bevel;
+      dirc/line-clip: false;
+      dird/line-width: 4;
+      dird/line-dasharray: 0,15,1,158;
+      dird/line-color: #6c70d5;
+      dird/line-join: bevel;
+      dird/line-clip: false;
     }
   }
 }


### PR DESCRIPTION
Code for every highway type is currently spread out over three places in
the code: once for bridges, once for tunnels, and once for normal roads.
This means that a lot of code is duplicated. The current pull request
brings the code for a single highway type together at one place in the
code.

Although the code is brought together, it does not yet collapse all
equivalent definitions. This will be done in the next pull request.

The advantage of this is easier maintenance, because a) the CartoCSS
code will be shorter; b) there will be less duplication in the code;
and c) code for one type of road is at only one location in the code.
## Changes

Although the aim of this change is to improve the structure of the code,
it has some small changes of rendering as side effects:
- The tag access=no is no longer rendered on railways, aeroways, and
  roads under construction.
- For bridges and tunnels, access restrictions are rendered at the same
  time as the roads to which they apply, just like it was already the
  case for normal roads.
- Direction arrows are now layered as own attachment, but still directly
  on top of the layer they apply to.
- Tunnels and bridges that are a link are now rendered under other roads
  of the same osm-layer, just like links that are not a tunnel or bridge.
- The following kind of tunnels are now correctly rendered in the tunnel
  layer instead of in the regular layer: the highway types tertiary
  (z10-12), residential (z10-12), unclassified (z10-12), service,
  living_street, road (fill only), road (z10-12), pedestrian, platform,
  steps, track, raceway, construction, proposed; all railway types; all
  aeroway types.
- The following kind of bridges are now correctly rendered in the bridge
  layer instead of in the regular layer: the highway types secondary
  (z12), tertiary (z10-13), unclassified (z10-13), residential (z10-13),
  road (z10-13), living_street, pedestrian (z13-15), bridleway (z13),
  footway (z13), cycleway (z13), path (z13), track (z13), raceway,
  construction, platform, steps; the railway types spur (z11-12), siding
  (z11-12), yard (z11-12), funicular, minitiature, tram, lightrail
  (z13), subway (z12-13), preserved, monorail, platform, turntable; the
  aeroway type runway (z11-13).
- Ways with both tunnel=yes and bridge=yes might get rendered different
  than before (but such ways should not exist anyway).
- highway=road is now also rendered on the layer for bridges and
  tunnels.
- One-way restrictions on bridges are no longer displayed on highways
  types that are not rendered.
- One-way restrictions on bridges are now displayed on all rendered
  railway types.
## Performance

In general performance seems to improve. I compared performance between
2254ec971ca418e34295c67417febf003c5182cc and
42e4203f2fd9a40e9732b59db0a97506e399ec96. The resulting output osm.xml
is now 8% smaller. I measure a performance loss of 4% at z15, but
performance gains of 12%, 16%, and 13% on z16, z17, and z18,
respectively. My measurements are not very accurate, so I would be happy
if @pnorman or someone else could independently verify this.
## Pull request size

I'm sorry for the huge pull request. I couldn't break it up without
breaking functionality or significantly increasing run-time. The next
pull requests will be smaller.
