### PR TITLE
render educational areas as distinct later - fixes #1660

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -477,10 +477,13 @@
   [feature = 'amenity_hospital'],
   [feature = 'amenity_kindergarten'] {
     [zoom >= 10] {
-      polygon-fill: @school;
+      polygon-fill: @residential;
       [zoom >= 12] {
-        line-width: 0.3;
-        line-color: brown;
+        polygon-fill: @school;
+        [zoom >= 13] {
+          line-width: 0.3;
+          line-color: brown;
+        }
       }
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }


### PR DESCRIPTION
I think that rendering borders at z12 makes no sense - as are mostly hidden under other features and small present fragments are not really useful. For example UBC at z12 has visible only small triangle

![aaaa](https://cloud.githubusercontent.com/assets/899988/8718599/d80b337c-2ba5-11e5-8068-03e586facfdc.png)

At z10 and z11 even the biggest educational areas are quite small and a separate colour fill makes no sense. Even at z12 value of it is dubious.

https://cloud.githubusercontent.com/assets/899988/8718499/155e1dbc-2ba5-11e5-8400-1ff230630ab0.png
https://cloud.githubusercontent.com/assets/899988/8718500/1563519c-2ba5-11e5-94b7-3a1b7194a42e.png
https://cloud.githubusercontent.com/assets/899988/8718501/15674edc-2ba5-11e5-97a2-d51f484a207b.png
https://cloud.githubusercontent.com/assets/899988/8718502/156797c0-2ba5-11e5-8939-afd2721f8d87.png

with one of test versions of the new road style

https://cloud.githubusercontent.com/assets/899988/8718503/1a70020c-2ba5-11e5-867e-8aaf535e2682.png
https://cloud.githubusercontent.com/assets/899988/8718505/1a788526-2ba5-11e5-9b3d-13743256c3c6.png
https://cloud.githubusercontent.com/assets/899988/8718504/1a7757fa-2ba5-11e5-851e-70b018b3c373.png
https://cloud.githubusercontent.com/assets/899988/8718506/1a943686-2ba5-11e5-894e-eb1bfd5b75c9.png

Thanks to @pnorman for a big educational area in well mapped place.