### PR TITLE
gitignore npm dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 layers/
 data/
 *.xml
+node_modules/


### PR DESCRIPTION
If installing carto from this dir, you end up with a node_modules directory which should be ignored
