### PR TITLE
render footways, steps and paths from z14

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1204,7 +1204,7 @@
     }
 
     [feature = 'highway_steps'] {
-      [zoom >= 13][zoom < 15] {
+      [zoom >= 14][zoom < 15] {
         .roads-fill, .tunnels-fill {
           line-width: 6;
           line-color: @steps-casing;
@@ -1261,7 +1261,7 @@
 
     [feature = 'highway_footway'],
     [feature = 'highway_path'][foot = 'designated'] {
-      [zoom >= 13] {
+      [zoom >= 14] {
         .tunnels-fill {
           tunnelcasing/line-width: 5.5;
           tunnelcasing/line-color: @tunnel-casing;
@@ -1283,7 +1283,6 @@
           line/line-width: 1.5;
         }
         .bridges-fill {
-          [zoom >= 13] { line/line-width: 1.5; }
           [zoom >= 14] { line/line-width: 2; }
         }
         .tunnels-fill {
@@ -1331,7 +1330,7 @@
     * given the specitivity precedence.
     */
     [feature = 'highway_path'] {
-      [zoom >= 13] {
+      [zoom >= 14] {
         .tunnels-fill {
           tunnelcasing/line-width: 5.5;
           tunnelcasing/line-color: @tunnel-casing;


### PR DESCRIPTION
Rendering from z13 resulted in ugly clutter in fully mapped areas. Rendering of cycleways and bridleways is unchanged, as density of these ways is lower and there is almost no danger of messy clutter.

Many fully mapped areas result at z13 result in terrible mess due to displaying footways, paths and steps. Examples include Cambridge ( http://www.openstreetmap.org/#map=13/52.2173/0.1468 ) Berlin ( http://www.openstreetmap.org/#map=13/52.5091/13.4464 ), Moscow ( http://www.openstreetmap.org/#map=13/55.7676/37.6213 ), Kraków ( http://www.openstreetmap.org/#map=13/50.0730/19.9556 ), Paris ( http://www.openstreetmap.org/#map=13/48.8544/2.3571 ).

I am aware that this will make map worse in remote areas and places that have with less important paths and footways unmapped, but overall effect IMHO will be clearly positive.

(fully mapped = further mapping of current state will not change what is rendered by default style)

Example of change, Cambridge currently at z13:

![przechwytywanie](https://cloud.githubusercontent.com/assets/899988/3416611/b1469678-fe2e-11e3-9c9d-9565ad23ce0d.PNG)

and after this change:

![przechwytywanie](https://cloud.githubusercontent.com/assets/899988/3416605/9a048fba-fe2e-11e3-841e-8e1121325519.PNG)
