### PR TITLE
show man_made=bridge

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -44,3 +44,9 @@
     }
   }
 }
+
+#bridge {
+  [zoom >= 12] {
+    polygon-fill: #B8B8B8;
+  }
+}

--- a/project.mml
+++ b/project.mml
@@ -501,6 +501,32 @@
       "advanced": {}
     },
     {
+      "name": "bridge",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "",
+      "id": "bridge",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    man_made,\n    name\n  FROM planet_osm_polygon\n  WHERE man_made = 'bridge'\n) AS bridge",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 12
+      },
+      "advanced": {}
+    },
+    {
       "name": "buildings",
       "srs-name": "900913",
       "geometry": "polygon",
@@ -1555,6 +1581,32 @@
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
         "table": "(SELECT\n    way,\n    highway,\n    junction,\n    ref,\n    name\n  FROM planet_osm_point\n  WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'\n) AS junctions",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 11
+      },
+      "advanced": {}
+    },
+    {
+      "name": "bridge-text",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "",
+      "id": "bridge-text",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    man_made,\n    name\n  FROM planet_osm_polygon\n  WHERE man_made = 'bridge'\n) AS bridge_text",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -415,6 +415,25 @@ Layer:
     properties:
       minzoom: 17
     advanced: {}
+  - id: "bridge"
+    name: "bridge"
+    class: ""
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            man_made,
+            name
+          FROM planet_osm_polygon
+          WHERE man_made = 'bridge'
+        ) AS bridge
+    properties:
+      minzoom: 12
+    advanced: {}
   - id: "buildings"
     name: "buildings"
     class: ""
@@ -1743,6 +1762,25 @@ Layer:
           FROM planet_osm_point
           WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
         ) AS junctions
+    properties:
+      minzoom: 11
+    advanced: {}
+  - id: "bridge-text"
+    name: "bridge-text"
+    class: ""
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            man_made,
+            name
+          FROM planet_osm_polygon
+          WHERE man_made = 'bridge'
+        ) AS bridge_text
     properties:
       minzoom: 11
     advanced: {}

--- a/roads.mss
+++ b/roads.mss
@@ -1974,6 +1974,35 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 }
 
+#bridge-text  {
+  [man_made = 'bridge'] {
+    [zoom >= 12][way_pixels > 4] {
+      text-name: "[name]";
+      text-size: 7;
+      text-fill: black;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: 1;
+      text-halo-fill: rgba(255,255,255,0.6);
+      text-min-distance: 2;
+      text-wrap-width: 30;
+      [way_pixels > 100] {
+        text-size: 9;
+      }
+      [way_pixels > 1000] {
+        text-size: 11;
+        text-halo-radius: 1.5;
+      }
+      [way_pixels > 4000] {
+        text-size: 12;
+      }
+      [way_pixels > 10000] {
+        text-size: 13;
+        text-halo-radius: 2;
+      }
+    }
+  }
+}
+
 .access::fill {
   [access = 'destination'] {
     [feature = 'highway_secondary'],


### PR DESCRIPTION
fixes #436
closes #828 as it is no longer necessary
partially implements #1320 

It adds two new layers - it is avoidable but at cost of complex SQL. I am not fully convinced what would be better idea but avoiding unnecessary complexity is certainly good and I am not sure whatever adding new layers has significant performance impact.

Labelling of bridges may be too agressive, I may be easily convinced to show labels later. 

Done as part of GSoC but may be reviewed independently from road restyling.

It should make one of the most popular tagging for renderer obsolete (bridges as building=* instead of man_made=bridge).

https://cloud.githubusercontent.com/assets/899988/8510890/367f514a-22ff-11e5-98aa-43e9547edf49.png
https://cloud.githubusercontent.com/assets/899988/8510889/367eb276-22ff-11e5-92cb-2f89b4abe799.png
https://cloud.githubusercontent.com/assets/899988/8510892/3680c188-22ff-11e5-9cb7-ca12d3a15660.png
https://cloud.githubusercontent.com/assets/899988/8510891/367fdf2a-22ff-11e5-8a1d-df2fe5f3b02b.png
