### PR TITLE
Fix contradictory unzip options

### DIFF
--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -u
 
-UNZIP_OPTS=-qqun
+UNZIP_OPTS=-qqu
 
 # create and populate data dir
 


### PR DESCRIPTION
-u and -n are mutually exclusive options. Info-ZIP wasn't reporting
this as an error, but BSD zip caught it.

Fixes #1233