### PR TITLE
display gates from z16 like other barriers. related to #323

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -89,7 +89,7 @@
   }
 
   [barrier = 'gate']::barrier {
-    [zoom >= 15] {
+    [zoom >= 16] {
       point-file: url('symbols/gate2.png');
       point-placement: interior;
     }


### PR DESCRIPTION
Displaying gates on z15 makes no sense except rare cases, clutters map, hides labels (as icon for gate has priority over any label - what after #942 will be even worse), on z15 gate on side road is frequently rendered over main road.

In addition other barriers, including lift_gate are rendered from z16.

Before/after in a well mapped city area ( http://www.openstreetmap.org/?mlat=50.0503&mlon=19.9250#map=15/50.0503/19.9196 )

![selection_011](https://cloud.githubusercontent.com/assets/899988/4407490/b3ddf538-44ca-11e4-8031-416fb4264b05.png)
