### PR TITLE
adding antarctic icesheet rendering based on preprocessed shapefiles

### DIFF
--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -11,6 +11,8 @@ mkdir -p data/simplified-land-polygons-complete-3857
 mkdir -p data/ne_110m_admin_0_boundary_lines_land
 mkdir -p data/ne_10m_populated_places
 mkdir -p data/land-polygons-split-3857
+mkdir -p antarctica-icesheet-polygons-3857
+mkdir -p antarctica-icesheet-outlines-3857
 
 # world_boundaries
 echo "dowloading world_boundaries..."
@@ -65,6 +67,27 @@ unzip $UNZIP_OPTS data/land-polygons-split-3857.zip \
   land-polygons-split-3857/land_polygons.cpg \
   -d data/
 
+# antarctica-icesheet-polygons-3857
+echo "dowloading antarctica-icesheet-polygons-3857..."
+curl -z "data/antarctica-icesheet-polygons-3857.zip" -L -o "data/antarctica-icesheet-polygons-3857.zip" "http://data.openstreetmapdata.com/antarctica-icesheet-polygons-3857.zip"
+echo "expanding antarctica-icesheet-polygons-3857..."
+unzip $UNZIP_OPTS data/antarctica-icesheet-polygons-3857.zip \
+  antarctica-icesheet-polygons-3857/icesheet_polygons.shp \
+  antarctica-icesheet-polygons-3857/icesheet_polygons.shx \
+  antarctica-icesheet-polygons-3857/icesheet_polygons.prj \
+  antarctica-icesheet-polygons-3857/icesheet_polygons.dbf \
+  -d data/
+
+# antarctica-icesheet-outlines-3857
+echo "dowloading antarctica-icesheet-outlines-3857..."
+curl -z "data/antarctica-icesheet-outlines-3857.zip" -L -o "data/antarctica-icesheet-outlines-3857.zip" "http://data.openstreetmapdata.com/antarctica-icesheet-outlines-3857.zip"
+echo "expanding antarctica-icesheet-outlines-3857..."
+unzip $UNZIP_OPTS data/antarctica-icesheet-outlines-3857.zip \
+  antarctica-icesheet-outlines-3857/icesheet_outlines.shp \
+  antarctica-icesheet-outlines-3857/icesheet_outlines.shx \
+  antarctica-icesheet-outlines-3857/icesheet_outlines.prj \
+  antarctica-icesheet-outlines-3857/icesheet_outlines.dbf \
+  -d data/
 
 #process populated places
 echo "processing ne_10m_populated_places..."
@@ -77,6 +100,8 @@ echo "indexing shapefiles"
 shapeindex --shape_files \
 data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp \
 data/land-polygons-split-3857/land_polygons.shp \
+data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp \
+data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp \
 data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp \
 data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp
 

--- a/project.mml
+++ b/project.mml
@@ -223,6 +223,28 @@
       "advanced": {}
     },
     {
+      "name": "icesheet-poly",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "",
+      "id": "icesheet-poly",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 4
+      },
+      "advanced": {}
+    },
+    {
       "name": "water-areas",
       "srs-name": "900913",
       "geometry": "polygon",
@@ -271,6 +293,28 @@
       ],
       "properties": {
         "minzoom": 10
+      },
+      "advanced": {}
+    },
+    {
+      "name": "icesheet-outlines",
+      "srs-name": "900913",
+      "geometry": "linestring",
+      "class": "",
+      "id": "icesheet-outlines",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 4
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -222,6 +222,17 @@ Layer:
       minzoom: 8
       maxzoom: 11
     advanced: {}
+  - id: "icesheet-poly"
+    name: "icesheet-poly"
+    class: ""
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      file: "data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp"
+      type: "shape"
+    properties:
+      minzoom: 4
+    advanced: {}
   - id: "water-areas"
     name: "water-areas"
     class: ""
@@ -262,6 +273,17 @@ Layer:
         ) AS water_areas_overlay
     properties:
       minzoom: 10
+    advanced: {}
+  - id: "icesheet-outlines"
+    name: "icesheet-outlines"
+    class: ""
+    geometry: "linestring"
+    <<: *extents
+    Datasource:
+      file: "data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp"
+      type: "shape"
+    properties:
+      minzoom: 4
     advanced: {}
   - id: "water-lines"
     name: "water-lines"

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -31,6 +31,26 @@
   }
 }
 
+#icesheet-poly {
+  [zoom >= 6] {
+    polygon-fill: @glacier;
+    [zoom >= 8] {
+      polygon-pattern-file: url('symbols/glacier.png');
+    }
+  }
+}
+
+#icesheet-outlines {
+  [zoom >= 6] {
+    [ice_edge = 'ice_ocean'],
+    [ice_edge = 'ice_land'] {
+      line-dasharray: 4,2;
+      line-width: 0.75;
+      line-color: @glacier-line;
+    }
+  }
+}
+
 #builtup {
   [zoom >= 8][zoom < 10] {
     polygon-fill: #ddd;


### PR DESCRIPTION
Since the preprocessed Antarctic icesheet data is now regularly available on [openstreetmapdata.com](http://openstreetmapdata.com/data/icesheet) (where also the coastlines come from) this PR adds rendering of the Antarctic ice based on that data.  Style-wise this should be an exact equivalent to normal glacier rendering.

See also #960 for more background information.

Rendering examples:

![z=6](http://www.imagico.de/files/icesheet_1.png)
![McMurdo dry valleys](http://www.imagico.de/files/icesheet_2.png)
![with explicitly mapped glacier](http://www.imagico.de/files/icesheet_3.png)

Resolves #960
