### PR TITLE
Add missing font size for bank

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1477,6 +1477,7 @@
     [feature = 'amenity_atm'] {
       text-name: "[operator]";
     }
+    text-size: 10;
     [feature = 'amenity_bank'] { text-dy: 9; }
     [feature = 'amenity_atm']  { text-dy: 10; }
     text-fill: black;


### PR DESCRIPTION
Better explicitly add the size, so that it won't depends on some default.