### PR TITLE
Improve road and lake visibility in forested areas

### DIFF
--- a/style.mss
+++ b/style.mss
@@ -15,5 +15,5 @@ Map {
                 "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
-@water-color: #b5d0d0;
+@water-color: #809fac;
 @land-color: #f2efe9;


### PR DESCRIPTION
Slightly darker, but still muted color for all water. In saturation and luminosity, it is currently too hard to distinguish water and forests, especially small lakes in the middle of vast stretches of wood. Now, the text color will also have to change, of course.
