### PR TITLE
Fix unifont case

### DIFF
--- a/style.mss
+++ b/style.mss
@@ -2,11 +2,11 @@ Map {
   background-color: @water-color;
 }
 
-@book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
+@book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "Unifont Medium";
 @bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", 
-                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "Unifont Medium";
 @oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", 
-                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "unifont Medium";
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular", "Droid Sans Fallback Regular", "Unifont Medium";
 
 @water-color: #b5d0d0;
 @land-color: #f2efe9;


### PR DESCRIPTION
For some reason unifont is included as `unifont Medium` in `style.mss`. That breaks rendering, because at least in Fedora the font as installed as `Unifont Medium`. This PR fixes that.
