### PR TITLE
Reduce number of overlapping admin borders

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -1,6 +1,13 @@
 @admin-boundaries: #ac46ac;
 
-#admin-01234 {
+/* For performance reasons, the admin border layers are split into three groups
+for low, middle and high zoom levels.
+For each zoomlevel, all borders come from a single attachment, to handle
+overlapping borders correctly.  */
+
+#admin-low-zoom[zoom < 11],
+#admin-mid-zoom[zoom >= 11][zoom < 13],
+#admin-high-zoom[zoom >= 13] {
   [admin_level = '2'],
   [admin_level = '3'] {
     [zoom >= 4] {
@@ -48,7 +55,8 @@
   comp-op: darken;
 }
 
-#admin-5678 {
+#admin-mid-zoom[zoom >= 11][zoom < 13],
+#admin-high-zoom[zoom >= 13] {
   [admin_level = '5'][zoom >= 11] {
     background/line-color: white;
     background/line-width: 2;
@@ -80,7 +88,7 @@
   comp-op: darken;
 }
 
-#admin-other {
+#admin-high-zoom[zoom >= 13] {
   [admin_level = '9'],
   [admin_level = '10'] {
     [zoom >= 13] {

--- a/project.mml
+++ b/project.mml
@@ -888,14 +888,14 @@
       "advanced": {}
     }, 
     {
-      "name": "admin-01234", 
+      "name": "admin-low-zoom", 
       "srs-name": "900913", 
       "geometry": "linestring", 
-      "id": "admin-01234", 
+      "id": "admin-low-zoom", 
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('0', '1', '2', '3', '4')\n       ORDER BY admin_level DESC\n       ) AS admin_01234", 
+        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('0', '1', '2', '3', '4')\n       ORDER BY admin_level DESC\n       ) AS admin_low_zoom", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -911,14 +911,14 @@
       "advanced": {}
     }, 
     {
-      "name": "admin-5678", 
+      "name": "admin-mid-zoom", 
       "srs-name": "900913", 
       "geometry": "linestring", 
       "class": "", 
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('5', '6', '7', '8')\n       ORDER BY admin_level DESC\n       ) AS admin_5678", 
+        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n       ORDER BY admin_level DESC\n       ) AS admin_mid_zoom", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -930,18 +930,18 @@
         180, 
         85.05112877980659
       ], 
-      "id": "admin-5678", 
+      "id": "admin-mid-zoom", 
       "advanced": {}
     }, 
     {
-      "name": "admin-other", 
+      "name": "admin-high-zoom", 
       "srs-name": "900913", 
       "geometry": "linestring", 
       "class": "", 
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('9', '10')\n       ORDER BY admin_level DESC\n       ) AS admin_other", 
+        "table": "(SELECT way, admin_level\n       FROM planet_osm_roads\n       WHERE \"boundary\" = 'administrative'\n         AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n       ORDER BY admin_level DESC\n       ) AS admin_high_zoom", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 
@@ -953,7 +953,7 @@
         180, 
         85.05112877980659
       ], 
-      "id": "admin-other", 
+      "id": "admin-high-zoom", 
       "advanced": {}
     }, 
     {

--- a/project.yaml
+++ b/project.yaml
@@ -997,8 +997,8 @@ Layer:
       table: |2-
         (SELECT way FROM planet_osm_line WHERE highway = 'bus_guideway' AND (tunnel IS NULL OR tunnel != 'yes')) AS guideways
     advanced: {}
-  - name: "admin-01234"
-    id: "admin-01234"
+  - name: "admin-low-zoom"
+    id: "admin-low-zoom"
     class: ""
     geometry: "linestring"
     <<: *extents
@@ -1010,10 +1010,10 @@ Layer:
                WHERE "boundary" = 'administrative'
                  AND admin_level IN ('0', '1', '2', '3', '4')
                ORDER BY admin_level DESC
-               ) AS admin_01234
+               ) AS admin_low_zoom
     advanced: {}
-  - id: "admin-5678"
-    name: "admin-5678"
+  - id: "admin-mid-zoom"
+    name: "admin-mid-zoom"
     class: ""
     geometry: "linestring"
     <<: *extents
@@ -1023,12 +1023,12 @@ Layer:
         (SELECT way, admin_level
                FROM planet_osm_roads
                WHERE "boundary" = 'administrative'
-                 AND admin_level IN ('5', '6', '7', '8')
+                 AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
                ORDER BY admin_level DESC
-               ) AS admin_5678
+               ) AS admin_mid_zoom
     advanced: {}
-  - id: "admin-other"
-    name: "admin-other"
+  - id: "admin-high-zoom"
+    name: "admin-high-zoom"
     class: ""
     geometry: "linestring"
     <<: *extents
@@ -1038,9 +1038,9 @@ Layer:
         (SELECT way, admin_level
                FROM planet_osm_roads
                WHERE "boundary" = 'administrative'
-                 AND admin_level IN ('9', '10')
+                 AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
                ORDER BY admin_level DESC
-               ) AS admin_other
+               ) AS admin_high_zoom
     advanced: {}
   - id: "power-minorline"
     name: "power-minorline"


### PR DESCRIPTION
This prevents overlapping admin borders by rendering them in order from high to low admin_level, and by giving all admin borders a white background while using comp-op: darken.

Admin borders are currently grouped into three groups: level 0-4, level 5-8, and level 9+. Overlap between these groups is avoided, without compromising performance, by creating one attachment for admin_levels 0-4 for low zoom levels, one for admin_levels 0-8 for mid zoom levels, and one for all admin_levels for all zoom levels.

This solves #344.
