### PR TITLE
Make fill of residential/unclassified/service tunnels grey

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -57,7 +57,7 @@
 @primary-tunnel-fill: lighten(@primary-fill, 10%);
 @secondary-tunnel-fill: lighten(@secondary-fill, 5%);
 @tertiary-tunnel-fill: lighten(@tertiary-fill, 5%);
-@residential-tunnel-fill: lighten(@residential-fill, 10%);
+@residential-tunnel-fill: darken(@residential-fill, 5%);
 @living-street-tunnel-fill: lighten(@living-street-fill, 10%);
 
 @motorway-width-z12:              3;
@@ -1142,6 +1142,9 @@
         }
         line-join: round;
         line-cap: round;
+      }
+      .tunnels-fill {
+        line-color: darken(white, 5%);
       }
     }
 


### PR DESCRIPTION
Make the fill of tunnels for highway types residential, unclassified,
and service tunnels light gray. The old dashed rendering was not
sufficient to make the distinction clear.
