### PR TITLE
Change boundary nature reserve / national park areas

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -125,21 +125,34 @@ overlapping borders correctly.  */
 }
 
 #nature-reserve-boundaries {
-  [zoom >= 7] {
-    ::fill [zoom < 13] {
-      opacity: 0.05;
-      polygon-fill: green;
-    }
-    ::line {
-      opacity: 0.15;
-      line-color: green;
-      line-width: 1.5;
-      line-dasharray: 4,2;
-      [zoom >= 10] {
-        line-width: 3;
-        line-dasharray: 6,2;
-        line-join: bevel;
+  [way_pixels > 100][zoom >= 7] {
+    [zoom < 10] {
+      ::fill {
+        opacity: 0.05;
+        polygon-fill: green;
       }
+    }
+    a/line-width: 1;
+    a/line-offset: -0.5;
+    a/line-color: green;
+    a/line-opacity: 0.15;
+    a/line-join: round;
+    a/line-cap: round;
+    b/line-width: 2;
+    b/line-offset: -1;
+    b/line-color: green;
+    b/line-opacity: 0.15;
+    b/line-join: round;
+    b/line-cap: round;
+    [zoom >= 10] {
+      a/line-width: 2;
+      a/line-offset: -1;
+      b/line-width: 4;
+      b/line-offset: -2;
+    }
+    [zoom >= 14] {
+      b/line-width: 6;
+      b/line-offset: -3;
     }
   }
 }

--- a/project.mml
+++ b/project.mml
@@ -1010,7 +1010,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over", 
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508", 
-        "table": "(SELECT way, way_area, name, boundary FROM planet_osm_polygon WHERE (boundary = 'national_park' OR leisure = 'nature_reserve') AND building IS NULL) AS national_park_boundaries", 
+        "table": "(SELECT way, way_area, name, boundary, way_area/(!pixel_width!*!pixel_height!) AS way_pixels FROM planet_osm_polygon WHERE (boundary = 'national_park' OR leisure = 'nature_reserve') AND building IS NULL) AS national_park_boundaries", 
         "geometry_field": "way", 
         "type": "postgis", 
         "key_field": "", 

--- a/project.yaml
+++ b/project.yaml
@@ -1072,7 +1072,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |2-
-        (SELECT way, way_area, name, boundary FROM planet_osm_polygon WHERE (boundary = 'national_park' OR leisure = 'nature_reserve') AND building IS NULL) AS national_park_boundaries
+        (SELECT way, way_area, name, boundary, way_area/(!pixel_width!*!pixel_height!) AS way_pixels FROM planet_osm_polygon WHERE (boundary = 'national_park' OR leisure = 'nature_reserve') AND building IS NULL) AS national_park_boundaries
     advanced: {}
   - id: "theme-park"
     name: "theme-park"


### PR DESCRIPTION
This changes the rendering of national parks in the following way:
- Render border with a double uninterrupted line (line marinas).
- Require 100px minimum size for rendering.
- For zoom levels 10-12, drop transparent fill.
- Resolves #69
- Resolves #563
- Supersedes #1077

Changes with respect to #1077:
- Restore transparent fill for zoomlevels 7-9.
- Make line slightly narrower on zoomlevels 10-12 and wider on zoomlevel 10-13.
