### PR TITLE
fix dy for golf labels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -965,7 +965,7 @@
     text-halo-radius: 1;
     text-halo-fill: rgba(255,255,255,0.6);
     text-placement: interior;
-    text-dy: 11;
+    text-dy: 13;
     text-wrap-width: 40;
   }
 


### PR DESCRIPTION
Unfortunately, YA text-dy is too low :(

![leisure golf_course name eeeeee eeeeee eeeeee ref 1 ele 8000 closed_way master - dy](https://cloud.githubusercontent.com/assets/899988/6740986/816ca2b8-ce84-11e4-96dc-779061ca196a.png)
