### PR TITLE
Shift minimal zoom levels for villages and hamlets.

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -78,7 +78,7 @@
       text-wrap-width: 20;
       text-min-distance: 10;
     }
-    [zoom >= 11] {
+    [zoom >= 10] {
       text-size: 11;
     }
     [zoom >= 14] {
@@ -105,7 +105,7 @@
 
 #placenames-small::village {
   [place = 'village'] {
-    [zoom >=12] {
+    [zoom >=10] {
       text-name: "[name]";
       text-size: 10;
       text-fill: @placenames;
@@ -126,7 +126,7 @@
   [place = 'neighbourhood'],
   [place = 'isolated_dwelling'],
   [place = 'farm'] {
-    [zoom >= 14] {
+    [zoom >= 12] {
       text-name: "[name]";
       text-size: 9;
       text-fill: @placenames;


### PR DESCRIPTION
At current setup, villages are shown at zoom levels >= 12 and hamlets at
zoom levels >= 14. In many countries the map seems 'uninhabited' with such
settings and this make it unusable for trip planning.

Shift minimal visible zoom level for village to 10 and to 12 for hamlets.

Closes bug #2057 in trac.

Tested for Belarus, Estonia, Switzerland.

Images (before and after patch) at 10 zoom in hight-density area (Switzerland):

![switzerland-osm](https://cloud.githubusercontent.com/assets/117467/2689685/f4654050-c317-11e3-8300-2cd6f0d665b0.png)
![switzerland-new](https://cloud.githubusercontent.com/assets/117467/2689684/f462fb1a-c317-11e3-8207-ce6d569c8935.png)
