### PR TITLE
Refactor pedestrian and living_street

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -31,9 +31,8 @@
 @tertiary-casing: #c6c68a;
 @residential-casing: #bbb;
 @service-casing: @residential-casing;
-@living-street-casing: @default-casing;
-@living-street-tunnel-casing: #bbb;
-@pedestrian-casing: grey;
+@living-street-casing: @residential-casing;
+@pedestrian-casing: @residential-casing;
 @path-casing: @default-casing;
 @footway-casing: @default-casing;
 @steps-casing: @default-casing;
@@ -71,6 +70,8 @@
 @secondary-width-z13:             7;
 @tertiary-width-z13:              5;
 @residential-width-z13:           3;
+@living-street-width-z13:         2;
+@pedestrian-width-z13:            2;
 @bridleway-width-z13:             0.3;
 @footway-width-z13:               0.7;
 @cycleway-width-z13:              0.7;
@@ -82,6 +83,8 @@
 
 @tertiary-width-z14:              7.5;
 @residential-width-z14:           4.5;
+@living-street-width-z14:         4;
+@pedestrian-width-z14:            4;
 @service-width-z14:               2.5;
 
 @motorway-width-z15:             12.8;
@@ -91,6 +94,8 @@
 @secondary-width-z15:            12.8;
 @tertiary-width-z15:             11.2;
 @residential-width-z15:           8.3;
+@living-street-width-z15:         6;
+@pedestrian-width-z15:            6;
 @bridleway-width-z15:             1.2;
 @footway-width-z15:               1.5;
 @cycleway-width-z15:              1.2;
@@ -101,6 +106,8 @@
 @steps-width-z15:                 4;
 
 @residential-width-z16:          11.2;
+@living-street-width-z16:         9;
+@pedestrian-width-z16:            9;
 @service-width-z16:               6;
 @minor-service-width-z16:         4;
 
@@ -111,6 +118,8 @@
 @secondary-width-z17:            18;
 @tertiary-width-z17:             15.5;
 @residential-width-z17:          15.5;
+@living-street-width-z17:        14;
+@pedestrian-width-z17:           14;
 @service-width-z17:               7;
 
 @casing-width-z12:                0.5;
