### PR TITLE
different rendering for aerialway=goods

### DIFF
--- a/aerialways.mss
+++ b/aerialways.mss
@@ -1,7 +1,6 @@
 #aerialways {
   [aerialway = 'cable_car'],
-  [aerialway = 'gondola'],
-  [aerialway = 'goods'] {
+  [aerialway = 'gondola'] {
     [zoom >= 12] {
       line/line-width: 1;
       line/line-join: round;
@@ -13,6 +12,21 @@
       dash/line-cap: round;
       dash/line-color: black;
       dash/line-dasharray: 0.4,13;
+      dash/line-clip: false;
+    }
+  }
+
+  [aerialway = 'goods'] {
+    [zoom >= 12] {
+      line/line-width: 1;
+      line/line-join: round;
+      line/line-cap: round;
+      line/line-color: #808080;
+
+      dash/line-width: 3.5;
+      dash/line-join: round;
+      dash/line-color: #707070;
+      dash/line-dasharray: 6,25;
       dash/line-clip: false;
     }
   }


### PR DESCRIPTION
Fixes #875.

Symbols are grey instead of black and square instead of rounded. Square vs. round may not be really visible. But since #1612 it will be easier to adjust the pattern in discussion.

preview (right=new) (outdated)
aerialway=goods on the right side vs. other aerialways on the left side of each half.
![aerialway_goods](https://cloud.githubusercontent.com/assets/3531092/8292394/bc3201ae-192f-11e5-8212-140234caa5e5.png)