### PR TITLE
allow collisions with some symbols

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -88,18 +88,21 @@
   [highway = 'mini_roundabout'][zoom >= 16]::highway {
     point-file: url('symbols/mini_round.png');
     point-placement: interior;
+    point-ignore-placement: true;
   }
 
   [barrier = 'gate']::barrier {
     [zoom >= 16] {
       point-file: url('symbols/gate2.png');
       point-placement: interior;
+      point-ignore-placement: true;
     }
   }
 
   [barrier = 'lift_gate'][zoom >= 16]::barrier {
     point-file: url('symbols/liftgate.png');
     point-placement: interior;
+    point-ignore-placement: true;
   }
 
   [barrier = 'bollard'],
@@ -107,6 +110,7 @@
     [zoom >= 16] {
       point-file: url('symbols/bollard.png');
       point-placement: interior;
+      point-ignore-placement: true;
     }
   }
 }

--- a/power.mss
+++ b/power.mss
@@ -18,17 +18,21 @@
 #power-towers {
   [zoom >= 14] {
     point-file: url('symbols/power_tower_3x3.png');
+    point-ignore-placement: true;
   }
   [zoom >= 15] {
     point-file: url('symbols/power_tower_5x5.png');
+    point-ignore-placement: true;
   }
   [zoom >= 17] {
     point-file: url('symbols/power_tower.png');
+    point-ignore-placement: true;
   }
 }
 
 #power-poles {
   [zoom >= 16] {
     point-file: url('symbols/power_pole.png');
+    point-ignore-placement: true;
   }
 }


### PR DESCRIPTION
obvious situation with strong improvement

http://www.openstreetmap.org/?mlat=49.4712&mlon=21.3811#map=15/49.4712/21.3811

![selection_011](https://cloud.githubusercontent.com/assets/899988/4475628/80032d84-496e-11e4-8cf1-80ca405b882a.png)

really high gate density with some improvements and some regressions, overall effect is IMHO positive (and new problem may be almost certainly fixed by adding halo to street names)

http://www.openstreetmap.org/#map=16/50.0484/19.9300

![selection_001](https://cloud.githubusercontent.com/assets/899988/4476284/a4236aca-4974-11e4-8e66-8527bedb697f.png)

Fixes parts of #323 and #964 

Likely also other symbols may benefit from similar change, but not all of them - see https://github.com/gravitystorm/openstreetmap-carto/issues/982#issuecomment-57062765
