### PR TITLE
Change list of light buildings

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -744,7 +744,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,aeroway,\n        case\n         when building in ('garage','roof','garages','service','shed','shelter','cabin','storage_tank','tank','support','glasshouse','mobile_home','kiosk','silo','canopy','tent') then 'INT-light'::text\n         else building\n        end as building\n       from planet_osm_polygon\n       where (building is not null\n         and building not in ('no','station','supermarket','planned')\n         and (railway is null or railway != 'station')\n         and (amenity is null or amenity != 'place_of_worship'))\n          or aeroway = 'terminal'\n       order by z_order,way_area desc) as buildings",
+        "table": "      (select way,aeroway,\n        case\n         when building in ('garage','roof','garages','service','shed','shelter','cabin','storage_tank','tank','support','glasshouse','greenhouse','mobile_home','kiosk','silo','canopy','tent') then 'INT-light'::text\n         else building\n        end as building\n       from planet_osm_polygon\n       where (building is not null\n         and building not in ('no','station','supermarket','planned')\n         and (railway is null or railway != 'station')\n         and (amenity is null or amenity != 'place_of_worship'))\n          or aeroway = 'terminal'\n       order by z_order,way_area desc) as buildings",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",
         "geometry_field": "way",


### PR DESCRIPTION
- The building types residential, house, detached, terrace and
  apartments are no longer light.
- The building types roof, service, shed, shelter, cabin,
  storage_tank, tank, support, glasshouse, mobile_home, kiosk
  silo, canopy and tent are now light.

This commit is based on a comment by @vincentdephily:
https://github.com/gravitystorm/openstreetmap-carto/pull/434#issuecomment-38928265

This closes #68 and supersedes #434.
