### PR TITLE
tourism=attraction - partially restore old label, stop rendering areas

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1250,10 +1250,9 @@
       text-size: @landcover-font-size;
       [way_pixels > 12000] { text-size: @landcover-font-size-big; }
       [way_pixels > 48000] { text-size: @landcover-font-size-bigger; }
-      text-fill: darken(@attraction, 40%);
-      text-face-name: @landcover-face-name;
-      text-halo-radius: 1;
-      text-halo-fill: rgba(255,255,255,0.6);
+      text-fill: #660033;
+      text-face-name: @book-fonts;
+      text-halo-radius: 2;
       text-wrap-width: @landcover-wrap-width-size;
       [way_pixels > 12000] {text-wrap-width: @landcover-wrap-width-size-big; }
       [way_pixels > 48000] {text-wrap-width: @landcover-wrap-width-size-bigger; }

--- a/landcover.mss
+++ b/landcover.mss
@@ -37,7 +37,6 @@
 @aerodrome: #e9e7e2;
 @allotments: #e5c7ab;
 @apron: #e9d1ff;
-@attraction: #f2caea;
 @barracks: #ff8f8f;
 @campsite: #def6c0; // also caravan_site, picnic_site
 @cemetery: #aacbaf; // also grave_yard
@@ -81,10 +80,6 @@
       line-color: saturate(darken(@campsite, 60%), 30%);
       line-width: 0.3;
     }
-  }
-
-  [feature = 'tourism_attraction'][zoom >= 10] {
-    polygon-fill: @attraction;
   }
 
   [feature = 'landuse_quarry'][zoom >= 10] {


### PR DESCRIPTION
it reverts some changes introduced in #941 - styling of tourism=attraction labels is changed to the old one, except depending on way_pixels and yielding to building label style

Closes #1047
Closes #460

Rendering of tourism=attraction areas is not really useful, as it may be exactly anything and anyway this pink area rarely gets displayed. The new tourism=attraction label introduced by #941 does not look very nice in many situations.

http://www.openstreetmap.org/node/274088761#map=19/50.06627/19.94299
![selection_005](https://cloud.githubusercontent.com/assets/899988/4626060/68265a92-537d-11e4-9a14-ae5d8c4ef81b.png)

http://www.openstreetmap.org/#map=17/51.50264/-0.17279
![selection_002](https://cloud.githubusercontent.com/assets/899988/4626014/eef8aa3a-537c-11e4-8077-17fa495d11d8.png)

http://www.openstreetmap.org/#map=19/51.51183/-0.15888
![selection_003](https://cloud.githubusercontent.com/assets/899988/4626018/fc1901ec-537c-11e4-9e38-b8f20ac486c6.png)

http://www.openstreetmap.org/#map=18/51.54213/-0.14535
![selection_004](https://cloud.githubusercontent.com/assets/899988/4626024/03244eb0-537d-11e4-8943-c16a453c2938.png)
