### PR TITLE
Drop polygon-opacity from landcover

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -4,7 +4,7 @@
 @grass: #cfeca8; // also meadow, common, garden, village_green, conservation
 @golf_course: #b5e3b5;
 @natural: #c6e4b4; // also grassland
-@park: #b6fdb6; // also recreation_ground
+@park: #cdf7c9; // also recreation_ground
 @wood: #aed1a0;
 @vineyard: #abdf96;
 
@@ -34,18 +34,18 @@
 
 // --- Other ----
 
-@aerodrome: #ccc;
+@aerodrome: #e9e7e2;
 @allotments: #e5c7ab;
 @apron: #e9d1ff;
 @attraction: #f2caea;
 @barracks: #ff8f8f;
-@campsite: #ccff99; // also caravan_site, picnic_site
+@campsite: #def6c0; // also caravan_site, picnic_site
 @cemetery: #aacbaf; // also grave_yard
-@construction: #9d9d6c;
+@construction: #b6b592;
 @danger_area: pink;
 @desert: #e3b57a;
 @field: @farmland;
-@garages: #996;
+@garages: #dfddce;
 @heath: #d6d99f;
 @parking: #f7efb7;
 @playground: #ccfff1;


### PR DESCRIPTION
Drop polygon-opacity from landcover tags that still had it, i.e.:
- tourism = camp_site
- tourism = caravan_site
- tourism = picnic_site
- landuse = garages
- landuse = field
- leisure = park
- leisure = recreation_ground
- landuse = brownfield
- landuse = landfill
- landuse = construction
- aeroway = aerodome

Polygon-opacity should be avoided, as it gives smudgy and sometimes unexpected
colours in case of overlapping polygons.

Also colour landuse=field as landuse=farm_land, as the old landuse=field
without opacity is too dark.

Resolves #461.
