### PR TITLE
Add back labels for railways

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2496,3 +2496,52 @@
     }
   }
 }
+
+#railways-text-name {
+  [railway = 'rail'],
+  [railway = 'subway'] {
+    [zoom >= 13] {
+      text-name: "[name]";
+      text-size: 8;
+      text-fill: black;
+      text-spacing: 300;
+      text-clip: false;
+      text-placement: line;
+      text-face-name: @book-fonts;
+      text-halo-radius: 0;
+    }
+    [zoom >= 14] {
+      text-size: 9;
+    }
+    [zoom >= 15] {
+      text-size: 10;
+    }
+    [zoom >= 17] {
+      text-size: 11;
+    }
+  }
+  [railway = 'light_rail'],
+  [railway = 'tram'],
+  [railway = 'funicular'],
+  [railway = 'monorail'],
+  [railway = 'narrow_gauge'],
+  [railway = 'abandoned'],
+  [railway = 'construction'],
+  [railway = 'disused'],
+  [railway = 'miniature'],
+  [railway = 'preserved'] {
+    [zoom >= 14] {
+      text-name: "[name]";
+      text-size: 9;
+      text-fill: #000;
+      text-spacing: 300;
+      text-clip: false;
+      text-placement: line;
+      text-face-name: @book-fonts;
+      text-halo-radius: 0;
+    }
+    [zoom >= 17] {
+      text-size: 11;
+    }
+  }
+}


### PR DESCRIPTION
Add back labels for <code>railway=rail</code>, <code>railway=subway</code>, etc., partially fixing #505. Note that this is my first ever pull request so may need a few modifications.
