### PR TITLE
Render motorcar=* the same as access=*

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2333,7 +2333,7 @@
 }
 
 .access::fill {
-  [access = 'permissive'] {
+  [access = 'permissive'],[motorcar='permissive'] {
     [feature = 'highway_unclassified'],
     [feature = 'highway_residential'],
     [feature = 'highway_footway'] {
@@ -2357,7 +2357,7 @@
       [zoom >= 16] { access/line-width: 6; }
     }
   }
-  [access = 'destination'] {
+  [access = 'destination'],[motorcar='destination'] {
     [feature = 'highway_unclassified'],
     [feature = 'highway_residential'] {
       [zoom >= 15] {


### PR DESCRIPTION
Currently the standard style renders highways tagged with permissive and destination differently. Given that most uses, particularly of access=destination are actually wrong (excludes access for all including pedestrians for example), it would seem to be sensible to render at least the most of the time correct motorcar=destination and motor_vehicle=destination the same or drop the special rendering alltogether. motor_vehicle and motorcycle tags are missing from the osm2pgsql style file so thats not possible at this point in time without a lot of effort) , 

Note motorcar=no might be a candidate for rendering the same as access=no, however this should only be done on roads that commonaly are open to cars. 

The pull request is untested.
