### PR TITLE
Quick dev. environment using Vagrant & Salt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep get-shapefiles.sh with LF-endings as to avoid Vagrant issues
+# Should be the case for all shell-files, and as such is *.sh
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Keep get-shapefiles.sh with LF-endings as to avoid Vagrant issues
 # Should be the case for all shell-files, and as such is *.sh
 *.sh text eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ layers/
 data/
 *.xml
 node_modules/
+.vagrant/
+Vagrantfile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  # This can be changed to anything else, but keep in mind the states
+  # are only written with 14.04.1 in mind.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Setting up port-forwarding for kosmtik, so you can access it at
+  # http://127.0.0.1:6789
+  config.vm.network "forwarded_port", guest: 6789, host: 6789
+
+  # Configurations specific to customizing the virtual machine for the 
+  # provider we use. Here, we use virtualbox, but you can use another if
+  # you'd like -- just remember to make a separate section for it, as
+  # this only applies to VirtualBox.
+
+  config.vm.provider "virtualbox" do |vb|
+    # We're dealing with memory intensive business: minimum should be 2048MB.
+    # Default here is 4096MB, but you can decrease or increase it as you need.
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    
+    # The following are recommended values for the VM for relatively high 
+    # degrees of responsiveness. Note that you need virtualization extensions
+    # enabled on your computer to use the last option.
+    # The extra CPU cores for the VM are highly recommended for importing
+    # larger areas, especially when dealing with complete countries.
+    # vb.customize ["modifyvm", :id, "--cpus", "4"]
+    # vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
+  end
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+
+  # Here we share the same folder to /srv/openstreetmap-carto/ so that
+  # we can have the sources available for kosmtik to render.
+  config.vm.synced_folder ".", "/srv/openstreetmap-carto"
+  # Since we want to run Salt masterless, we've got to setup the Salt root
+  # as well, resulting in us being able to get the dev. environment up.
+  config.vm.synced_folder "salt/", "/srv/salt/"
+
+  # Set up the Salt provisioner, without much special configuration.
+  config.vm.provision :salt do |salt|
+    salt.minion_config = "salt/minion"
+    salt.run_highstate = true
+
+    # IF you'd like to use any plugins for kosmtik, you can provide them 
+    # underneath here by uncommenting the block. Check out the kosmtik
+    # project on github for a list over plugins, or execute
+    # $ node index.js plugins --available 
+    # while in /usr/local/kosmtik
+    
+    #salt.pillar({
+    # "kosmtik" => {
+    #   "plugins" => [
+    #     "kosmtik-map-compare",
+    #     "kosmtik-place-search"
+    #   ]
+    # }
+    #})
+  end
+  
+end

--- a/salt/gis.sls
+++ b/salt/gis.sls
@@ -1,0 +1,126 @@
+# get the software packages installed
+base:
+  pkg.installed:
+    - install_recommends: false
+    - pkgs:
+      # just some basic packages, not specific to the carto setup.
+      - git 
+      - unzip
+      - curl
+      - build-essential
+      - software-properties-common
+    - refresh: true
+
+# installing the required GIS-software, plus...
+# create the postgresql database and enabling PostGIS
+gis:
+  pkg.installed:
+    - install_recommends: false
+    - pkgs:
+      # here come the goodies; PostGIS is elementary to a current dev. environment.
+      - postgresql-9.3-postgis-2.1
+      - postgresql-contrib-9.3
+      - proj-bin
+      - libgeos-dev
+  # Let's make it easy for our GIS-in-aid software to access our PostGIS database
+  file.blockreplace:
+    - name: /etc/postgresql/9.3/main/pg_hba.conf
+    - marker_start: "# TYPE  DATABASE"
+    - marker_end: '# "local" is'
+    - content: "local   all             gisuser                                 trust"
+  service:
+    - name: postgresql
+    - running
+    - watch:
+      - file: postgresql.conf.work_mem
+      - file: postgresql.conf.maintenance_work_mem
+      - file: gis
+    - require:
+      - pkg: gis
+      - file: gis
+  postgres_user.present:
+    - name: gisuser
+    - superuser: true
+    - createdb: true
+    - require:
+      - service: gis
+  postgres_database.present:
+    - name: gis
+    - db_user: gisuser
+    - require:
+      - postgres_user: gis
+
+# PostGIS: hstore -- extension
+hstore:
+  postgres_extension.present:
+    - db_user: gisuser
+    - maintenance_db: gis
+    - require:
+        - service: gis
+
+# PostGIS: postgis -- extension
+postgis:
+  postgres_extension.present:
+    - db_user: gisuser
+    - maintenance_db: gis
+    - require:
+      - service: gis
+
+# Conservative tweaks to PostgreSQL conf, based on 
+# "Loading OSM data" located at switch2osm.org.
+# TODO: figure out if it's possible to get rid of the other ID, so I can sleep better at night.
+postgresql.conf.work_mem:
+  file.replace:
+    - name: /etc/postgresql/9.3/main/postgresql.conf
+    - pattern: "#work_mem = 1MB"
+    - repl: "work_mem = 16MB"
+
+postgresql.conf.maintenance_work_mem:
+  file.replace:
+    - name: /etc/postgresql/9.3/main/postgresql.conf
+    - pattern: "#maintenance_work_mem = 16MB"
+    - repl: "maintenance_work_mem = 128MB"
+
+# Configure the system to allow overcommitting
+sysctl.overcommit:
+  file.managed:
+    - name: /etc/sysctl.d/60-overcommit.conf
+    - contents: |
+        # Overcommit settings to allow faster osm2pgsql imports
+        vm.overcommit_memory=1
+  cmd.wait:
+    - name: sysctl -p /etc/sysctl.d/60-overcommit.conf
+    - cwd: /
+    - watch:
+      - file: sysctl.overcommit
+
+# OpenStreetMap related repos and packages
+osm:
+  # add the ppa for osm2pgsql with osmctools
+  pkgrepo.managed:
+    - ppa: kakrueger/openstreetmap
+  # install the packages from above-mentioned repo!
+  pkg.latest:
+    - install_recommends: false
+    - refresh: true
+    - pkgs:
+      - osm2pgsql
+      - osmctools
+
+gis.shapefiles:
+  pkg.installed:
+    - install_recommends: false
+    # we need gdal-bin for ogr2ogr, and mapnik-utils for shapefiles
+    - pkgs:
+      - mapnik-utils
+      - gdal-bin
+  cmd.run:
+    # run/download/generate shapefiles for the style
+    - name: /srv/openstreetmap-carto/get-shapefiles.sh
+    - cwd: /srv/openstreetmap-carto
+    #- unless: "test -d /srv/openstreetmap-carto/data/"
+    # Experimental setting: different VT, allows for instant output within salt logs.
+    - use_vt: true
+    # We'll be needing these if we are to run get-shapefiles.sh
+    - require:
+      - pkg: gis.shapefiles

