### PR TITLE
Increase text-dy for default shop style

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1100,7 +1100,7 @@
   [shop != ''][zoom >= 17]::shop {
     text-name: [name];
     text-size: 9;
-    text-dy: 9;
+    text-dy: 10;
     text-fill: #939;
     text-face-name: @book-fonts;
     text-halo-radius: 1;


### PR DESCRIPTION
On the [talk list](https://lists.openstreetmap.org/pipermail/talk/2014-July/070270.html), Jóhannes Birgir Jensson pointed out these shops, for which the name is not rendered:

http://www.openstreetmap.org/node/2939951075
http://www.openstreetmap.org/node/2125818740

Increasing text-dy by one pixel allows the name to be rendered.
Before and after:
![old](https://cloud.githubusercontent.com/assets/5209216/3711726/dee7b098-14e6-11e4-9b71-4d4757cc13ed.png), ![new](https://cloud.githubusercontent.com/assets/5209216/3711728/e2a13a7e-14e6-11e4-9d93-dbc7b7fa9bd0.png)

See also #762.