@@ -301,50 +310,47 @@
 
     [feature = 'highway_pedestrian'] {
       [zoom >= 13] {
-        line-join: round;
-        .roads-casing, .tunnels-casing {
-          line-width: 2;
-          line-color: @pedestrian-casing;
+        line-color: @pedestrian-casing;
+        line-width: @pedestrian-width-z13;
+        [zoom >= 14] { line-width: @pedestrian-width-z14; }
+        [zoom >= 15] { line-width: @pedestrian-width-z15; }
+        [zoom >= 16] { line-width: @pedestrian-width-z16; }
+        [zoom >= 17] { line-width: @pedestrian-width-z17; }
+        .roads-casing {
+          line-join: round;
           line-cap: round;
-          [zoom >= 14] { line-width: 3.6; }
-          [zoom >= 15] { line-width: 6.5; }
-          [zoom >= 16] { line-width: 9; }
-          .tunnels-casing {
-            line-dasharray: 4,2;
-          }
+        }
+        .tunnels-casing {
+          line-dasharray: 4,2;
         }
         .bridges-casing {
-          line-width: 2.2;
-          line-color: @bridge-casing;
-          [zoom >= 14] { line-width: 3.8; }
-          [zoom >= 15] { line-width: 7; }
-          [zoom >= 16] { line-width: 9.5; }
+          [zoom >= 14] {
+            line-color: @bridge-casing;
+            line-join: round;
+          }
         }
       }
     }
 
     [feature = 'highway_living_street'] {
       [zoom >= 13] {
-        line-width: 2.5;
         line-color: @living-street-casing;
-        [zoom >= 14] { line-width: 4; }
-        [zoom >= 15] { line-width: 6; }
-        [zoom >= 16] { line-width: 9; }
-        [zoom >= 17] { line-width: 14.5; }
+        line-width: @living-street-width-z13;
+        [zoom >= 14] { line-width: @living-street-width-z14; }
+        [zoom >= 15] { line-width: @living-street-width-z15; }
+        [zoom >= 16] { line-width: @living-street-width-z16; }
+        [zoom >= 17] { line-width: @living-street-width-z17; }
         .roads-casing {
           line-cap: round;
           line-join: round;
         }
         .tunnels-casing {
-          line-color: @living-street-tunnel-casing;
           line-dasharray: 4,2;
         }
         .bridges-casing {
           [zoom >= 14] {
             line-color: @bridge-casing;
-            [zoom >= 15] { line-width: 6.2; }
-            [zoom >= 16] { line-width: 8.9; }
-            [zoom >= 17] { line-width: 15; }
+            line-join: round;
           }
         }
       }
@@ -972,17 +978,26 @@
 
     [feature = 'highway_living_street'] {
       [zoom >= 13] {
-        line-width: 1.5;
-        line-color: @living-street-fill;
+        line-width: @living-street-width-z13 - 2 * @casing-width-z13;
+        [zoom >= 14] { line-width: @living-street-width-z14 - 2 * @casing-width-z14; }
+        [zoom >= 15] { line-width: @living-street-width-z15 - 2 * @casing-width-z15; }
+        [zoom >= 16] { line-width: @living-street-width-z16 - 2 * @casing-width-z16; }
+        [zoom >= 17] { line-width: @living-street-width-z17 - 2 * @casing-width-z17; }
+        .roads-fill, .bridges-fill {
+          line-color: @living-street-fill;
+        }
+        .tunnels-fill {
+          line-color: @living-street-tunnel-fill;
+        }
+        .bridges-fill {
+          line-width: @living-street-width-z13 - 2 * @casing-width-z13;
+          [zoom >= 14] { line-width: @living-street-width-z14 - 2 * @bridge-casing-width-z14; }
+          [zoom >= 15] { line-width: @living-street-width-z15 - 2 * @bridge-casing-width-z15; }
+          [zoom >= 16] { line-width: @living-street-width-z16 - 2 * @bridge-casing-width-z16; }
+          [zoom >= 17] { line-width: @living-street-width-z17 - 2 * @bridge-casing-width-z17; }
+        }
         line-join: round;
         line-cap: round;
-        [zoom >= 14] { line-width: 3; }
-        [zoom >= 15] { line-width: 4.7; }
-        [zoom >= 16] { line-width: 7.4; }
-        [zoom >= 17] { line-width: 13; }
-      }
-      .tunnels-fill {
-        line-color: @living-street-tunnel-fill;
       }
     }
 
@@ -1022,11 +1037,19 @@
 
     [feature = 'highway_pedestrian'] {
       [zoom >= 13] {
+        line-width: @living-street-width-z13 - 2 * @casing-width-z13;
+        [zoom >= 14] { line-width: @pedestrian-width-z14 - 2 * @casing-width-z14; }
+        [zoom >= 15] { line-width: @pedestrian-width-z15 - 2 * @casing-width-z15; }
+        [zoom >= 16] { line-width: @pedestrian-width-z16 - 2 * @casing-width-z16; }
+        [zoom >= 17] { line-width: @pedestrian-width-z17 - 2 * @casing-width-z17; }
         line-color: @pedestrian-fill;
-        line-width: 1.5;
-        [zoom >= 14] { line-width: 3; }
-        [zoom >= 15] { line-width: 5.5; }
-        [zoom >= 16] { line-width: 8; }
+        .bridges-fill {
+          line-width: @pedestrian-width-z13 - 2 * @casing-width-z13;
+          [zoom >= 14] { line-width: @pedestrian-width-z14 - 2 * @bridge-casing-width-z14; }
+          [zoom >= 15] { line-width: @pedestrian-width-z15 - 2 * @bridge-casing-width-z15; }
+          [zoom >= 16] { line-width: @pedestrian-width-z16 - 2 * @bridge-casing-width-z16; }
+          [zoom >= 17] { line-width: @pedestrian-width-z17 - 2 * @bridge-casing-width-z17; }
+        }
         line-join: round;
         line-cap: round;
       }


### PR DESCRIPTION
- Road widths pedestrian and living_street changed slightly to make them more
  consistent, both internally and with other roads
- Change colour of casing pedestrian and living_street (resolves #708)
- Solve various bugs/inconsistencies:
  - Render pedestrian bridges from z14 instead of z13
  - Add round line-join on living_street bridges
  - Render living_street fill in tunnels only from z13
  - Remove round line-cap from pedestrian tunnels (resolves #900)
- Road widths pedestrian and living_street are now defined with variables
- In general make code more consistent with other road types
