### PR TITLE
Add opacity to highway=proposed for less prominent rendering

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -699,6 +699,44 @@
 
 .roads-fill,.bridges-fill,.tunnels-fill {
   ::fill {
+    [feature = 'highway_proposed'] {
+      [zoom >= 13] {
+        line-width: 2;
+        line-color: white;
+        line-opacity: 0.3;
+        centre/line-width: 2;
+        centre/line-color: #9cc;
+        centre/line-opacity: 0.3;
+        centre/line-dasharray: 2,4;
+        right/line-offset: 2 / 2;
+        right/line-width: 0.1;
+        right/line-color: #9cc;
+        right/line-opacity: 0.3;
+        left/line-offset: -2 / 2;
+        left/line-width: 0.1;
+        left/line-color: #9cc;
+        left/line-opacity: 0.3;
+        [zoom >= 14] {
+          line-width: 3.5;
+          centre/line-width: 3.5;
+          centre/line-dasharray: 4,6;
+          right/line-offset: 3.5 / 2;
+          right/line-width: 0.25;
+          left/line-offset: -3.5 / 2;
+          left/line-width: 0.25;
+        }
+        [zoom >= 16] {
+          line-width: 7;
+          centre/line-width: 7;
+          centre/line-dasharray: 6,8;
+          right/line-offset: 7 / 2;
+          right/line-width: 0.5;
+          left/line-offset: -7 / 2;
+          left/line-width: 0.5;
+        }
+      }
+    }
+
     /*
      * The construction rules for small roads are strange, since if construction is null its assumed that
      * it's a more major road. The line-width = 0 could be removed by playing with the query to set a construction
@@ -710,7 +748,6 @@
      * https://github.com/mapbox/carto/issues/235
      * https://github.com/mapbox/carto/issues/237
      */
-    [feature = 'highway_proposed'],
     [feature = 'highway_construction'] {
       [zoom >= 12] {
         line-width: 2;
@@ -2182,7 +2219,22 @@
       text-size: 11;
     }
   }
-  [highway = 'proposed'],
+  [highway = 'proposed'] {
+    [zoom >= 15] {
+      text-name: "[name]";
+      text-size: 9;
+      text-fill: black;
+      text-spacing: 300;
+      text-clip: false;
+      text-placement: line;
+      text-halo-radius: 1;
+      text-face-name: @book-fonts;
+      text-opacity: 0.3;
+    }
+    [zoom >= 17] {
+      text-size: 11;
+    }
+  }
   [highway = 'construction'] {
     [zoom >= 13] {
       text-name: "[name]";


### PR DESCRIPTION
Based on the discussion in and supersedes #863.
At least partly resolves #826 and #345.
This does not add special styles for tunnels or bridges and might need some rework, when the 'proposed=*' key is available in the database.

Rendering example:
![proposed](https://cloud.githubusercontent.com/assets/5783139/5691170/c6471d7e-98b9-11e4-8f7b-7fcf8e401d17.png)
