### PR TITLE
Render amenity=food_court

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -428,6 +428,7 @@
 
   [feature = 'amenity_pub'],
   [feature = 'amenity_restaurant'],
+  [feature = 'amenity_food_court'],
   [feature = 'amenity_cafe'],
   [feature = 'amenity_fast_food'],
   [feature = 'amenity_biergarten'] {

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -244,7 +244,8 @@
     point-placement: interior;
   }
 
-  [feature = 'amenity_restaurant'][zoom >= 17] {
+  [feature = 'amenity_restaurant'][zoom >= 17],
+  [feature = 'amenity_food_court'][zoom >= 17] {
     point-file: url('symbols/restaurant.p.16.png');
     point-placement: interior;
   }


### PR DESCRIPTION
Currently, there isn't any rendering for food courts (amenity=food_court). It would be nice to add this. It could be rendered the same way like amenity=restaurant.

Fixes #868.