### PR TITLE
Change track name rendering

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2420,17 +2420,23 @@
   [highway = 'track'] {
     [zoom >= 15] {
       text-name: "[name]";
+      text-fill: #222;
       text-size: 8;
+      text-halo-radius: 1;
+      text-halo-fill: rgba(255,255,255,0.8); 
       text-spacing: 300;
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
+      text-dy: 5;
     }
     [zoom >= 16] {
       text-size: 9;
+      text-dy: 7;
     }
     [zoom >= 17] {
       text-size: 11;
+      text-dy: 9;
     }
   }
 


### PR DESCRIPTION
I propose to improve the readability of track names, by offsetting the labels from the track lines and adding a halo. Some time ago, an offset was added to the labels of other linear features (administrative boundaries, footways and cycleways), and this PR brings the rendering of track labels into line with those. The halo is added for consistency with other labels (without the halo, the labels are too dark compared to other labels).

Zoom 15 (old and new, [this location](http://www.openstreetmap.org/#map=17/52.44431/13.47151))
![15old](https://cloud.githubusercontent.com/assets/5209216/3637539/0c73884c-1010-11e4-9fe9-cda7a8cdce08.png), ![15new](https://cloud.githubusercontent.com/assets/5209216/3637540/10685630-1010-11e4-9863-03ef701b641b.png)

Zoom 16
![16old](https://cloud.githubusercontent.com/assets/5209216/3637542/15f5ed88-1010-11e4-848d-755bf475ff5e.png), ![16new](https://cloud.githubusercontent.com/assets/5209216/3637543/198c36dc-1010-11e4-9f87-d80139673172.png)

Zoom 17
![17old](https://cloud.githubusercontent.com/assets/5209216/3637544/21547d2a-1010-11e4-8f89-a343ba19ca32.png), ![17new](https://cloud.githubusercontent.com/assets/5209216/3637545/24b09184-1010-11e4-9fc8-182e1d7bedff.png)
