### PR TITLE
Tweak rendering of light buildings.

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -27,10 +27,14 @@
 }
 
 #buildings {
-  [building = 'INT-light'][zoom >= 12] {
+  [building = 'INT-light'][zoom >= 15] {
     polygon-fill: #bca9a9;
-    polygon-opacity: 0.7;
+    polygon-opacity: 0.5;
     polygon-clip: false;
+    [zoom >= 17] {
+      line-color: #330066;
+      line-width: 0.2;
+    }
   }
   [building != 'INT-light'][building != ''][zoom >= 12] {
     polygon-fill: #bca9a9;


### PR DESCRIPTION
- Add a border
- Make them more transparent
- Require a higher zoom to render them

The main change is adding the border, to prevent joined buildings looking like one big blob. Then I also made the rendering lighter and start at higer zoom, because those buildings are usually smaller, and by definition less important.

This should close the last item on issue #68, since the other items have been fixed by other PRs.
