### PR TITLE
Split off docs for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# OpenStreetMap Carto contribution guidelines
+
+## CartoCSS Style Guidelines
+
+* Always specify zoom levels as either >= or < . Don't use = or =< or >
+* Open curly braces on the same line, and close on an empty line.
+* One space before and after = etc
+* Two space indents. No tabs.
+* space after : but not before
+* Dashes, not underscores, in layer names
+* Name SQL subqueries after the layer name (but use underscores)
+* Avoid restating defaults, e.g. don't add `point-allow-overlap = false`
+* Avoid repeating the layer name for layers with mutiple attachments, i.e., prefer
+
+```css
+#layer {
+  ::outline {
+    line-width: 6;
+    line-color: black;
+  }
+  ::inline {
+    line-width: 2;
+    line-color: white;
+  }
+}
+```
+instead of
+
+```css
+#layer::outline {
+    line-width: 6;
+    line-color: black;
+}
+#layer::inline {
+    line-width: 2;
+    line-color: white;
+}
+```
+* Order the selectors in a style-sheet in rough order of importance (i.e., highway=primary, then highway=secondary) and beyond that, add layers that are rendered later (i.e., higher) lower in the file.
+
+## Previews
+
+Some changes benefit from a review from a wider audience. In most cases some static images are sufficient, but sometimes a demo layer is necessary. pnorman has a private server which can host layers and has some data from parts of the world loaded. Before requesting this in a pull request, make sure that you don't anticipate any more changes to it.
+
+This does not replace reviewing your changes in Tilemill

--- a/README.md
+++ b/README.md
@@ -127,43 +127,5 @@ There are over [400 open requests][trac] on trac, some that have been open for y
 reviewing and dividing into obvious fixes, or additional new features that need some cartographic
 judgement. The work done already in v1.0 and v2.0 will make it much easier to process these.
 
-# CartoCSS Style Guidelines
-
-* Always specify zoom levels as either >= or < . Don't use = or =< or >
-* Open curly braces on the same line, and close on an empty line.
-* One space before and after = etc
-* Two space indents. No tabs.
-* space after : but not before
-* Dashes, not underscores, in layer names
-* Name SQL subqueries after the layer name (but use underscores)
-* Avoid restating defaults, e.g. don't add `point-allow-overlap = false`
-* Avoid repeating the layer name for layers with mutiple attachments, i.e., prefer
-
-```css
-#layer {
-  ::outline {
-    line-width: 6;
-    line-color: black;
-  }
-  ::inline {
-    line-width: 2;
-    line-color: white;
-  }
-}
-```
-instead of
-
-```css
-#layer::outline {
-    line-width: 6;
-    line-color: black;
-}
-#layer::inline {
-    line-width: 2;
-    line-color: white;
-}
-```
-* Order the selectors in a style-sheet in rough order of importance (i.e., highway=primary, then highway=secondary) and beyond that, add layers that are rendered later (i.e., higher) lower in the file.
-
 [trac]: https://trac.openstreetmap.org/query?component=mapnik&status=!closed&order=changetime&desc=1&max=500
 [cleverness]: https://github.com/openstreetmap/mapnik-stylesheets/blob/master/inc/settings.xml.inc.template#L16


### PR DESCRIPTION
This allows us to grow the information specific to contributing without growing the information needed to just run the stylesheet
