### PR TITLE
correct minzoom value for amenity_points layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1415,7 +1415,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 13
+        "minzoom": 10
       },
       "advanced": {}
     },
@@ -1441,7 +1441,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 13
+        "minzoom": 10
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -1328,7 +1328,7 @@ Layer:
                  OR (power = 'generator' AND ("generator:source" = 'wind' OR power_source = 'wind'))
          ORDER BY way_area desc      ) AS amenity_points_poly
     properties:
-      minzoom: 13
+      minzoom: 10
     advanced: {}
   - id: "amenity-points"
     name: "amenity-points"
@@ -1354,7 +1354,7 @@ Layer:
                  OR (power = 'generator' AND ("generator:source" = 'wind' OR power_source = 'wind'))
               ) AS amenity_points
     properties:
-      minzoom: 13
+      minzoom: 10
     advanced: {}
   - id: "power-towers"
     name: "power-towers"


### PR DESCRIPTION
resolves #1306 and also restores other amenity_points stuff at z<=12 (i.e. peaks).

In general i think a systematic check of the minzoom/maxzoom values would be in order.