### PR TITLE
Resolve wrong layering of low-zoom layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -836,29 +836,6 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,coalesce(('highway_' || (case when highway is not null then highway else null end)), ('railway_' || (case when (railway='rail' and service in ('spur','siding','yard'))  then 'INT-spur-siding-yard' when railway in ('rail','tram','light_rail','funicular','narrow_gauge') then railway else null end))) as feature,tunnel\n       from planet_osm_roads\n       where highway is not null\n          or (railway is not null and railway!='preserved' and (service is null or service not in ('spur','siding','yard')))\n       order by z_order\n      ) as roads_low_zoom",
-        "extent": "-20037508,-19929239,20037508,19929239",
-        "key_field": "",
-        "geometry_field": "way",
-        "dbname": "gis"
-      },
-      "id": "roads-low-zoom",
-      "class": "",
-      "srs-name": "900913",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "advanced": {},
-      "name": "roads-low-zoom"
-    },
-    {
-      "geometry": "linestring",
-      "extent": [
-        -179.99999692067183,
-        -84.96651228427099,
-        179.99999692067183,
-        84.96651228427098
-      ],
-      "Datasource": {
-        "type": "postgis",
         "table": "(select way,name from planet_osm_line where waterway='canal' and bridge in ('yes','true','1','aqueduct') order by z_order) as waterway_bridges",
         "extent": "-20037508,-19929239,20037508,19929239",
         "key_field": "",

--- a/roads.mss
+++ b/roads.mss
@@ -671,6 +671,16 @@
     [feature = 'railway_rail'][zoom >= 13],
     [feature = 'railway_preserved'][zoom >= 14],
     [feature = 'railway_monorail'][zoom >= 14] {
+      [zoom >= 6][zoom < 13] {
+        line-width: 0.6;
+        line-color: #aaa;
+        [zoom >= 9] { line-width: 1; }
+        [zoom >= 10] { line-width: 2; }
+        .tunnels-casing {
+          line-dasharray: 5,2;
+        }
+      }
+
       .bridges-casing {
         line-width: 5;
         line-color: white;
@@ -729,6 +739,14 @@
 .roads-fill,.bridges-fill,.tunnels-fill {
   ::fill_links {
     [feature = 'highway_motorway_link'] {
+      [zoom >= 5][zoom < 12] {
+        line-width: 0.5;
+        line-color: @motorway-fill;
+        [zoom >= 7] { line-width: 1; }
+        [zoom >= 9] { line-width: 1.4; }
+        [zoom >= 10] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @motorway-link-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @motorway-link-width-z13 - 2 * @casing-width-z13; }
@@ -752,6 +770,16 @@
     }
 
     [feature = 'highway_trunk_link'] {
+      [zoom >= 5][zoom < 12] {
+        line-width: 0.4;
+        line-color: @trunk-fill;
+        [zoom >= 7] {
+          line-width: 1;
+          line-color: @trunk-fill-alternative;
+        }
+        [zoom >= 9] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @trunk-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @trunk-width-z13 - 2 * @casing-width-z13; }
@@ -775,6 +803,13 @@
     }
 
     [feature = 'highway_primary_link'] {
+      [zoom >= 7][zoom < 12] {
+        line-width: 0.5;
+        line-color: @primary-fill;
+        [zoom >= 9] { line-width: 1.2; }
+        [zoom >= 10] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @primary-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @primary-width-z13 - 2 * @casing-width-z13; }
@@ -798,6 +833,11 @@
     }
 
     [feature = 'highway_secondary_link'] {
+      [zoom >= 9][zoom < 12] {
+        line-width: 1;
+        line-color: @secondary-fill;
+        [zoom >= 11] { line-width: 2; }
+      }
       [zoom >= 12] {
         line-width: @secondary-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @secondary-width-z13 - 2 * @casing-width-z13; }
@@ -932,6 +972,14 @@
     }
 
     [feature = 'highway_motorway'] {
+      [zoom >= 5][zoom < 12] {
+        line-width: 0.5;
+        line-color: @motorway-fill;
+        [zoom >= 7] { line-width: 1; }
+        [zoom >= 9] { line-width: 1.4; }
+        [zoom >= 10] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @motorway-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @motorway-width-z13 - 2 * @casing-width-z13; }
@@ -955,6 +1003,16 @@
     }
 
     [feature = 'highway_trunk'] {
+      [zoom >= 5][zoom < 12] {
+        line-width: 0.4;
+        line-color: @trunk-fill;
+        [zoom >= 7] {
+          line-width: 1;
+          line-color: @trunk-fill-alternative;
+        }
+        [zoom >= 9] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @trunk-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @trunk-width-z13 - 2 * @casing-width-z13; }
@@ -978,6 +1036,13 @@
     }
 
     [feature = 'highway_primary'] {
+      [zoom >= 7][zoom < 12] {
+        line-width: 0.5;
+        line-color: @primary-fill;
+        [zoom >= 9] { line-width: 1.2; }
+        [zoom >= 10] { line-width: 2; }
+        [zoom >= 11] { line-width: 2.5; }
+      }
       [zoom >= 12] {
         line-width: @primary-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @primary-width-z13 - 2 * @casing-width-z13; }
@@ -1001,6 +1066,11 @@
     }
 
     [feature = 'highway_secondary'] {
+      [zoom >= 9][zoom < 12] {
+        line-width: 1;
+        line-color: @secondary-fill;
+        [zoom >= 11] { line-width: 2; }
+      }
       [zoom >= 12] {
         line-width: @secondary-width-z12 - 2 * @casing-width-z12;
         [zoom >= 13] { line-width: @secondary-width-z13 - 2 * @casing-width-z13; }
@@ -1379,6 +1449,25 @@
 
     [feature = 'railway_rail'],
     [feature = 'railway_INT-spur-siding-yard'] {
+      [feature = 'railway_rail'] {
+        [zoom >= 6][zoom < 13] {
+          line-width: 0.6;
+          line-color: #aaa;
+          [zoom >= 9] { line-width: 1; }
+          [zoom >= 10] { line-width: 2; }
+          .tunnels-casing {
+            line-dasharray: 5,2;
+          }
+        }
+      }
+      [feature = 'railway_INT-spur-siding-yard'] {
+        [zoom >= 11] {
+          line-width: 1;
+          line-color: #aaa;
+          line-join: round;
+        }
+      }
+
       [zoom >= 13] {
         .roads-fill, .bridges-fill {
           dark/line-color: #999999;
@@ -1433,6 +1522,17 @@
             g/line-width: 2;
           }
         }
+      }
+    }
+
+    [feature = 'railway_tram'],
+    [feature = 'railway_light_rail'],
+    [feature = 'railway_funicular'],
+    [feature = 'railway_narrow_gauge'] {
+      [zoom >= 8][zoom < 13] {
+        line-width: 1;
+        line-color: #ccc;
+        [zoom >= 10] { line-color: #aaa }
       }
     }
 
@@ -1949,85 +2049,6 @@
       access/line-join: round;
       access/line-cap: round;
       [zoom >= 16] { access/line-width: 6; }
-    }
-  }
-}
-
-#roads-low-zoom {
-  [feature = 'highway_motorway'],
-  [feature = 'highway_motorway_link'] {
-    [zoom >= 5][zoom < 12] {
-      line-width: 0.5;
-      line-color: @motorway-fill;
-      [zoom >= 7] { line-width: 1; }
-      [zoom >= 9] { line-width: 1.4; }
-      [zoom >= 10] { line-width: 2; }
-      [zoom >= 11] { line-width: 2.5; }
-    }
-  }
-
-  [feature = 'highway_trunk'],
-  [feature = 'highway_trunk_link'] {
-    [zoom >= 5][zoom < 12] {
-      line-width: 0.4;
-      line-color: @trunk-fill;
-      [zoom >= 7] {
-        line-width: 1;
-        line-color: @trunk-fill-alternative;
-      }
-      [zoom >= 9] { line-width: 2; }
-      [zoom >= 11] { line-width: 2.5; }
-    }
-  }
-
-  [feature = 'highway_primary'],
-  [feature = 'highway_primary_link'] {
-    [zoom >= 7][zoom < 12] {
-      line-width: 0.5;
-      line-color: @primary-fill;
-      [zoom >= 9] { line-width: 1.2; }
-      [zoom >= 10] { line-width: 2; }
-      [zoom >= 11] { line-width: 2.5; }
-    }
-  }
-
-  [feature = 'highway_secondary'],
-  [feature = 'highway_secondary_link'] {
-    [zoom >= 9][zoom < 12] {
-      line-width: 1;
-      line-color: @secondary-fill;
-      [zoom >= 11] { line-width: 2; }
-    }
-  }
-
-  [feature = 'railway_rail'] {
-    [zoom >= 6][zoom < 13] {
-      line-width: 0.6;
-      line-color: #aaa;
-      [zoom >= 9] { line-width: 1; }
-      [zoom >= 10] { line-width: 2; }
-      .tunnels-casing {
-        line-dasharray: 5,2;
-      }
-    }
-  }
-
-  [feature = 'railway_INT-spur-siding-yard'] {
-    [zoom >= 11] {
-      line-width: 1;
-      line-color: #aaa;
-      line-join: round;
-    }
-  }
-
-  [feature = 'railway_tram'],
-  [feature = 'railway_light_rail'],
-  [feature = 'railway_funicular'],
-  [feature = 'railway_narrow_gauge'] {
-    [zoom >= 8][zoom < 13] {
-      line-width: 1;
-      line-color: #ccc;
-      [zoom >= 10] { line-color: #aaa }
     }
   }
 }


### PR DESCRIPTION
The rendering rules of the low-zoom layer are inserted into the regular
layers. This makes sure that low-zoom roads are rendered like other
roads, and prevents therefore incorrect layering of roads on low zoom
levels.

It should also improve the readability of the code.

This solves #400.
