### PR TITLE
remove unused highway=gate from style

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -89,7 +89,6 @@
     point-placement: interior;
   }
 
-  [highway = 'gate']::highway,
   [barrier = 'gate']::barrier {
     [zoom >= 15] {
       point-file: url('symbols/gate2.png');


### PR DESCRIPTION
highway=gate according to taginfo is used exactly once - see http://taginfo.openstreetmap.org/tags/highway=gate#overview

On wiki highway=gate redirects to barrier=gate

https://github.com/mkoniecz/hg - before/after (as expected nothing changes and style still works)

not listed on #204
