### PR TITLE
Change rendering country/state labels

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -1,13 +1,14 @@
 @placenames: #222;
 @placenames-light: #777777;
 .country {
-  [place = 'country'][zoom >= 2][zoom < 6] {
+  [admin_level = '2'][zoom >= 2][way_pixels > 3000][way_pixels < 196000] {
     text-name: "[name]";
     text-size: 9;
     text-fill: #9d6c9d;
     text-face-name: @book-fonts;
     text-halo-radius: 1.5;
     text-wrap-width: 50;
+    text-placement: interior;
     [zoom >= 4] {
       text-size: 10;
     }
@@ -15,20 +16,24 @@
 }
 
 .state {
-  [place = 'state'][zoom >= 4][zoom < 9] {
-    text-name: "[ref]";
-    text-size: 9;
-    text-fill: #9d6c9d;
-    text-face-name: @oblique-fonts;
-    text-halo-radius: 1.5;
-    text-wrap-width: 0;
-    [zoom >= 5] {
-      text-name: "[name]";
-      text-wrap-width: 50;
-    }
-    [zoom >= 7] {
-      text-size: 11;
-      text-wrap-width: 70;
+  [admin_level = '4'] {
+    [zoom >= 4][zoom < 5][way_pixels > 750][way_pixels < 196000],
+    [zoom >= 5][way_pixels > 3000][way_pixels < 196000] {
+      text-name: "[ref]";
+      text-size: 9;
+      text-fill: #9d6c9d;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: 1.5;
+      text-wrap-width: 0;
+      text-placement: interior;
+      [zoom >= 5] {
+        text-name: "[name]";
+        text-wrap-width: 50;
+      }
+      [zoom >= 7] {
+        text-size: 11;
+        text-wrap-width: 70;
+      }
     }
   }
 }

--- a/project.mml
+++ b/project.mml
@@ -1078,7 +1078,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, place, name, ref\n       FROM planet_osm_point\n       WHERE place IN ('country', 'state')\n      ) AS placenames_large", 
+        "table": "(SELECT way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels, name, ref, admin_level\n       FROM planet_osm_polygon\n       WHERE boundary = 'administrative' AND admin_level IN ('2', '4')\n      ) AS placenames_large", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 

--- a/project.yaml
+++ b/project.yaml
@@ -1103,9 +1103,9 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |2-
-        (SELECT way, place, name, ref
-               FROM planet_osm_point
-               WHERE place IN ('country', 'state')
+        (SELECT way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels, name, ref, admin_level
+               FROM planet_osm_polygon
+               WHERE boundary = 'administrative' AND admin_level IN ('2', '4')
               ) AS placenames_large
     advanced: {}
   - id: "placenames-capital"


### PR DESCRIPTION
- Country and state labels are now rendered from the admin borders in the polygons
  table rather than from the place nodes in the points table.
- The maximum zoom level requirement for country/state labels is replaced by a
  maximum area size requirement.
- A minimum area size requirement for country/state labels is added.

Advantages:
- Avoid cluttering of too many labels of small areas, in particular on z4 and z5.
- Easier to detect broken country and state multipolygons.

Disadvantage:
- This requires that country and state multipolygons are not broken, otherwise
  the labels won't render.
