### PR TITLE
Clean up place name rendering

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -46,15 +46,15 @@
     text-face-name: @book-fonts;
     text-halo-radius: 1.5;
     text-halo-fill: rgba(255,255,255,0.6);
-    text-wrap-width: 25;
+    text-wrap-width: 45;
     text-min-distance: 10;
     [zoom >= 6] {
       text-size: 12;
-      text-wrap-width: 70;
+      text-wrap-width: 60;
     }
     [zoom >= 11] {
       text-size: 15;
-      text-wrap-width: 90;
+      text-wrap-width: 75;
     }
   }
 }
@@ -68,15 +68,15 @@
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
-      text-wrap-width: 25;
+      text-wrap-width: 45;
       text-min-distance: 10;
       [zoom >= 9] {
         text-size: 12;
-      text-wrap-width: 70;
+        text-wrap-width: 60;
       }
       [zoom >= 11] {
         text-size: 15;
-      text-wrap-width: 90;
+        text-wrap-width: 75;
       }
     }
   }
@@ -84,51 +84,57 @@
 
 #placenames-medium::town {
   [place = 'town'] {
-    [zoom >= 9] {
+    [zoom >= 9][zoom < 16] {
       text-name: "[name]";
       text-size: 9;
       text-fill: @placenames;
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
-      text-wrap-width: 50;
+      text-wrap-width: 45;
       text-min-distance: 10;
-    }
-    [zoom >= 11] {
-      text-size: 11;
-      text-wrap-width: 70;
-    }
-    [zoom >= 14] {
-      text-size: 15;
-      text-wrap-width: 90;
-      text-fill: @placenames-light;
-      text-halo-fill: white;
+      [zoom >= 11] {
+        text-size: 11;
+        text-wrap-width: 55;
+      }
+      [zoom >= 12] {
+        text-size: 13;
+        text-wrap-width: 65;
+      }
+      [zoom >= 14] {
+        text-size: 15;
+        text-wrap-width: 75;
+      }
     }
   }
 }
 
 #placenames-small::suburb {
-  [place = 'suburb'][zoom >= 12] {
+  [place = 'suburb'][zoom >= 12][zoom < 17] {
     text-name: "[name]";
     text-size: 11;
     text-fill: @placenames;
     text-face-name: @book-fonts;
     text-halo-radius: 1.5;
     text-halo-fill: rgba(255,255,255,0.6);
-    text-wrap-width: 70;
+    text-wrap-width: 55;
     text-min-distance: 10;
     [zoom >= 14] {
       text-size: 14;
-      text-wrap-width: 90;
+      text-wrap-width: 70;
       text-fill: @placenames-light;
       text-halo-fill: white;
+    }
+    [zoom >= 16] {
+      text-size: 15;
+      text-wrap-width: 75;
     }
   }
 }
 
 #placenames-small::village {
   [place = 'village'] {
-    [zoom >=12] {
+    [zoom >= 12][zoom < 17] {
       text-name: "[name]";
       text-size: 10;
       text-fill: @placenames;
@@ -137,10 +143,15 @@
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 50;
       text-min-distance: 10;
-      [zoom >= 15] {
-        text-size: 13;
+      [zoom >= 14] {
         text-fill: @placenames-light;
         text-halo-fill: white;
+        text-size: 13;
+        text-wrap-width: 65;
+      }
+      [zoom >= 16] {
+        text-size: 15;
+        text-wrap-width: 75;
       }
     }
   }
@@ -152,19 +163,19 @@
   [place = 'neighbourhood'],
   [place = 'isolated_dwelling'],
   [place = 'farm'] {
-    [zoom >= 14] {
+    [zoom >= 15] {
       text-name: "[name]";
       text-size: 9;
       text-fill: @placenames;
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
-      text-wrap-width: 50;
+      text-wrap-width: 45;
       text-min-distance: 10;
     }
     [zoom >= 16] {
       text-size: 12;
-      text-wrap-width: 70;
+      text-wrap-width: 60;
       text-fill: @placenames-light;
       text-halo-fill: white;
     }

--- a/project.mml
+++ b/project.mml
@@ -1124,7 +1124,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT way, place, name, ref\n       FROM planet_osm_point\n       WHERE place IN ('city', 'town') AND capital = 'yes'\n      ) AS placenames_capital",
+        "table": "(SELECT way, place, name, ref\n       FROM planet_osm_point\n       WHERE place IN ('city', 'town') AND (capital = 'yes' OR capital = '4')\n      ) AS placenames_capital",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1147,7 +1147,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT way, place, name\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND (capital IS NULL OR capital != 'yes')\n      ) AS placenames_medium",
+        "table": "(SELECT way, place, name\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND (capital IS NULL OR (capital != 'yes' AND capital != '4'))\n      ) AS placenames_medium",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1137,7 +1137,7 @@ Layer:
       table: |2-
         (SELECT way, place, name, ref
                FROM planet_osm_point
-               WHERE place IN ('city', 'town') AND capital = 'yes'
+               WHERE place IN ('city', 'town') AND (capital = 'yes' OR capital = '4')
               ) AS placenames_capital
     advanced: {}
   - id: "placenames-medium"
@@ -1151,7 +1151,7 @@ Layer:
         (SELECT way, place, name
               FROM planet_osm_point
               WHERE place IN ('city', 'town')
-                AND (capital IS NULL OR capital != 'yes')
+                AND (capital IS NULL OR (capital != 'yes' AND capital != '4'))
               ) AS placenames_medium
     advanced: {}
   - id: "placenames-small"


### PR DESCRIPTION
* Don't render place=town on z16 and higher, and place=suburb and place=village
  on z17 and higher.
* Render place=hamlet, place=locality, place=neighbourhood,
  place=isolated_dwelling, and place=farm from z15 rather than from z14 (resolves
  #948).
* Render place=town black rather than gray.
* Make font sizes more consistent by increasing font size for place=town on z12
  and z13, for place=suburb on z16, and for place=village on z14 and z16
  (resolves #734, resolves #1204).
* Treat capital=4 like capital=yes (resolves #522).
* Make text-wrap consistent.