### PR TITLE
stop displaying really small zoos and theme parks

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -624,20 +624,23 @@
 }
 
 #tourism-boundary {
-  [tourism = 'zoo'][zoom >= 10],
-  [tourism = 'theme_park'][zoom >= 10] {
+  [tourism = 'zoo'][zoom >= 10][way_pixels >= 20],
+  [tourism = 'theme_park'][zoom >= 10][way_pixels >= 20] {
     a/line-width: 1;
     a/line-offset: -0.5;
     a/line-color: @tourism;
     a/line-opacity: 0.5;
     a/line-join: round;
     a/line-cap: round;
-    b/line-width: 4;
-    b/line-offset: -2;
-    b/line-color: @tourism;
-    b/line-opacity: 0.3;
-    b/line-join: round;
-    b/line-cap: round;
+    [zoom >= 17],
+    [way_pixels >= 60] {
+      b/line-width: 4;
+      b/line-offset: -2;
+      b/line-color: @tourism;
+      b/line-opacity: 0.3;
+      b/line-join: round;
+      b/line-cap: round;    
+    }
     [zoom >= 17] {
       a/line-width: 2;
       a/line-offset: -1;

--- a/project.mml
+++ b/project.mml
@@ -1144,7 +1144,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    tourism\n  FROM planet_osm_polygon\n  WHERE tourism = 'theme_park'\n    OR tourism = 'zoo'\n) AS tourism_boundary",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    tourism\n  FROM planet_osm_polygon\n  WHERE tourism = 'theme_park'\n    OR tourism = 'zoo'\n) AS tourism_boundary",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1336,6 +1336,7 @@ Layer:
       table: |-
         (SELECT
             way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             name,
             tourism
           FROM planet_osm_polygon


### PR DESCRIPTION
![xxx](https://cloud.githubusercontent.com/assets/899988/8512775/c5452906-2352-11e5-826a-96be899a2dee.png)


![selection_003](https://cloud.githubusercontent.com/assets/899988/8512765/1704b8ca-2352-11e5-9ac0-984fd4825f78.png)


Unfortunately I was unable to eliminate weird effect for multypolygon observed in London - only one section receives full border. See http://www.openstreetmap.org/?mlat=51.5391&mlon=-0.1566#map=12/51.5391/-0.1566

![selection_002](https://cloud.githubusercontent.com/assets/899988/8512743/670986e4-2351-11e5-8e8a-20f77a9c8a8d.png)

https://cloud.githubusercontent.com/assets/899988/8512754/97f0c164-2351-11e5-9394-ab665e94e056.png
https://cloud.githubusercontent.com/assets/899988/8512753/97e99128-2351-11e5-82d9-37aec99d8837.png
https://cloud.githubusercontent.com/assets/899988/8512755/97f18c0c-2351-11e5-89b9-2e9d0099ab8c.png
https://cloud.githubusercontent.com/assets/899988/8512750/7bf017f8-2351-11e5-9e42-f8b374387fd8.png
https://cloud.githubusercontent.com/assets/899988/8512751/7bf055ec-2351-11e5-8882-eaed417faa08.png

EDIT: reported also on PL forum - see http://forum.openstreetmap.org/viewtopic.php?pid=514230#p514230