### PR TITLE
clean up and improve some amenities

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -209,7 +209,7 @@
     }
   }
 
-  [amenity = 'police'][zoom >= 15]::amenity {
+  [amenity = 'police'][zoom >= 16]::amenity {
     point-file: url('symbols/police.p.16.png');
     point-placement: interior;
   }
@@ -450,7 +450,7 @@
     }
   }
 
-  [amenity = 'police'][zoom >= 16]::amenity {
+  [amenity = 'police'][zoom >= 17]::amenity {
     text-name: "[name]";
     text-size: 10;
     text-fill: #734a08;


### PR DESCRIPTION
Some general changes to the way some amenities are rendered:
- hospitals are rendered from level 15 onwards. police stations should behave similarly as they also provide emergency services. You won't drive to a fire station for an emergency so it doesn't make as much sense, but if you want to file a complaint you will search for a police station (And in a real emergency you will call the emergency number to call an ambulance just like to call the police)
- pubs and biergartens are rendered at zoom level 16, while all comparable amenities (restaurants, bars, cafes) are rendered starting from zoom level 17
- amenity=recycling is rendered on level 16. For people who use a map (that don't know the place like visitors, tourists, etc) recycling bins are probably not as important as post boxes, telephones and those aren't shown on level 16 either
- zooming from level 16 to 17 makes a mess out of the map in "party areas" with many pubs, bars, nightclubs, shops, etc. because most of these amenities and shops get rendered at this point together with their names. At this zoom level there is nearly no space in such high density areas for the names so only a few (maybe 10%) get rendered. It's a big game "Which name gets lucky?". The map would be much more readable when the names get rendered from level 18 onwards

Please test it and give feedback regarding the different changes. I tried to be very conservative so it should be only a first tiny step to a cleaner and more readable map