--- a/salt/gis.sls
+++ b/salt/gis.sls
@@ -96,16 +96,17 @@ sysctl.overcommit:
 
 # OpenStreetMap related repos and packages
 osm:
-  # add the ppa for osm2pgsql with osmctools
+  # Add the ppa for osm2pgsql
+  # It also contains libapache2-mod-tile, should it be needed
   pkgrepo.managed:
     - ppa: kakrueger/openstreetmap
-  # install the packages from above-mentioned repo!
+  # Install any specifically OSM related package
   pkg.latest:
     - install_recommends: false
     - refresh: true
     - pkgs:
-      - osm2pgsql
-      - osmctools
+      - osm2pgsql  # installs from the PPA
+      - osmctools  # installs from ubuntu main v0.1-2
 
 gis.shapefiles:
   pkg.installed:

--- a/salt/gis.sls
+++ b/salt/gis.sls
@@ -134,7 +134,8 @@ gis.shapefiles:
     # run/download/generate shapefiles for the style
     - name: /srv/openstreetmap-carto/get-shapefiles.sh
     - cwd: /srv/openstreetmap-carto
-    - unless: "test -d /srv/openstreetmap-carto/data/"
+    # Checks the index time for the land_polygons.index to see if shapefiles should run again
+    - unless: "test `find /srv/openstreetmap-carto/data/land-polygons-split-3857/land_polygons.index -mmin +1440 -exec echo 1`"
     # Experimental setting: different VT, allows for instant output within salt logs.
     - use_vt: true
     # We'll be needing these if we are to run get-shapefiles.sh

--- a/salt/kosmtik.sls
+++ b/salt/kosmtik.sls
@@ -1,0 +1,106 @@
+# Salt states for getting kosmtik installed for purposes of
+# improving the OpenStreetMap CartoCSS implementation and style.
+
+
+# A whole bunch of libraries that we'll need, plus a bunch
+# of extra fonts.
+# TODO: fill in exact requirements
+package-requirements:
+  pkg.installed:
+    - install_recommends: false
+    - pkgs:
+      - libgtk2.0-dev
+      - libwebkitgtk-dev
+      - protobuf-compiler
+      - libprotobuf-dev
+      - libgdal1-dev
+      - gdal-bin
+      - python-yaml
+      # here be the fonts
+      - ttf-dejavu
+      - ttf-unifont
+      - fonts-droid
+      - fonts-sipa-arundina
+      - fonts-sil-padauk
+      - fonts-khmeros
+
+# nodejs is what kosmtik runs on
+nodejs:
+  pkgrepo.managed:
+    - humanname: NodeSource node.js
+    - name: deb https://deb.nodesource.com/node/ trusty main
+    - dist: trusty
+    - file: /etc/apt/sources.list.d/nodesource.list
+    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+  pkg.latest:
+    - pkgs:
+      - nodejs
+    - install_recommends: false
+    - refresh: true
+
+# Getting kosmtik from github, latest version
+kosmtik:
+  git.latest:
+    - rev: master
+    - name: https://github.com/kosmtik/kosmtik.git
+    - target: /usr/local/kosmtik
+    - depth: 1
+    - require:
+      - pkg: package-requirements
+  npm.bootstrap:
+    - name: /usr/local/kosmtik
+    - require:
+      - pkg: nodejs
+      - git: kosmtik
+  # localconfig.json -- can be edited, is stored in the home directory
+  file.managed:
+    - name: /root/localconfig.json
+    - contents: |
+        [
+          { 
+            "where": "Layer",
+            "if": {
+              "Datasource.type": "postgis"
+            },
+            "then": {
+              "Datasource.dbname": "gis",
+              "Datasource.password": "",
+              "Datasource.user": "gisuser",
+              "Datasource.host": ""
+            }
+          }
+        ]
+
+/etc/init/kosmtik.conf:
+  file.managed:
+    - contents: |
+        description "Kosmtik render service"
+        author "Thor M. K. H. <thor@roht.no>"
+        start on started postgresql
+        stop on runlevel [016]
+        env HOME=/root/
+        chdir /usr/local/kosmtik
+        exec node index.js serve /srv/openstreetmap-carto/project.yaml --host=0.0.0.0 --localconfig /root/localconfig.json
+  service.running:
+    - name: kosmtik
+    - require:
+      - file: /etc/init/kosmtik.conf
+
+
+/root/.config/:
+  file.directory:
+    - user: root
+
+{% for plugin in salt['pillar.get']('kosmtik:plugins', {}) %}
+{{ plugin }}:
+  cmd.run:
+    - name: node index.js plugins --install {{ plugin }}
+    - user: root
+    - cwd: {{ salt['pillar.get']('kosmtik.path', '/usr/local/kosmtik') }}
+    - creates: /usr/local/kosmtik/node_modules/{{ plugin }}/package.json
+    - require:
+      - npm: kosmtik
+      - file: /root/.config/
+    - require_in:
+      - service: /etc/init/kosmtik.conf
+{% endfor %}

