### PR TITLE
Fix line-cap and line-join on bridge background

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -605,7 +605,6 @@
           line-width: 4;
           line-color: @bridleway-casing;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -617,7 +616,6 @@
           line-width: 4.5;
           line-color: @footway-casing;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -629,7 +627,6 @@
           line-width: 4;
           line-color: @cycleway-casing;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -651,7 +648,6 @@
           line-width: 2.5;
           line-color: @path-casing;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -662,7 +658,6 @@
           line-width: 3;
           line-color: @track-casing;
           line-join: round;
-          line-cap: round;
           [tracktype = 'grade1'] { line-width: 3.5; }
         }
       }
@@ -684,7 +679,6 @@
           line-width: 4;
           line-color: white;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -700,7 +694,6 @@
           line-width: 4.5;
           line-color: white;
           line-join: round;
-          line-cap: round;
         }
       }
     }
@@ -710,6 +703,7 @@
         [zoom >= 14] {
           line-width: 4;
           line-color: white;
+          line-join: round;
         }
       }
     }
@@ -720,6 +714,7 @@
         [zoom >= 14] {
           line-width: 4;
           line-color: white;
+          line-join: round;
         }
       }
     }


### PR DESCRIPTION
The white background of bridges should not have a round line-cap,
but should have a round line-join.

With round line-cap, artefacts appear at the end of the bridges
on non-white backgrounds.
