### PR TITLE
Clean up waterways

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -167,7 +167,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,waterway\n      from planet_osm_line\n      where waterway in ('stream','drain','ditch')\n        and (tunnel is null or tunnel != 'yes')\n      ) as water_lines_casing",
+        "table": "      (select way,waterway,case when tunnel in ('yes','culvert') then 'yes' else 'no' end as int_tunnel \n      from planet_osm_line\n      where waterway in ('stream','drain','ditch')\n        and (tunnel is null or tunnel != 'yes')\n      ) as water_lines_casing",
         "extent": "-20037508,-20037508,20037508,20037508",
         "key_field": "",
         "geometry_field": "way",
@@ -259,7 +259,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,waterway,lock,name,tunnel\n      from planet_osm_line\n      where waterway in ('weir','river','canal','derelict_canal','stream','drain','ditch','wadi')\n        and (bridge is null or bridge not in ('yes','true','1','aqueduct'))\n      order by z_order\n      ) as water_lines",
+        "table": "      (select way,waterway,lock,name,case when tunnel in ('yes','culvert') then 'yes' else 'no' end as int_tunnel\n      from planet_osm_line\n      where waterway in ('weir','river','canal','derelict_canal','stream','drain','ditch','wadi')\n        and (bridge is null or bridge not in ('yes','true','1','aqueduct'))\n      order by z_order\n      ) as water_lines",
         "extent": "-20037508,-20037508,20037508,20037508",
         "key_field": "",
         "geometry_field": "way",
