### PR TITLE
render mud from z10

### DIFF
--- a/water.mss
+++ b/water.mss
@@ -53,7 +53,7 @@
     }
   }
 
-  [natural = 'mud'][zoom >= 13]::natural {
+  [natural = 'mud'][zoom >= 10]::natural {
     polygon-pattern-file: url('symbols/mud.png');
     polygon-pattern-alignment: global;
   }


### PR DESCRIPTION
continuation of #420, fixes #1018 

> http://www.openstreetmap.org/#map=13/53.6174/0.0715
> 
> Here there is both mud and sand areas adjacent to each other. At z10, 11 & 12 only the sand is rendered, creating an 'island' of sand. In reality this is a single, continuous tidal flat.

Also, with smaller areas of mud rendering is OK http://www.openstreetmap.org/#map=10/53.6918/9.3082 http://overpass-turbo.eu/s/5oY

![selection_005](https://cloud.githubusercontent.com/assets/899988/4594847/4dba426e-5093-11e4-9572-b53cc744283f.png)
