### PR TITLE
Nicer rendering for highway=proposed

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -712,47 +712,47 @@
      * https://github.com/mapbox/carto/issues/235
      * https://github.com/mapbox/carto/issues/237
      */
-   [feature = 'highway_proposed']{
+    [feature = 'highway_proposed'] {
       [zoom >= 12] {
         line-width: 0;
         a/line-color: @residential-construction;
-	a/line-offset: @residential-width-z13 / 2;
+        a/line-offset: @residential-width-z13 / 2;
         a/line-width: 0.2;
-	a/line-dasharray: 6,4;
+        a/line-dasharray: 6,4;
         b/line-color: @residential-construction;
-	b/line-offset: 0 - @residential-width-z13 / 2;
+        b/line-offset: 0 - @residential-width-z13 / 2;
         b/line-width: 0.2;
-	b/line-dasharray: 6,4;
+        b/line-dasharray: 6,4;
         [zoom >= 13] {
-	  a/line-offset: @residential-width-z13 / 2 - @casing-width-z13;
+          a/line-offset: @residential-width-z13 / 2 - @casing-width-z13;
           a/line-width: @casing-width-z13;
-	  b/line-offset: 0 - @residential-width-z13 / 2 + @casing-width-z13;
+          b/line-offset: 0 - @residential-width-z13 / 2 + @casing-width-z13;
           b/line-width: @casing-width-z13;
         }
         [zoom >= 14] {
-	  a/line-offset: @residential-width-z14 / 2 - @casing-width-z14;
+          a/line-offset: @residential-width-z14 / 2 - @casing-width-z14;
           a/line-width: @casing-width-z14;
-	  b/line-offset: 0 - @residential-width-z14 / 2 + @casing-width-z14;
+          b/line-offset: 0 - @residential-width-z14 / 2 + @casing-width-z14;
           b/line-width: @casing-width-z14;
         }
         [zoom >= 15] {
-	  a/line-offset: @residential-width-z15 / 2 - @casing-width-z15;
+          a/line-offset: @residential-width-z15 / 2 - @casing-width-z15;
           a/line-width: @casing-width-z15;
-	  b/line-offset: 0 - @residential-width-z15 / 2 + @casing-width-z15;
+          b/line-offset: 0 - @residential-width-z15 / 2 + @casing-width-z15;
           b/line-width: @casing-width-z15;
         }
         [zoom >= 16] {
-	  a/line-offset: @residential-width-z16 / 2 - @casing-width-z16;
+          a/line-offset: @residential-width-z16 / 2 - @casing-width-z16;
           a/line-width: @casing-width-z16;
-	  a/line-dasharray: 8,6;
-	  b/line-offset: 0 - @residential-width-z16 / 2 + @casing-width-z16;
+          a/line-dasharray: 8,6;
+          b/line-offset: 0 - @residential-width-z16 / 2 + @casing-width-z16;
           b/line-width: @casing-width-z16;
-	  b/line-dasharray: 8,6;
+          b/line-dasharray: 8,6;
         }
         [zoom >= 17] {
-	  a/line-offset: @residential-width-z17 / 2 - @casing-width-z17;
+          a/line-offset: @residential-width-z17 / 2 - @casing-width-z17;
           a/line-width: @casing-width-z17;
-	  b/line-offset: 0 - @residential-width-z17 / 2 + @casing-width-z17;
+          b/line-offset: 0 - @residential-width-z17 / 2 + @casing-width-z17;
           b/line-width: @casing-width-z17;
         }
       }

--- a/roads.mss
+++ b/roads.mss
@@ -712,7 +712,52 @@
      * https://github.com/mapbox/carto/issues/235
      * https://github.com/mapbox/carto/issues/237
      */
-    [feature = 'highway_proposed'],
+   [feature = 'highway_proposed']{
+      [zoom >= 12] {
+        line-width: 0;
+        a/line-color: @residential-construction;
+	a/line-offset: @residential-width-z13 / 2;
+        a/line-width: 0.2;
+	a/line-dasharray: 6,4;
+        b/line-color: @residential-construction;
+	b/line-offset: 0 - @residential-width-z13 / 2;
+        b/line-width: 0.2;
+	b/line-dasharray: 6,4;
+        [zoom >= 13] {
+	  a/line-offset: @residential-width-z13 / 2 - @casing-width-z13;
+          a/line-width: @casing-width-z13;
+	  b/line-offset: 0 - @residential-width-z13 / 2 + @casing-width-z13;
+          b/line-width: @casing-width-z13;
+        }
+        [zoom >= 14] {
+	  a/line-offset: @residential-width-z14 / 2 - @casing-width-z14;
+          a/line-width: @casing-width-z14;
+	  b/line-offset: 0 - @residential-width-z14 / 2 + @casing-width-z14;
+          b/line-width: @casing-width-z14;
+        }
+        [zoom >= 15] {
+	  a/line-offset: @residential-width-z15 / 2 - @casing-width-z15;
+          a/line-width: @casing-width-z15;
+	  b/line-offset: 0 - @residential-width-z15 / 2 + @casing-width-z15;
+          b/line-width: @casing-width-z15;
+        }
+        [zoom >= 16] {
+	  a/line-offset: @residential-width-z16 / 2 - @casing-width-z16;
+          a/line-width: @casing-width-z16;
+	  a/line-dasharray: 8,6;
+	  b/line-offset: 0 - @residential-width-z16 / 2 + @casing-width-z16;
+          b/line-width: @casing-width-z16;
+	  b/line-dasharray: 8,6;
+        }
+        [zoom >= 17] {
+	  a/line-offset: @residential-width-z17 / 2 - @casing-width-z17;
+          a/line-width: @casing-width-z17;
+	  b/line-offset: 0 - @residential-width-z17 / 2 + @casing-width-z17;
+          b/line-width: @casing-width-z17;
+        }
+      }
+    }
+
     [feature = 'highway_construction'] {
       [zoom >= 12] {
         line-width: 2;


### PR DESCRIPTION
This is a proposal for a nicer rendering of `highway=proposed`. It's based on the ideas in #826 and should at least partly solve #826 and #345.

We do not currently have the `proposed=*` key in the database, so it is not possible to differ between proposed motorways or proposed footways. Therefore, I used the colour of the residential casing and the width of residential roads.

In the future the colours and widths could be ajusted to the different highway styles, when the `proposed=*` key is added to the database.

Some example renderings:

Zoom 12 before:
![bruchsal_z12_before](https://cloud.githubusercontent.com/assets/5783139/3855586/bfff8dda-1ee7-11e4-98de-54f102d62b64.png)
Zoom 12 after:
![bruchsal_z12_after](https://cloud.githubusercontent.com/assets/5783139/3855589/c15fa2dc-1ee7-11e4-8956-420015a23b3e.png)

Zoom 13 before:
![bruchsal_z13_before](https://cloud.githubusercontent.com/assets/5783139/3855596/c52e3ef0-1ee7-11e4-974d-4d553b2caa5a.png)
Zoom 13 after:
![bruchsal_z13_after](https://cloud.githubusercontent.com/assets/5783139/3855592/c4a04dca-1ee7-11e4-9375-c07e2c9c5adc.png)

Zoom 14 before:
![bruchsal_z14_before](https://cloud.githubusercontent.com/assets/5783139/3855595/c5116898-1ee7-11e4-933d-88a1f34c7ee9.png)
Zoom 14 after:
![bruchsal_z14_after](https://cloud.githubusercontent.com/assets/5783139/3855594/c4fb2e66-1ee7-11e4-854e-3fc26ee3a7cf.png)

Proposed dual carriageway before:
![b10_before](https://cloud.githubusercontent.com/assets/5783139/3855601/ceecb61a-1ee7-11e4-86b0-62c1c57d37ee.png)
Proposed dual carriageway after:
![b10_after](https://cloud.githubusercontent.com/assets/5783139/3855600/ce5b30b4-1ee7-11e4-9dbc-ea10b94ea2ab.png)

Proposed improvement from single to dual carriageway before:
![b500_before](https://cloud.githubusercontent.com/assets/5783139/3855602/cf38e634-1ee7-11e4-88ab-88247e6dce0a.png)
Proposed improvement from single to dual carriageway after:
![b500_after](https://cloud.githubusercontent.com/assets/5783139/3855603/cfb13cce-1ee7-11e4-9049-7550a115cd92.png)

Proposed highway with junction before:
![rheinbrcke_before](https://cloud.githubusercontent.com/assets/5783139/3855604/d3182f3a-1ee7-11e4-9de9-cbec7791de92.png)

Proposed highway with junction after:
![rheinbrucke_after](https://cloud.githubusercontent.com/assets/5783139/3855605/d33381e0-1ee7-11e4-8cff-f10d5326a88a.png)

Proposed residential road before:
![waghausel_before](https://cloud.githubusercontent.com/assets/5783139/3855606/d3440a4c-1ee7-11e4-84bb-d9a217bd3b4d.png)
Proposed residential road after:
![waghusel_after](https://cloud.githubusercontent.com/assets/5783139/3855607/d3baec48-1ee7-11e4-8a06-d756cd2b793f.png)

This approach still has the following issues:
* Proposed footways, cycleways and tracks might still look a bit strange and too prominent
* Complex junctions with overlapping highways can look strange
* Low contrast on construction background. Example:
![construction](https://cloud.githubusercontent.com/assets/5783139/3855728/ac4c6298-1ee9-11e4-9267-4efb3ee488fc.png)
