@@ -1666,7 +1666,7 @@
       ],
       "Datasource": {
         "type": "postgis",
-        "table": "      (select way,waterway,lock,name,tunnel\n      from planet_osm_line\n      where waterway in ('weir','river','canal','derelict_canal','stream','drain','ditch','wadi')\n       order by z_order\n      ) as water_lines_text",
+        "table": "      (select way,waterway,lock,name,case when tunnel in ('yes','culvert') then 'yes' else 'no' end as int_tunnel\n      from planet_osm_line\n      where waterway in ('weir','river','canal','derelict_canal','stream','drain','ditch','wadi')\n       order by z_order\n      ) as water_lines_text",
         "extent": "-20037508,-20037508,20037508,20037508",
         "key_field": "",
         "geometry_field": "way",

--- a/water.mss
+++ b/water.mss
@@ -69,11 +69,13 @@
   [waterway='stream'],
   [waterway='ditch'],
   [waterway='drain'] {
-    [zoom >= 13] {
-      line-width: 1.5;
-      line-color: white;
-      [waterway='stream'][zoom >= 15] {
-        line-width: 2.5;
+    [int_tunnel = 'no'] {
+      [zoom >= 13] {
+        line-width: 1.5;
+        line-color: white;
+        [waterway='stream'][zoom >= 15] {
+          line-width: 2.5;
+        }
       }
     }
   }
@@ -105,95 +107,47 @@
     [zoom >= 16] { line-width: 2; }
   }
 
+  [waterway = 'canal'][zoom >= 12],
   [waterway = 'river'][zoom >= 12] {
     line-color: @water-color;
     line-width: 2;
+    [zoom >= 13] { line-width: 3; }
+    [zoom >= 14] { line-width: 5; }
+    [zoom >= 15] { line-width: 6; }
+    [zoom >= 17] { line-width: 10; }
+    [zoom >= 18] { line-width: 12; }
     line-cap: round;
     line-join: round;
-    [zoom >= 13] {
-      line-width: 3;
-    }
-    [zoom >= 14] {
-      line-width: 5;
-    }
-    [zoom >= 15] {
-      line-width: 6;
-    }
-    [zoom >= 17] {
-      line-width: 10;
-    }
-    [zoom >= 18] {
-      line-width: 12;
-    }
-    [tunnel = 'yes'] {
-      [zoom >= 14] {
-        a/line-width: 6;
-        a/line-dasharray: 4,2;
-        a/line-color: @water-color;
-        b/line-width: 4;
-        b/line-color: white;
-      }
-      [zoom >= 15] {
-        a/line-width: 7;
-      }
-      [zoom >= 17] {
-        a/line-width: 11;
-        b/line-width: 7;
-      }
-      [zoom >= 18] {
-        a/line-width: 13;
-        b/line-width: 9;
-      }
+    [int_tunnel = 'yes'] {
+      line-dasharray: 4,2;
+      line-cap: butt;
+      line-join: miter;
+      a/line-color: #f3f7f7;
+      a/line-width: 1;
+      [zoom >= 14] { a/line-width: 2; }
+      [zoom >= 15] { a/line-width: 3; }
+      [zoom >= 17] { a/line-width: 7; }
+      [zoom >= 18] { a/line-width: 8; }
     }
   }
 
   [waterway = 'stream'],
   [waterway = 'ditch'],
   [waterway = 'drain'] {
-    [zoom >= 13][zoom < 15] {
+    [zoom >= 13] {
       line-width: 1;
       line-color: @water-color;
-    }
-  }
-
-  [waterway = 'stream'][zoom >= 15] {
-    line-width: 2;
-    line-color: @water-color;
-    [tunnel = 'yes'] {
-      line-dasharray: 4,2;
-      line-width: 2.4;
-      a/line-width: 1.2;
-      a/line-color: #f3f7f7;
-    }
-  }
-
-  [waterway = 'drain'],
-  [waterway = 'ditch'] {
-    [zoom >= 15] {
-      line-width: 1;
-      line-color: @water-color;
-      [tunnel = 'yes'] {
+      [waterway = 'stream'][zoom >= 15] {
         line-width: 2;
+      }
+      [int_tunnel = 'yes'][zoom >= 15] {
+        line-width: 2.5;
+        [waterway = 'stream'] { line-width: 3.5; }
         line-dasharray: 4,2;
         a/line-width: 1;
+        [waterway = 'stream'] { a/line-width: 2; }
         a/line-color: #f3f7f7;
       }
-    }
-  }
-
-  [waterway = 'canal'][zoom >= 12] {
-    line-color: @water-color;
-    line-width: 3;
-    [zoom >= 13] { line-width: 4; }
-    [zoom >= 14] { line-width: 7; }
-    [zoom >= 17] { line-width: 11; }
-    line-cap: round;
-    line-join: round;
-    [tunnel = 'yes'][zoom >= 14] {
-      line-dasharray: 4,2;
-      b/line-width: 3;
-      b/line-color: white;
-      [zoom >= 17] { line-width: 7; }
     }
   }
 
@@ -241,7 +195,7 @@
     text-size: 10;
     text-halo-radius: 1;
     [zoom >= 14] { text-size: 12; }
-    [tunnel = 'yes'] { text-min-distance: 200; }
+    [int_tunnel = 'yes'] { text-min-distance: 200; }
   }
 
   [waterway = 'canal'][zoom >= 13][zoom < 14] {


### PR DESCRIPTION
- Merge definitions of canal and river (canals are now as wide as rivers
  instead or wider on some and narrower on other zoomlevels).
- Merge definitions of stream, drain, and ditch.
- Render river/canal in tunnel like stream/drain/ditch in tunnel.
- Render river/canal in tunnel in tunnel-style on z12 and z13.
- Render tunnel=culvert like tunnel=yes.

This solves the following issues:
- Fixes 3590 (trac): Canals wider than rivers at z12, disappear at z11
- Fixes 4227 (trac): canals as tunnels render differently at low zooms
- Fixes 4507 (trac): Waterways in a tunnel may be confused for roads
- Fixes 4656 (trac): waterway=canal too wide compared with highways at z14
- Fixes #198: Add rendering of tunnel=culvert for waterway
- Fixes #222: Inconsistent water-lines-casing tunnel check
- Fixes #282: "waterway=stream" with "tunnel=yes" nearly invisible

With thanks to @yarl for the work on #198.

This supersedes #624.
