### PR TITLE
Added missing comma, which caused Tilemill-error

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -235,7 +235,7 @@
     }
   }
 
-  [feature = 'power_sub_station']
+  [feature = 'power_sub_station'],
   [feature = 'power_substation'] {
     [zoom >= 13] {
       polygon-fill: @power;


### PR DESCRIPTION
Resolves the following Tilemill-error:

landcover.mss:239:32 [[feature]=power_substation] added to
[feature]=power_sub_station produces an invalid filter
