### PR TITLE
Do not wrap junction ref

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1839,7 +1839,6 @@
     ref/text-min-distance: 2;
     ref/text-face-name: @oblique-fonts;
     ref/text-halo-radius: 1.5;
-    ref/text-wrap-width: 12;
     [zoom >= 12] {
       name/text-name: "[name]";
       name/text-size: 9;


### PR DESCRIPTION
This prevents junction refs such as '26 A' from being wrapped.
Wrapping of junction refs used to prevent rendering of junction
names.

This resolves 4646 on trac.
