### PR TITLE
render cave symbols less opaque when access is restricted

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -19,7 +19,7 @@
 @standard-wrap-width: 30;
 
 .points {
-  [feature = 'tourism_alpine_hut'][zoom >= 1c3] {
+  [feature = 'tourism_alpine_hut'][zoom >= 13] {
     point-file: url('symbols/alpinehut.p.16.png');
     point-placement: interior;
   }

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -552,7 +552,7 @@
     point-file: url('symbols/poi_cave.p.16.png');
     point-placement: interior;
     [access != ''][access != 'yes'] {
-      point-opacity: 0.55;
+      point-opacity: 0.4;
     }
   }
 
@@ -796,7 +796,7 @@
     text-wrap-width: @standard-wrap-width;
     text-placement: interior;
     [access != ''][access != 'yes'] {
-      text-opacity: 0.55;
+      text-opacity: 0.4;
     }
   }
 

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -19,7 +19,7 @@
 @standard-wrap-width: 30;
 
 .points {
-  [feature = 'tourism_alpine_hut'][zoom >= 13] {
+  [feature = 'tourism_alpine_hut'][zoom >= 1c3] {
     point-file: url('symbols/alpinehut.p.16.png');
     point-placement: interior;
   }
@@ -551,6 +551,9 @@
   [feature = 'natural_cave_entrance'][zoom >= 15]::natural {
     point-file: url('symbols/poi_cave.p.16.png');
     point-placement: interior;
+    [access != ''][access != 'yes'] {
+      point-opacity: 0.55;
+    }
   }
 
   [feature = 'natural_spring'][zoom >= 14]::natural {
@@ -792,6 +795,9 @@
     text-halo-radius: 1;
     text-wrap-width: @standard-wrap-width;
     text-placement: interior;
+    [access != ''][access != 'yes'] {
+      text-opacity: 0.55;
+    }
   }
 
   [feature = 'historic_memorial'][zoom >= 17] {


### PR DESCRIPTION
natural=cave_entrance is rendered less opaque when access is restricted. This is a partial fix for #1012 .

Visual comparison:
left: old, right: opaque 0.55
![natural_cave_entrance_with_name](https://cloud.githubusercontent.com/assets/779297/5948070/5500ab7a-a742-11e4-8d7c-74a1ba722056.PNG) | ![natural_cave_entrance_with_name_0 55](https://cloud.githubusercontent.com/assets/779297/5948071/55030410-a742-11e4-91c0-da010eb280a6.PNG)
![natural_cave_entrance](https://cloud.githubusercontent.com/assets/779297/5948072/5505f0d0-a742-11e4-83c4-0ea3e3b88f25.PNG) | ![natural_cave_entrance_0 55](https://cloud.githubusercontent.com/assets/779297/5948073/5508756c-a742-11e4-810b-08ac1284df6c.PNG)

More opacity values (0.1 to 0.8):

![natural_cave_entrance_with_name_opacity1-8](https://cloud.githubusercontent.com/assets/779297/5994124/514925f6-aa68-11e4-9fa5-11d2c4c39091.PNG)
