### PR TITLE
Render building labels from the same zoomlevel as landuse labels

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -33,9 +33,7 @@
 }
 
 #building-text {
-  [way_area >= 150000][zoom >= 14],
-  [way_area >= 80000][zoom >= 15],
-  [way_area >= 20000][zoom >= 16],
+  [zoom >= 14][way_pixels > 3000],
   [zoom >= 17] {
     text-name: "[name]";
     text-size: 11;

--- a/project.mml
+++ b/project.mml
@@ -1492,7 +1492,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT name, way, way_area\nFROM planet_osm_polygon\nWHERE building IS NOT NULL AND building NOT IN ('no', 'station', 'supermarket')) AS building_text", 
+        "table": "(SELECT name, way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels\nFROM planet_osm_polygon\nWHERE building IS NOT NULL AND building NOT IN ('no', 'station', 'supermarket')) AS building_text", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 

--- a/project.yaml
+++ b/project.yaml
@@ -1416,7 +1416,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |2-
-        (SELECT name, way, way_area
+        (SELECT name, way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels
         FROM planet_osm_polygon
         WHERE building IS NOT NULL AND building NOT IN ('no', 'station', 'supermarket')) AS building_text
     advanced: {}


### PR DESCRIPTION
Render building labels from 3000 pixels.

Old minimum pixel sizes for labels:
1643 pixels on z14 (buildings that big are very rare), 3505 pixels on z15 and z16.

This makes the code more consistent.
