### PR TITLE
Expand shapefile paths when unzipping

### DIFF
--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e -u
 
 UNZIP_OPTS=-qqun
@@ -22,25 +22,48 @@ tar -xzf data/world_boundaries-spherical.tgz -C data/
 echo "downloading simplified-land-polygons-complete-3857..."
 curl -z "data/simplified-land-polygons-complete-3857.zip" -L -o "data/simplified-land-polygons-complete-3857.zip" "http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip"
 echo "simplified-land-polygons-complete-3857..."
-unzip $UNZIP_OPTS data/simplified-land-polygons-complete-3857.zip simplified-land-polygons-complete-3857/simplified_land_polygons.{shp,shx,prj,dbf,cpg} -d data/
+unzip $UNZIP_OPTS data/simplified-land-polygons-complete-3857.zip \
+  simplified-land-polygons-complete-3857/simplified_land_polygons.shp \
+  simplified-land-polygons-complete-3857/simplified_land_polygons.shx \
+  simplified-land-polygons-complete-3857/simplified_land_polygons.prj \
+  simplified-land-polygons-complete-3857/simplified_land_polygons.dbf \
+  simplified-land-polygons-complete-3857/simplified_land_polygons.cpg \
+  -d data/
 
 # ne_110m_admin_0_boundary_lines_land
 echo "dowloading ne_110m_admin_0_boundary_lines_land..."
 curl -z data/ne_110m_admin_0_boundary_lines_land.zip -L -o data/ne_110m_admin_0_boundary_lines_land.zip http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip
 echo "expanding ne_110m_admin_0_boundary_lines_land..."
-unzip $UNZIP_OPTS data/ne_110m_admin_0_boundary_lines_land.zip ne_110m_admin_0_boundary_lines_land.{shp,shx,prj,dbf} -d data/ne_110m_admin_0_boundary_lines_land/
+unzip $UNZIP_OPTS data/ne_110m_admin_0_boundary_lines_land.zip \
+  ne_110m_admin_0_boundary_lines_land.shp \
+  ne_110m_admin_0_boundary_lines_land.shx \
+  ne_110m_admin_0_boundary_lines_land.prj \
+  ne_110m_admin_0_boundary_lines_land.dbf \
+  -d data/ne_110m_admin_0_boundary_lines_land/
 
 # ne_10m_populated_places
 echo "dowloading ne_10m_populated_places..."
 curl -z data/ne_10m_populated_places.zip -L -o data/ne_10m_populated_places.zip http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_populated_places.zip
 echo "expanding ne_10m_populated_places..."
-unzip $UNZIP_OPTS data/ne_10m_populated_places.zip ne_10m_populated_places.{shp,shx,prj,dbf,cpg} -d data/ne_10m_populated_places/
+unzip $UNZIP_OPTS data/ne_10m_populated_places.zip \
+  ne_10m_populated_places.shp \
+  ne_10m_populated_places.shx \
+  ne_10m_populated_places.prj \
+  ne_10m_populated_places.dbf \
+  ne_10m_populated_places.cpg \
+  -d data/ne_10m_populated_places/
 
 # land-polygons-split-3857
 echo "dowloading land-polygons-split-3857..."
 curl -z "data/land-polygons-split-3857.zip" -L -o "data/land-polygons-split-3857.zip" "http://data.openstreetmapdata.com/land-polygons-split-3857.zip"
 echo "expanding land-polygons-split-3857..."
-unzip $UNZIP_OPTS data/land-polygons-split-3857.zip land-polygons-split-3857/land_polygons.{shp,shx,prj,dbf,cpg} -d data/
+unzip $UNZIP_OPTS data/land-polygons-split-3857.zip \
+  land-polygons-split-3857/land_polygons.shp \
+  land-polygons-split-3857/land_polygons.shx \
+  land-polygons-split-3857/land_polygons.prj \
+  land-polygons-split-3857/land_polygons.dbf \
+  land-polygons-split-3857/land_polygons.cpg \
+  -d data/
 
 
 #process populated places


### PR DESCRIPTION
Explicitly listing the shapefile paths avoids the need for bash.

This fixes #653 in a different way than #666, but they don't conflict.

Tested on 12.04
