### PR TITLE
Made Travis output on yaml2mml.py failure more comprehensive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
   - jsonlint project.mml
   - ./node_modules/carto/bin/carto project.mml | xmllint - | wc -l
-  - scripts/yaml2mml.py < project.yaml > project.mml2 && diff project.mml project.mml2
+  - ./scripts/travis_check_project_files

--- a/scripts/travis_check_project_files
+++ b/scripts/travis_check_project_files
@@ -1,0 +1,12 @@
+#!/bin/bash
+scripts/yaml2mml.py < project.yaml > project.mml2 && diff -q project.mml project.mml2
+exitcode=$?
+
+if [ $exitcode -eq 0 ]
+then
+  echo "project.yaml and project.mml are in sync."
+else
+  printf "\nproject.yaml and project.mml are not in sync!\nYou should only modify project.yaml, not project.mml and run scripts/yaml2mml.py before committing.\nRead https://github.com/gravitystorm/openstreetmap-carto/blob/master/CONTRIBUTING.md#editing-layers for further information.\n"
+fi
+
+exit $exitcode


### PR DESCRIPTION
Fixes #1329.

See https://travis-ci.org/floscher/openstreetmap-carto/builds/51741837 for a failing build and https://travis-ci.org/floscher/openstreetmap-carto/builds/51741018 for a sucessful build.

This suppresses the output of the complete diff, because I'd say that in only a very few cases it would be of interest **what** differs between `project.mml` and `project.mml2`, the information **that** there are differences should be enough. In most cases the author of the commit simply forgot to run `yaml2mml.py` (like in https://travis-ci.org/gravitystorm/openstreetmap-carto/builds/51634644).

This could surely be done in a oneliner, but I wanted to keep it readable. Additionally Travis will always print out the full command. That means it would also print the string saying that the files are out of sync, even when that is not the case. This is avoided by putting the code in a separate script-file.