### PR TITLE
Fixes elliptical tertiary turning circles at zoom 17+

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1695,7 +1695,7 @@
     marker-fill: @tertiary-fill;
     [zoom >= 17] {
       marker-width: (@tertiary-width-z17 - 2 * @casing-width-z17) * 1.8;
-      marker-width: (@tertiary-width-z17 - 2 * @casing-width-z17) * 1.8;
+      marker-height: (@tertiary-width-z17 - 2 * @casing-width-z17) * 1.8;
     }
   }
 


### PR DESCRIPTION
Due to a copy/paste typo, turning circles on tertiary highways are rendered as ellipses at zoom level 17+.
This fixes the height to match the width.
