### PR TITLE
Use layer tag of tunnels for rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -431,7 +431,10 @@
       "srs-name": "900913",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "advanced": {},
-      "name": "tunnels"
+      "name": "tunnels",
+      "properties": {
+        "group-by": "layernotnull"
+      }
     },
     {
       "geometry": "linestring",


### PR DESCRIPTION
The layer tag is not taken into account for the rendering of tunnels.
In other words, overlapping tunnels on different layers are now
properly ordered. This is done by using group-by.
