### PR TITLE
Render intermittend rivers with dashed line also on low zoom levels

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -204,7 +204,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT way, waterway\n  FROM planet_osm_line\n  WHERE waterway = 'river'\n) AS water_lines_low_zoom",
+        "table": "(SELECT way, waterway, intermittent\n  FROM planet_osm_line\n  WHERE waterway = 'river'\n) AS water_lines_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -212,7 +212,7 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT way, waterway
+        (SELECT way, waterway, intermittent
           FROM planet_osm_line
           WHERE waterway = 'river'
         ) AS water_lines_low_zoom

--- a/water.mss
+++ b/water.mss
@@ -93,6 +93,12 @@
 
 #water-lines-low-zoom {
   [waterway = 'river'][zoom >= 8][zoom < 12] {
+    [intermittent = 'yes'] {
+      line-dasharray: 8,4;
+      line-cap: butt;
+      line-join: round;
+      line-clip: false;
+    }  
     line-color: @water-color;
     line-width: 0.7;
     [zoom >= 9] { line-width: 1.2; }


### PR DESCRIPTION
Render intermittend rivers with dashed line also on low zoom levels.

Screenshot:

![preview](https://cloud.githubusercontent.com/assets/6830724/6697329/bbb67e88-cce7-11e4-8c8c-093bc4733c2e.png)

Resolves #1305 and substitutes #1376 and #1399 