### PR TITLE
Use a specific version of carto for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -q python-demjson
 install:
-  - npm install carto
+  - npm install carto@0.12.1
   - mkdir -p data/world_boundaries
   - mkdir -p data/simplified-land-polygons-complete-3857
   - mkdir -p data/ne_110m_admin_0_boundary_lines_land


### PR DESCRIPTION
This works around mapbox/carto#368, but it's more to lock down versions
and keep CI as a test solely of the stylesheet, not of any components.

Travis build passes.
