### PR TITLE
change rendering for natural=spring

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -584,9 +584,10 @@
   }
 
   [feature = 'natural_spring'][zoom >= 14] {
-    marker-file: url('symbols/spring.svg');
+    marker-file: url('symbols/spring.16.svg');
     marker-placement: interior;
     marker-clip: false;
+    marker-fill: @water-color;
   }
 
   [feature = 'power_generator']['generator:source' = 'wind'],

--- a/symbols/spring.16.svg
+++ b/symbols/spring.16.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 16 16"
+   id="svg2">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="16"
+     height="16"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="m 9.0003502,1 c -1.53125,0 -3,0.9998209 -3,2.5 0,1.5001791 1,2.03125 2,5.5 1,-3.4375 3.3749998,-4 3.4999998,-5.5 C 11.62535,2 10.5316,1 9.0003502,1 z m -5.5,6.5 c -2.0183,0 -2.416834,2.697459 -1,4 1.416834,1.302541 2.887622,1.099599 4.5,3.5 0.400102,-2 0.282636,-3 0,-4 -0.282636,-1 -1.4817,-3.5 -3.5,-3.5 z M 12.50035,8 c -2.0183,0 -3.2173638,2 -3.4999998,3 -0.282636,1 -0.400102,2 0,4 1.6123778,-2.400401 3.5831658,-1.697459 4.9999998,-3 1.416834,-1.302541 0.5183,-4 -1.5,-4 z"
+     id="spring"
+     style="fill:#1a1a1a;fill-opacity:1;stroke:none" />
+</svg>

--- a/symbols/spring.svg
+++ b/symbols/spring.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<svg xmlns="http://www.w3.org/2000/svg"
-   version="1.1"
-   width="5"
-   height="7">
-	<rect width="5" height="7" fill="white" />
-	<path d="M 4,1 1,1 1,4 3,4 3,5 1,5 1,6 4,6 4,3 2,3 2,2 4,2 4,1 z" fill="#588499" />
-</svg>


### PR DESCRIPTION
Resolves #325.

before
![spring_waterway_before](https://cloud.githubusercontent.com/assets/3531092/6653150/be4e2730-ca86-11e4-9ec9-dd42cf779676.png)
![spring_forest_before](https://cloud.githubusercontent.com/assets/3531092/6653151/c245280c-ca86-11e4-98cf-cb4622cca491.png)

after
![spring_waterway_after](https://cloud.githubusercontent.com/assets/3531092/6653152/c78c7a2c-ca86-11e4-992a-16d8cdc480f4.png)
![spring_forest_after](https://cloud.githubusercontent.com/assets/3531092/6653153/cb12c944-ca86-11e4-9f13-b8b309f24718.png)

Here I would again recommend icon halos that have been rejected in #1341.