### PR TITLE
Only show track and pitch outline at zoom >= 15

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -386,14 +386,18 @@
 
   [feature = 'leisure_track'][zoom >= 10] {
     polygon-fill: @track;
-    line-width: 0.5;
-    line-color: saturate(darken(@track, 40%), 20%);
+    [zoom >= 15] {
+      line-width: 0.5;
+      line-color: saturate(darken(@track, 40%), 20%);
+    }
   }
 
   [feature = 'leisure_pitch'][zoom >= 10] {
     polygon-fill: @pitch;
-    line-width: 0.5;
-    line-color: saturate(darken(@pitch, 40%), 20%);
+    [zoom >= 15] {
+      line-width: 0.5;
+      line-color: saturate(darken(@pitch, 40%), 20%);
+    }
   }
 }
 


### PR DESCRIPTION
This solves #618. Pitches and tracks are too prominent at low zooms because their dark outline is shown at all zoom levels. This PR renders outlines of tracks and pitches at zoom levels 15 and higher. (Maybe 14 and higher would also work.)

Left: before, right: after.
Zoom 11
![11org](https://cloud.githubusercontent.com/assets/5209216/3273163/2ec18040-f321-11e3-955d-8a7bd92ec296.png),  ![11new](https://cloud.githubusercontent.com/assets/5209216/3273164/3278a4a2-f321-11e3-9549-e310e8a7f9c7.png)

Zoom 12
![12old](https://cloud.githubusercontent.com/assets/5209216/3273165/3a239db0-f321-11e3-89b4-2e22e984969c.png), ![12new](https://cloud.githubusercontent.com/assets/5209216/3273166/3d341ad4-f321-11e3-8442-383c7772ef55.png)

Zoom 13
![13old](https://cloud.githubusercontent.com/assets/5209216/3273170/42dce9fc-f321-11e3-83ac-99b326de5b17.png), ![13new](https://cloud.githubusercontent.com/assets/5209216/3273172/45c8c85c-f321-11e3-84bf-24ae482f6a14.png)

Zoom 14
![14old](https://cloud.githubusercontent.com/assets/5209216/3273174/4bea101a-f321-11e3-85d3-48ede6568344.png), ![14new](https://cloud.githubusercontent.com/assets/5209216/3273177/4e5cf72c-f321-11e3-9f67-245b66185f3d.png)

Zoom 15 (no change)
![15](https://cloud.githubusercontent.com/assets/5209216/3273182/5765ea86-f321-11e3-9b2f-1d852d3e3c0f.png), ![15](https://cloud.githubusercontent.com/assets/5209216/3273198/966e700e-f321-11e3-8bcb-bc42460d0a7a.png)
