### PR TITLE
add missing landcovers to text-poly-low-zoom

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1469,7 +1469,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "  (SELECT way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels,\n      COALESCE('landuse_' || landuse, 'natural_' || \"natural\", 'boundary_' || boundary) AS feature,\n      name,\n      way_area,\n      CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n    FROM planet_osm_polygon\n    WHERE (landuse IN ('forest')\n      OR \"natural\" IN ('wood')\n      OR boundary IN ('national_park'))\n      AND building IS NULL\n    ORDER BY way_area DESC\n  ) AS text_poly_low_zoom",
+        "table": "  (SELECT way, way_area/(!pixel_width!*!pixel_height!) AS way_pixels,\n      COALESCE('landuse_' || landuse, 'natural_' || \"natural\", 'boundary_' || boundary) AS feature,\n      name,\n      way_area,\n      CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n    FROM planet_osm_polygon\n    WHERE (landuse IN ('forest')\n      OR \"natural\" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')\n      OR boundary IN ('national_park'))\n      AND building IS NULL\n    ORDER BY way_area DESC\n  ) AS text_poly_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1383,7 +1383,7 @@ Layer:
               CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest')
-              OR "natural" IN ('wood')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')
               OR boundary IN ('national_park'))
               AND building IS NULL
             ORDER BY way_area DESC


### PR DESCRIPTION
Adds missing labels for glaciers and bare ground land covers for low zooms <10.  This is purely a fix for a coding error - styling already has the correct settings, just missing in project.yaml/mml.

In general the separate layers are prone to this kind of mistake, would probably be good to prominently mention this in CONTRIBUTING.md.