### PR TITLE
Shift minimal zoom levels for villages and hamlets.

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -134,7 +134,7 @@
 
 #placenames-small::village {
   [place = 'village'] {
-    [zoom >= 12][zoom < 17] {
+    [zoom >= 11][zoom < 17] {
       text-name: "[name]";
       text-size: 10;
       text-fill: @placenames;
@@ -143,6 +143,7 @@
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 50;
       text-min-distance: 10;
+      [zoom <=11] {text-min-distance: 30;}
       [zoom >= 14] {
         text-fill: @placenames-light;
         text-halo-fill: white;
@@ -163,7 +164,7 @@
   [place = 'neighbourhood'],
   [place = 'isolated_dwelling'],
   [place = 'farm'] {
-    [zoom >= 15] {
+    [zoom >= 12] {
       text-name: "[name]";
       text-size: 9;
       text-fill: @placenames;

--- a/project.mml
+++ b/project.mml
@@ -1340,7 +1340,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 12
+        "minzoom": 11
       },
       "advanced": {}
     },


### PR DESCRIPTION
In continue of discussiion in the https://github.com/gravitystorm/openstreetmap-carto/pull/472

Shift minimal visible zoom level for village to 11 and to 12 for
hamlets. Set minimal text distance to 30 for villages names at zoom 11.

Switzerland, z11:
![sw-z11](https://cloud.githubusercontent.com/assets/117467/7896902/3c655004-06d1-11e5-8811-d959b70564c4.png)
Switzerland, z12:
![sw-z12](https://cloud.githubusercontent.com/assets/117467/7896901/3c53633a-06d1-11e5-9a43-0e7e877bc9a9.png)
Switzerland, z13:
![sw-z13](https://cloud.githubusercontent.com/assets/117467/7896900/3c51d83a-06d1-11e5-8b00-abbfae13c70e.png)

Belarus, z11:
![bel-z11](https://cloud.githubusercontent.com/assets/117467/7896899/3c4fe084-06d1-11e5-9beb-75eafdc2a0ec.png)
Belarus, z12:
![bel-z12](https://cloud.githubusercontent.com/assets/117467/7896898/3c4dc704-06d1-11e5-9266-4c2ea41260cf.png)
Belarus, z13:
![bel-z13](https://cloud.githubusercontent.com/assets/117467/7896897/3c4cd506-06d1-11e5-89b4-dbdd05983a5f.png)

