### PR TITLE
Increase minimum font size for islands to 10pt

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -422,7 +422,7 @@
   [feature = 'place_islet'][zoom >= 17] {
     text-name: "[name]";
     text-fill: #000;
-    text-size: 9;
+    text-size: 10;
     [way_pixels > 12000] { text-size: 12; }
     [way_pixels > 48000] { text-size: 15; }
     text-face-name: @oblique-fonts;


### PR DESCRIPTION
This is in line with the increased minimum font size for landcover.
