### PR TITLE
remove deprecated and unused man_made=power_wind

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -66,8 +66,7 @@
   }
 
   [power = 'generator']['generator:source' = 'wind']::power,
-  [power = 'generator'][power_source = 'wind']::power,
-  [man_made = 'power_wind'] {
+  [power = 'generator'][power_source = 'wind']::power {
     [zoom >= 15] {
       point-file: url('symbols/power_wind.png');
       point-placement: interior;


### PR DESCRIPTION
Used 0 times worldwide - http://taginfo.openstreetmap.org/tags/man_made=power_wind#overview
Deprecated according to wiki - http://wiki.openstreetmap.org/wiki/Tag:man_made%3Dpower_wind

I confirmed that this change is not introducing syntax errors, and test data generated the same images as https://github.com/mkoniecz/hg
