### PR TITLE
adjust hue of landuse=residential

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -1,5 +1,5 @@
 @building-fill: #d6d1c8;
-@building-line: darken(@building-fill, 10%);
+@building-line: darken(@building-fill, 15%);
 @building-low-zoom: darken(@building-fill, 4%);
 
 @building-major-fill: darken(@building-fill, 20%);

--- a/landcover.mss
+++ b/landcover.mss
@@ -16,8 +16,7 @@
 
 // --- "base" landuses ---
 
-@residential: #E1E1E1;      // Lch(89,0,0)
-@residential-line: #B9B9B9; // Lch(75,0,0)
+@residential: #e3e2df;
 @retail: #FFD6D1;           // Lch(89,16,30)
 @retail-line: #D99C95;      // Lch(70,25,30)
 @commercial: #F2DAD9;       // Lch(89,8.5,25)
@@ -152,9 +151,12 @@
 
   [feature = 'landuse_residential'][zoom >= 10] {
     polygon-fill: @residential;
-    [zoom >= 16] {
+    [zoom >= 17] {
+      polygon-fill: lighten(@residential, 2%);
+    }
+    [zoom >= 15] {
       line-width: .5;
-      line-color: @residential-line;
+      line-color: darken(@residential, 15%);
       [name != ''] {
         line-width: 0.7;
       }


### PR DESCRIPTION
This tries to make the new building colour look better on `landuse=residential`.

* It darkens the building outline by 5% for better contrast.
* It gives residential colour the same hue as buildings and lightens it a bit.
* To compensate for that the outline is a bit stronger and is rendered already at z15.
* At z17 residential colour is lightened up a bit by 2% to have more contrast with buildings, while keeping it recognisable at lower zoom levels.

Drawbacks: residential colour is now more similar to aerodrome colour, but they were not that different before. I propose to adjust aerodrome colour if they are too similar.

![bildschirmfoto vom 2015-01-06 18 55 26](https://cloud.githubusercontent.com/assets/3531092/5633237/9b443850-95d5-11e4-807f-7c177f29dbfa.png)

http://www.openstreetmap.org/#map=15/48.0804/16.6021
before z15
![residenital_aerodrome_before_z15](https://cloud.githubusercontent.com/assets/3531092/5633257/c8f2152e-95d5-11e4-9225-cd2e9d3fb708.png)
(aerodrome left, residential right)

http://www.openstreetmap.org/#map=17/48.17157/16.39569
before z17
![residential_before_z17](https://cloud.githubusercontent.com/assets/3531092/5633264/d5f8ae18-95d5-11e4-9b08-742a37e5e574.png)

after z15
![residential_aerodrome_after_2_z15](https://cloud.githubusercontent.com/assets/3531092/5633269/dd7b3764-95d5-11e4-84c3-a66a01367747.png)
(aerodrome left, residential right)

after z17
![residential_after_2_z17](https://cloud.githubusercontent.com/assets/3531092/5633275/ea046f6e-95d5-11e4-9d47-9a157d1e32fc.png)