### PR TITLE
start displaying minor rail from z13, fixes #1645

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1472,7 +1472,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'railway_rail'][zoom >= 7],
-    [feature = 'railway_INT-spur-siding-yard'][zoom >= 11] {
+    [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
       [zoom < 13] {
         line-color: #aaa;
         [feature = 'railway_rail'] {


### PR DESCRIPTION
small changes:

https://cloud.githubusercontent.com/assets/899988/8616741/f99326a0-26fd-11e5-9f0e-cd2c1a939a74.png
https://cloud.githubusercontent.com/assets/899988/8616743/f994ba6a-26fd-11e5-8698-77c3bbe7c85b.png
https://cloud.githubusercontent.com/assets/899988/8616742/f9944738-26fd-11e5-8b82-b2a14779a233.png
https://cloud.githubusercontent.com/assets/899988/8616745/f998f2f6-26fd-11e5-9c05-54c9c2d5cd73.png
https://cloud.githubusercontent.com/assets/899988/8616922/5d0a2494-26ff-11e5-9558-072ba1bae43a.png

big changes in rendering:

https://cloud.githubusercontent.com/assets/899988/8604275/ddaa6460-267d-11e5-8899-9e5f76b1b435.png
https://cloud.githubusercontent.com/assets/899988/8616915/5143aa5e-26ff-11e5-86f4-107fd33e7fb6.png
https://cloud.githubusercontent.com/assets/899988/8616746/f99ee314-26fd-11e5-9207-863603b6b60d.png

@kocio-pl 

> I was not convinced after just reading the description, but images show me it really works.

Yet another good reason to attach before/after images :)

@dieterdreist 

> I like the current rendering, it gives a good sense how much space is taken up by railway infrastructure, and where/which shape/direction. The color makes it intuitive to understand.

"how much space" is also visible thanks to landuse. Yes, industrial and railway is the same but z11 and z12 is extremely busy and something should be removed from these zoom levels. Shape/direction is for me not really clear as rails merge in one blob. I think that it is rather improved when only main rails are as it makes them distinguishable from other features.