### PR TITLE
add rendering for amenity=townhall

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -181,6 +181,13 @@
     point-placement: interior;
   }
 
+  [feature = 'amenity_townhall'][zoom > 16] {
+    marker-file: url('symbols/town_hall.16.svg');
+    marker-fill: #734a08;
+    marker-placement: interior;
+    marker-clip: false;
+  }
+
   [feature = 'waterway_lock'],
   [feature = 'lock_yes'] {
     [zoom >= 15] {
@@ -662,6 +669,7 @@
   [feature = 'amenity_library'],
   [feature = 'amenity_theatre'],
   [feature = 'amenity_courthouse'],
+  [feature = 'amenity_townhall'],
   [feature = 'amenity_cinema'] {
     [zoom >= 17] {
       text-name: "[name]";

--- a/symbols/town_hall.16.svg
+++ b/symbols/town_hall.16.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 16 16">
+  <path
+     d="M 8,1 C 7.75,1.0032 7.5,1.1644239 7.5,1.5 L 7.5,5.375 2,8 14,8 8.5,5.375 8.5,1.5 C 8.5,1.1516409 8.25,0.99680426 8,1 z M 9,1 9,4 13,4 11,2.5 13,1 z m -7,8 0,1 1,0 0,4 -1,0 0,1 12,0 0,-1 -1,0 0,-4 1,0 0,-1 z m 6,1.5 c 1,0 2,0.5 2,1.5 l 0,2 -4,0 0,-2 c 0,-1 1,-1.5 2,-1.5 z" />
+</svg>


### PR DESCRIPTION
Resolves #77. Rendering rules are the same as for library, cinema, theatre and courthouse, only the icon is different.
Icon: [nebulon42/osmic/town-hall-16.svg](https://github.com/nebulon42/osmic/blob/master/administration/town-hall-16.svg)
(see also [nebulon42/osmic/government-16.svg](https://github.com/nebulon42/osmic/blob/master/administration/government-16.svg))

before
not rendered

after (http://www.openstreetmap.org/relation/11101)
![townhall](https://cloud.githubusercontent.com/assets/3531092/5824241/792c2b88-a0e3-11e4-8ad4-228a5e7ce82a.png)