### PR TITLE
Paranar font resides in fonts-taml-tscu on Trusty

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,15 +64,16 @@ If a font is missing, it will skip to the next available font which contains tho
 
 * Mukti Narrow, for Bangali (`ttf-indic-fonts-core`)
 * Gargi Medium, for Devanagari (`ttf-indic-fonts-core`)
-* TSCu_Paranar, for Tamil (`ttf-tamil-fonts`)
+* TSCu_Paranar, for Tamil (`ttf-tamil-fonts` or ``fonts-taml-tscu``, depending on your Ubuntu version)
 * Mallige, for Kannada (`ttf-indic-fonts-core` for normal and bold and `ttf-kannada-fonts` for oblique) *The filename uses "Malige" but the font name uses "Mallige"*
 
 On Ubuntu you can install all the fonts with
 
 ```
 sudo apt-get install ttf-dejavu fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
-ttf-indic-fonts-core ttf-tamil-fonts ttf-kannada-fonts
+ttf-indic-fonts-core fonts-taml-tscu ttf-kannada-fonts
 ```
+In Ubuntu 13.10 (Saucy) and lower, replace fonts-taml-tscu with ttf-tamil-fonts.
 
 ## Dependencies
 


### PR DESCRIPTION
Thanks to @woodpeck.

Supersedes #837.