### PR TITLE
Change track name rendering

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2420,17 +2420,23 @@
   [highway = 'track'] {
     [zoom >= 15] {
       text-name: "[name]";
+      text-fill: #222;
       text-size: 8;
+      text-halo-radius: 1;
+      text-halo-fill: rgba(255,255,255,0.8); 
       text-spacing: 300;
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
+      text-dy: 5;
     }
     [zoom >= 16] {
       text-size: 9;
+      text-dy: 7;
     }
     [zoom >= 17] {
       text-size: 11;
+      text-dy: 9;
     }
   }
 


### PR DESCRIPTION
I propose to improve the readability of track names, by offsetting the labels from the track lines and adding a halo. Some time ago, an offset was added to the labels of other linear features (administrative boundaries, footways and cycleways), and this PR brings the rendering of track labels into line with those. The halo is added for consistency with other labels (without the halo, the labels are too dark compared to other labels).

Zoom 15 (old and new, [this location](http://www.openstreetmap.org/#map=17/52.44431/13.47151))
![15old](https://cloud.githubusercontent.com/assets/5209216/3637437/8ff9fb62-1009-11e4-88c4-d90d9d01cd04.png), ![15new](https://cloud.githubusercontent.com/assets/5209216/3637438/953e2efe-1009-11e4-8a59-3dc71acaf497.png)

Zoom 16
![16old](https://cloud.githubusercontent.com/assets/5209216/3637440/a78953d6-1009-11e4-8622-e1559ef3eafb.png), ![16new](https://cloud.githubusercontent.com/assets/5209216/3637442/ad0d1aa4-1009-11e4-926c-dd84012827b0.png)

Zoom 17
![17old](https://cloud.githubusercontent.com/assets/5209216/3637443/b66e6030-1009-11e4-8870-9330552c7eee.png), ![17new](https://cloud.githubusercontent.com/assets/5209216/3637444/ba77fb96-1009-11e4-9bcb-8630b317e11b.png)
