### PR TITLE
Remove line-join and line-cap on service roads in tunnels/bridges

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -388,8 +388,10 @@
         [service = 'INT-minor'] {
           line-width: 4;
         }
-        line-join: round;
-        line-cap: round;
+        .roads-casing {
+          line-join: round;
+          line-cap: round;
+        }
         .tunnels-casing { line-dasharray: 4,2; }
         .bridges-casing {
           line-color: @bridge-casing;


### PR DESCRIPTION
This makes sure that the casing of service road is rendered correctly
in tunnels.

This resolves #438 on Github and #3755 on trac.
