### PR TITLE
Make railway station buildings transparent

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -2,6 +2,7 @@
   [zoom >= 10] {
     [railway = 'station']::railway,
     [building = 'station'] {
+      polygon-opacity: 0.9;
       polygon-fill: #d4aaaa;
       polygon-clip: false;
     }


### PR DESCRIPTION
This makes railway station buildings transparent, just like
other buildings are currently transparent.

This prevents railway stations from obscuring platforms.

This resolves #142.
