### PR TITLE
rework display of railway=tram

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1572,10 +1572,10 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'railway_tram'] {
       [zoom >= 12] {
-        line-color: #444;
-        line-width: 0.6;
+        line-color: #6E6E6E;
+        line-width: 0.75;
         [zoom >= 13] {
-          line-width: 0.75;
+          line-color: #444;
         }
         [zoom >= 14] {
           line-width: 1;

--- a/roads.mss
+++ b/roads.mss
@@ -1571,12 +1571,16 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'railway_tram'] {
-      [zoom >= 8] {
-        line-color: #ccc;
-        [zoom >= 10] { line-color: #aaa; }
-        [zoom >= 13] { line-color: #444; }
-        line-width: 1;
+      [zoom >= 12] {
+        line-color: #444;
+        line-width: 0.75;
+        [zoom >= 14] {
+          line-width: 1;
+        }
         [zoom >= 15] {
+          line-width: 1.5;
+        }
+        [zoom >= 17] {
           line-width: 2;
         }
         .tunnels-fill {

--- a/roads.mss
+++ b/roads.mss
@@ -1573,7 +1573,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'railway_tram'] {
       [zoom >= 12] {
         line-color: #444;
-        line-width: 0.4;
+        line-width: 0.55;
         [zoom >= 13] {
           line-width: 0.75;
         }

--- a/roads.mss
+++ b/roads.mss
@@ -1573,7 +1573,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'railway_tram'] {
       [zoom >= 12] {
         line-color: #444;
-        line-width: 0.55;
+        line-width: 0.6;
         [zoom >= 13] {
           line-width: 0.75;
         }

--- a/roads.mss
+++ b/roads.mss
@@ -1573,7 +1573,10 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'railway_tram'] {
       [zoom >= 12] {
         line-color: #444;
-        line-width: 0.75;
+        line-width: 0.4;
+        [zoom >= 13] {
+          line-width: 0.75;
+        }
         [zoom >= 14] {
           line-width: 1;
         }


### PR DESCRIPTION
dropped invisible clutter from z8 to z11
visible railway=tram on z12
subtler at z13, z15, z16

fixes #1637


https://cloud.githubusercontent.com/assets/899988/8548012/b85467c2-24c2-11e5-92d5-2890be60ade0.png