### PR TITLE
Add highway=pedestrian area label

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1447,6 +1447,29 @@
       "name": "roads-text-ref"
     },
     {
+      "geometry": "polygon",
+      "extent": [
+        -179.99999692067183,
+        -84.96651228427099,
+        179.99999692067183,
+        84.96651228427098
+      ],
+      "Datasource": {
+        "type": "postgis",
+        "table": "      (select way, highway, name\n       from planet_osm_polygon\n       where highway='pedestrian'\n         and name is not null\n      ) as roads_area_text_name",
+        "extent": "-20037508,-19929239,20037508,19929239",
+        "key_field": "",
+        "geometry_field": "way",
+        "dbname": "gis"
+      },
+      "id": "roads-area-text-name",
+      "class": "",
+      "srs-name": "900913",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "advanced": {},
+      "name": "roads-area-text-name"
+    },
+    {
       "geometry": "linestring",
       "extent": [
         -179.99999692067183,

--- a/roads.mss
+++ b/roads.mss
@@ -2795,6 +2795,24 @@
   }
 }
 
+#roads-area-text-name {
+  [highway = 'pedestrian'] {
+    [zoom >= 15] {
+      text-name: "[name]";
+      text-size: 8;
+      text-face-name: @book-fonts;
+      text-placement: interior;
+      text-wrap-width: 30;
+    }
+    [zoom >= 16] {
+      text-size: 9;
+    }
+    [zoom >= 17] {
+      text-size: 11;
+    }
+  }
+}
+
 #paths-text-name {
   [highway = 'track'] {
     [zoom >= 15] {


### PR DESCRIPTION
See #355. The styling is copied from highway=pedestrian line label, adjusted for polygons. Note that there are practically no highway=pedestrian nodes (77 instances). JOSM's stylesheet/validator rejects those.

(Also cleans up a confusing comment that I wrote previously.)
