### PR TITLE
Improve rendering of construction=residential on zoom 13

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -743,6 +743,11 @@
           [zoom < 13] {
             line-width: 0;
             b/line-width: 0;
+          }            
+          [zoom >= 13][zoom < 14] {
+            line-width: 3;
+            b/line-width: 2;
+            b/line-dasharray: 5,3;
           }
         }
         [construction = 'service'] {


### PR DESCRIPTION
Before:

![constructionbefore](https://cloud.githubusercontent.com/assets/5783139/5789149/abde2706-9e5f-11e4-9f65-3b11cbe19630.png)


After:

![constructionafter](https://cloud.githubusercontent.com/assets/5783139/5789150/b1a1f65e-9e5f-11e4-9688-0d63c4fd224f.png)
