### PR TITLE
Do not render island/islet name when way_pixels is big

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -687,10 +687,10 @@
 
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
-  [feature = 'place_island'][zoom >= 7][way_pixels > 3000],
-  [feature = 'place_island'][zoom >= 16],
-  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000],
-  [feature = 'place_islet'][zoom >= 17] {
+  [feature = 'place_island'][zoom >= 7][way_pixels > 3000][way_pixels < 800000],
+  [feature = 'place_island'][zoom >= 16][way_pixels < 800000],
+  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000][way_pixels < 800000],
+  [feature = 'place_islet'][zoom >= 17][way_pixels < 800000] {
     text-name: "[name]";
     text-fill: #000;
     text-size: 10;


### PR DESCRIPTION
Do not render island/islet name when way_pixels is big

If islands are big and the zoom level is high, we still have a label rendered for these islands. This seems a little confusing to me.

This PR uses way_pixels to discard label rendering if the island surface is quite big (relative to your screen).

Maybe this approach may be also useful for other way_pixel based labels?