--- a/salt/minion
+++ b/salt/minion
@@ -1,0 +1,1 @@
+file_client: local

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,0 +1,4 @@
+base:
+  '*':
+    - gis
+    - kosmtik


### PR DESCRIPTION
Following straight from the commit:
> Ubuntu 14.04.1 with osm2pgsql, postgis and kosmtik ready to use
 - Uses Vagrant to quickly create a VM based on Ubuntu 14.04.1 LTS
    - Adjustable amounts of CPU cores and memory
 - Easily have your own kosmtik plugins ready if you want to start from scratch
    - Sets up kosmtik as a service, so you can easily start/stop using $ service kosmtik <start/stop/status/restart>
 - Added .vagrant/ and Vagrantfile to the ignore list to avoid unintentional commits with edits
 - Does NOT import any .pbfs automatically, as it can quickly get messy
   doing such. However, I've played around with it and it works -- as
   long as you've got the memory and you're not importing overlapping
   areas.
 - However, it does execute get-shapefiles for you -- just `vagrant up` or `vagrant provision`
 - Edit as you please and reload it for kosmtik to pick it up
 - All you need to do to get started is to import with osm2pgsql

I queried @pnorman about this very briefly in #osm-dev at some point, and so here is a PR to see if there is any interest in adding this as part of the repo.
The benefits are mainly listed above, but the recap would be the following:
  - No messing around with relatively long lists of instructions
    - *The configuration is combined from switch2osm and the notepad with instructions that I've seen linked around here*
  - Allows for a "shared" development environment
    - *This is only to some degree; you all have vastly different HW requirements and desires for what and how to render, but it's an easy way to get an identical setup*
  - Makes it a whole lot easier for people on Windows to join the party
    - *I started it while I was using Windows myself, but even on any other distribution it's nice to not have to worry about the development environment too much. Note the .gitattributes addition is to avoid gits conversion of line endings for the shell scripts, so that errors don't occur when running i.e. `get-shapefiles.sh`*

For those of you not familiar with [Vagrant](http://docs.vagrantup.com/v2/getting-started/index.html), you won't be adding a whole VM to the repository -- just a configuration file for Vagrant and Salt roots for configuring the VM for osm2pgsql, kosmtik and postgis. (Though, not in _that_ order.) You can also clone my branch and simply run `vagrant up` once you've installed Vagrant on your computer, and have a look. 

Usage is currently as follows:
1. If not already present, install Vagrant and VirtualBox.
2. Clone the repository.
3. If you'd like kosmtik plugins, edit the Vagrantile and add the ones you want.
4. Run `vagrant up` from within the repository. 
5. Run `vagrant ssh` to SSH in, so that you can run your own `osm2pgsql` import. (Place any files in data/ and they'll be available at `/srv/openstreetmap-carto/data/` inside the VM.)
6. Once data is imported, the map will magically be visible at http://127.0.0.1:6789.
7. Ideally, edit stuff and see how simple it is to `vagrant destroy && vagrant up` if you want to recreate it.

Either way, if it's not something for you folks, that's completely understandable: the PR addes one file to the root, as well as an entire folder containing 4 files. (These can be put elsewhere if desired.) Should it be something that is a bit too meta, then I'll just keep it separated in its own repository. However, at least for me it's really practical when I can clone a repo, run `vagrant up` and be at the finish line for what I need to contribute to a project. :sunny:

If there is an interest in it, but something is amiss, let me know and I'll try what I can to fix & improve it.