### PR TITLE
adjust buildings hue, darken outlines

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -1,5 +1,5 @@
-@building-fill: #d6d1c8;
-@building-line: darken(@building-fill, 10%);
+@building-fill: #d9d0c9; //Lch(84, 5, 70)
+@building-line: darken(@building-fill, 15%);
 @building-low-zoom: darken(@building-fill, 4%);
 
 @building-major-fill: darken(@building-fill, 20%);


### PR DESCRIPTION
Starting from https://github.com/gravitystorm/openstreetmap-carto/pull/1202#issuecomment-68927316 I'd like to propose a change were the hue of buildings is moved from the more yellowish  HSV(39°, .07, .84) to the more reddish HSV(25°, .07, .84). At the same time the outline is darkened by 10% to now 20% from the fill for more contrast.

Previews (before on the left, after on the right):
These previews are outdated.

no landuse
![building_no_landuse_z18](https://cloud.githubusercontent.com/assets/3531092/5662072/16e66a5a-9734-11e4-838b-67cad2acc482.png)

industrial/retail/commerical
![building_industrial_etc_z16](https://cloud.githubusercontent.com/assets/3531092/5662070/0c25b5b2-9734-11e4-8fe5-d900e930c8c4.png)

residential/place of worship:
![building_residential_pow_z18](https://cloud.githubusercontent.com/assets/3531092/5662080/292c0954-9734-11e4-8aae-c05a0c6302aa.png)

garden/grass:
![building_green_z18](https://cloud.githubusercontent.com/assets/3531092/5662084/33c51f7c-9734-11e4-8c1f-a8d67b99076b.png)

farmland/farmyard:
![building_farmland_z16](https://cloud.githubusercontent.com/assets/3531092/5662094/45f2b48e-9734-11e4-9894-20050cc9d7e5.png)