### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,18 @@ node_js:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -q python-demjson
-script: jsonlint project.mml
+install:
+  - npm install carto
+  - mkdir -p data/world_boundaries
+  - mkdir -p data/simplified-land-polygons-complete-3857
+  - mkdir -p data/ne_110m_admin_0_boundary_lines_land
+  - mkdir -p data/ne_10m_populated_places
+  - mkdir -p data/land-polygons-split-3857
+  - touch data/world_boundaries/builtup_area.shp
+  - touch data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp
+  - touch data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp
+  - touch data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp
+  - touch data/land-polygons-split-3857/land_polygons.shp
+script:
+  - jsonlint project.mml
+  - ./node_modules/carto/bin/carto project.mml | xmllint --noout -


### PR DESCRIPTION
Travis needs to be enabled on this repo for this to work, but this will check that the .mml file is valid JSON and that carto compiles it without errors. See pnorman/openstreetmap-carto#2 for an example of how it looks.
