### PR TITLE
Render aeroway=aerodrome label at high zoom. Fixes #1021

### DIFF
--- a/amenity-symbols.mss
+++ b/amenity-symbols.mss
@@ -11,11 +11,9 @@
     text-wrap-width: 30;
   }
 
-  [aeroway = 'aerodrome'][zoom >= 10][zoom < 13]::aeroway {
-    [zoom < 11] {
-      point-file: url('symbols/aerodrome.p.16.png');
-      text-dy: -12;
-    }
+  [aeroway = 'aerodrome'][zoom >= 10]::aeroway {
+    point-file: url('symbols/aerodrome.p.16.png');
+    text-dy: -12;
     text-name: "[name]";
     text-size: 8;
     text-fill: #6692da;


### PR DESCRIPTION
http://www.openstreetmap.org/#map=15/50.0822/19.9946

![selection_005](https://cloud.githubusercontent.com/assets/899988/4742179/d4cb2d9e-5a1c-11e4-924f-f30919bc9336.png)
