### PR TITLE
Rationalize road sizes

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -60,41 +60,39 @@
 @residential-tunnel-fill: lighten(@residential-fill, 10%);
 @living-street-tunnel-fill: lighten(@living-street-fill, 10%);
 
-@motorway-width-z12:              3;
+@motorway-width-z12:              3.5;
 @motorway-link-width-z12:         1.5;
 @trunk-width-z12:                 3.5;
 @primary-width-z12:               3.5;
 @secondary-width-z12:             3;
 
-@motorway-width-z13:              6.5;
+@motorway-width-z13:              7;
 @motorway-link-width-z13:         4.5;
-@trunk-width-z13:                 8.5;
-@primary-width-z13:               8.5;
-@secondary-width-z13:             9.5;
-@tertiary-width-z13:              6;
+@trunk-width-z13:                 7;
+@primary-width-z13:               7;
+@secondary-width-z13:             7;
+@tertiary-width-z13:              5;
 @residential-width-z13:           3;
 
 @tertiary-width-z14:              7.5;
 @residential-width-z14:           4.5;
 
-@motorway-width-z15:             10.3;
+@motorway-width-z15:             12.8;
 @motorway-link-width-z15:         7.8;
 @trunk-width-z15:                12.8;
 @primary-width-z15:              12.8;
 @secondary-width-z15:            12.8;
 @tertiary-width-z15:             11.2;
-@tertiary-link-width-z15:        11;
 @residential-width-z15:           8.3;
 
 @residential-width-z16:          11.2;
 
-@motorway-width-z17:             13.5; // shouldn't be narrower than trunk!
+@motorway-width-z17:             18;
 @motorway-link-width-z17:        11.5;
 @trunk-width-z17:                18;
 @primary-width-z17:              18;
 @secondary-width-z17:            18;
 @tertiary-width-z17:             15.5;
-@tertiary-link-width-z17:        16;
 @residential-width-z17:          15.5;
 
 @casing-width-z12:                0.5;
@@ -102,10 +100,8 @@
 @residential-casing-width-z13:    0.5;
 @casing-width-z14:                0.75;
 @casing-width-z15:                0.9;
-@tertiary-link-casing-width-z15:  0.8;
 @casing-width-z16:                0.9;
 @casing-width-z17:                1.25;
-@tertiary-link-casing-width-z17:  1.5;
 
 @bridge-casing-width-z12:         0.5;
 @bridge-casing-width-z13:         0.5;
@@ -217,8 +213,8 @@
         line-color: @tertiary-casing;
         line-width: @tertiary-width-z13;
         [zoom >= 14] { line-width: @tertiary-width-z14; }
-        [zoom >= 15] { line-width: @tertiary-link-width-z15; }
-        [zoom >= 17] { line-width: @tertiary-link-width-z17; }
+        [zoom >= 15] { line-width: @tertiary-width-z15; }
+        [zoom >= 17] { line-width: @tertiary-width-z17; }
         .roads-casing {
           line-cap: round;
           line-join: round;
@@ -820,8 +816,8 @@
       [zoom >= 13] {
         line-width: @tertiary-width-z13 - 2 * @casing-width-z13;
         [zoom >= 14] { line-width: @tertiary-width-z14 - 2 * @casing-width-z14; }
-        [zoom >= 15] { line-width: @tertiary-link-width-z15 - 2 * @tertiary-link-casing-width-z15; }
-        [zoom >= 17] { line-width: @tertiary-link-width-z17 - 2 * @tertiary-link-casing-width-z17; }
+        [zoom >= 15] { line-width: @tertiary-width-z15 - 2 * @tertiary-width-z15; }
+        [zoom >= 17] { line-width: @tertiary-width-z17 - 2 * @tertiary-width-z17; }
         .roads-fill, .bridges-fill {
           line-color: @tertiary-fill;
         }
@@ -831,8 +827,8 @@
         .bridges-fill {
           line-width: @tertiary-width-z13 - 2 * @bridge-casing-width-z13;
           [zoom >= 14] { line-width: @tertiary-width-z14 - 2 * @bridge-casing-width-z14; }
-          [zoom >= 15] { line-width: @tertiary-link-width-z15 - 2 * @bridge-casing-width-z15; }
-          [zoom >= 17] { line-width: @tertiary-link-width-z17 - 2 * @bridge-casing-width-z17; }
+          [zoom >= 15] { line-width: @tertiary-width-z15 - 2 * @bridge-casing-width-z15; }
+          [zoom >= 17] { line-width: @tertiary-width-z17 - 2 * @bridge-casing-width-z17; }
         }
         line-cap: round;
         line-join: round;


### PR DESCRIPTION
These changes make sure that more important roads are not rendered
smaller than less important roads.
- Render motorways from z12 on wider.
- Render trunk, primary, secondary, and tertiary on z13 and z14 narrower.
- Render casing on tertiary link wider.

This solves #256.
