### PR TITLE
Create layer of low-priority symbols

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -25,14 +25,6 @@
     text-wrap-width: 30;
   }
 
-  [railway = 'level_crossing'][zoom >= 14]::railway {
-    point-file: url('symbols/level_crossing.svg');
-    point-placement: interior;
-    [zoom >= 16] {
-      point-file: url('symbols/level_crossing2.svg');
-    }
-  }
-
   [man_made = 'lighthouse'][zoom >= 15]::man_made {
     point-file: url('symbols/lighthouse.p.20.png');
     point-placement: interior;
@@ -83,6 +75,16 @@
   [man_made = 'mast'][zoom >= 17]::man_made {
     point-file: url('symbols/communications.p.20.png');
     point-placement: interior;
+  }
+}
+
+.amenity-low-priority {
+  [railway = 'level_crossing'][zoom >= 14]::railway {
+    point-file: url('symbols/level_crossing.svg');
+    point-placement: interior;
+    [zoom >= 16] {
+      point-file: url('symbols/level_crossing2.svg');
+    }
   }
 
   [highway = 'mini_roundabout'][zoom >= 16]::highway {

--- a/project.mml
+++ b/project.mml
@@ -1170,7 +1170,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT *\n      FROM planet_osm_point\n      WHERE aeroway IN ('aerodrome', 'helipad')\n         OR barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n         OR highway IN ('mini_roundabout', 'gate')\n         OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')\n         OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n         OR \"natural\" IN ('peak', 'volcano', 'spring', 'tree', 'cave_entrance')\n         OR railway = 'level_crossing'\n      ) AS amenity_symbols", 
+        "table": "(SELECT *\n      FROM planet_osm_point\n      WHERE aeroway IN ('aerodrome', 'helipad')\n         OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')\n         OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n         OR \"natural\" IN ('peak', 'volcano', 'spring', 'tree', 'cave_entrance')\n      ) AS amenity_symbols", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -1193,7 +1193,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT *\n      FROM planet_osm_polygon\n      WHERE aeroway IN ('aerodrome', 'helipad')\n         OR barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n         OR highway IN ('mini_roundabout', 'gate')\n         OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')\n         OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n         OR \"natural\" IN ('peak', 'volcano', 'spring', 'tree')\n         OR railway = 'level_crossing'\n      ) AS amenity_symbols_poly", 
+        "table": "(SELECT *\n      FROM planet_osm_polygon\n      WHERE aeroway IN ('aerodrome', 'helipad')\n         OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')\n         OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n         OR \"natural\" IN ('peak', 'volcano', 'spring', 'tree')\n      ) AS amenity_symbols_poly", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -1689,6 +1689,52 @@
         85.05112877980659
       ], 
       "id": "theme-park", 
+      "advanced": {}
+    }, 
+    {
+      "name": "amenity-low-priority", 
+      "srs-name": "900913", 
+      "geometry": "point", 
+      "class": "amenity-low-priority", 
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508", 
+        "table": "(SELECT *\n      FROM planet_osm_point\n      WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n         OR highway IN ('mini_roundabout')\n         OR railway = 'level_crossing'\n      ) AS amenity_low_priority", 
+        "geometry_field": "way", 
+        "type": "postgis", 
+        "key_field": "", 
+        "dbname": "gis"
+      }, 
+      "extent": [
+        -180, 
+        -85.05112877980659, 
+        180, 
+        85.05112877980659
+      ], 
+      "id": "amenity-low-priority", 
+      "advanced": {}
+    }, 
+    {
+      "name": "amenity-low-priority-poly", 
+      "srs-name": "900913", 
+      "geometry": "polygon", 
+      "class": "amenity-low-priority", 
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508", 
+        "table": "(SELECT *\n      FROM planet_osm_polygon\n      WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n         OR highway IN ('mini_roundabout')\n         OR railway = 'level_crossing'\n      ) AS amenity_low_priority_poly", 
+        "geometry_field": "way", 
+        "type": "postgis", 
+        "key_field": "", 
+        "dbname": "gis"
+      }, 
+      "extent": [
+        -180, 
+        -85.05112877980659, 
+        180, 
+        85.05112877980659
+      ], 
+      "id": "amenity-low-priority-poly", 
       "advanced": {}
     }
   ], 

--- a/project.yaml
+++ b/project.yaml
@@ -1162,12 +1162,9 @@ Layer:
         (SELECT *
               FROM planet_osm_point
               WHERE aeroway IN ('aerodrome', 'helipad')
-                 OR barrier IN ('bollard', 'gate', 'lift_gate', 'block')
-                 OR highway IN ('mini_roundabout', 'gate')
                  OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')
                  OR (power = 'generator' AND ("generator:source" = 'wind' OR power_source = 'wind'))
                  OR "natural" IN ('peak', 'volcano', 'spring', 'tree', 'cave_entrance')
-                 OR railway = 'level_crossing'
               ) AS amenity_symbols
     advanced: {}
   - id: "amenity-symbols-poly"
@@ -1181,12 +1178,9 @@ Layer:
         (SELECT *
               FROM planet_osm_polygon
               WHERE aeroway IN ('aerodrome', 'helipad')
-                 OR barrier IN ('bollard', 'gate', 'lift_gate', 'block')
-                 OR highway IN ('mini_roundabout', 'gate')
                  OR man_made IN ('lighthouse', 'power_wind', 'windmill', 'mast')
                  OR (power = 'generator' AND ("generator:source" = 'wind' OR power_source = 'wind'))
                  OR "natural" IN ('peak', 'volcano', 'spring', 'tree')
-                 OR railway = 'level_crossing'
               ) AS amenity_symbols_poly
     advanced: {}
   - id: "amenity-points-poly"
@@ -1515,4 +1509,34 @@ Layer:
       <<: *osm2pgsql
       table: |2-
         (SELECT way, name, tourism FROM planet_osm_polygon WHERE tourism = 'theme_park') AS theme_park
+    advanced: {}
+  - id: "amenity-low-priority"
+    name: "amenity-low-priority"
+    class: "amenity-low-priority"
+    geometry: "point"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |2-
+        (SELECT *
+              FROM planet_osm_point
+              WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
+                 OR highway IN ('mini_roundabout')
+                 OR railway = 'level_crossing'
+              ) AS amenity_low_priority
+    advanced: {}
+  - id: "amenity-low-priority-poly"
+    name: "amenity-low-priority-poly"
+    class: "amenity-low-priority"
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |2-
+        (SELECT *
+              FROM planet_osm_polygon
+              WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
+                 OR highway IN ('mini_roundabout')
+                 OR railway = 'level_crossing'
+              ) AS amenity_low_priority_poly
     advanced: {}


### PR DESCRIPTION
This layer contains symbols that have lower priority than text, i.e. symbols
that should not prevent the rendering of text labels.

The layer currently contains the barriers, level crossings, and mini
roundabouts.

This resolves #1046.
