### PR TITLE
Treat MML files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mml binary


### PR DESCRIPTION
Treating MML files as binary lets git not try to display a meaningless diff