### PR TITLE
Do not render nature reserve names on z11

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -104,8 +104,7 @@
       }
     }
   }
-  [way_area > 200000000][zoom >= 8][zoom < 12],
-  [zoom >= 11][zoom < 12] {
+  [way_area > 200000000][zoom >= 8][zoom < 12] {
     text-name: "[name]";
     text-size: 8;
     text-fill: #9c9;


### PR DESCRIPTION
Currently names of small nature reserves clutter the map on z11.
This commit prevents that.
