### PR TITLE
add explicit color definition for power line

### DIFF
--- a/power.mss
+++ b/power.mss
@@ -5,6 +5,7 @@
   }
   [zoom >= 16] {
     line-width: 1.5;
+    line-color: black;
   }
 }
 


### PR DESCRIPTION
I think it is better to be explicit.

I confirmed that it is causing no changes.

![cmp](https://cloud.githubusercontent.com/assets/899988/4598018/0b3c3a20-50b4-11e4-8ab7-c0e08b2b7bb3.png)
