### PR TITLE
SQL tweaks to improve Mapnik 3 performance for admin areas

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1040,7 +1040,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND NOT ST_Within(!bbox!, way)\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1901,7 +1901,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
+        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n    AND NOT ST_Within(!bbox!, way)\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1927,7 +1927,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND name IS NOT NULL\n) AS nature_reserve_text",
+        "table": "(SELECT\n    way,\n    name,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND name IS NOT NULL\n    AND NOT ST_Within(!bbox!, way)\n) AS nature_reserve_text",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1268,6 +1268,7 @@ Layer:
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
+            AND NOT ST_Within(!bbox!, way)
           ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
@@ -2134,6 +2135,7 @@ Layer:
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
+            AND NOT ST_Within(!bbox!, way)
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:
@@ -2154,6 +2156,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')
             AND name IS NOT NULL
+            AND NOT ST_Within(!bbox!, way)
         ) AS nature_reserve_text
     properties:
       minzoom: 13


### PR DESCRIPTION
Admin areas are labeled on the edges, so those where the bbox lies completely inside can be discarded in SQL


This helps with https://github.com/mapnik/mapnik/issues/2937 and generally slow performance with offsetting of polygons in the latest RC

https://github.com/mapnik/mapnik/issues/2942 prevents turning on clip for now, which would offer gains for nature reserve fill/edge