### PR TITLE
Increase spacing for supermarket text

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1105,7 +1105,7 @@
     [zoom >= 16] {
       text-name: "[name]";
       text-size: 9;
-      text-dy: 9;
+      text-dy: 11;
       text-fill: #939;
       text-face-name: @book-fonts;
       text-halo-radius: 1;


### PR DESCRIPTION
The text for supermarkets needs two pixels of additional dy spacing. See this [supermarket](http://www.openstreetmap.org/node/34045539) named "EMTÉ". Because of the accent on the capital letter, the name requires additional spacing to be rendered. Tested in TileMill.
