### PR TITLE
Add localconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ layers/
 data/
 *.xml
 node_modules/
+localconfig.json


### PR DESCRIPTION
A common workflow is to run kosmtik against project.yaml with a
localconfig.json, so it should be ignored by git