### PR TITLE
fix aerialway zoom regression

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -917,7 +917,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 15
+        "minzoom": 12
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -953,7 +953,7 @@ Layer:
       table: |2-
         (SELECT way, aerialway FROM planet_osm_line WHERE aerialway IS NOT NULL) AS aerialways
     properties:
-      minzoom: 15
+      minzoom: 12
     advanced: {}
   - id: "roads-low-zoom"
     name: "roads-low-zoom"


### PR DESCRIPTION
Resolves #1301.
Fixes a regression introduced by specifying minzoom for the aerialway layer.