### PR TITLE
Added support for rendering flat numbers in addr:flats

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -6,6 +6,18 @@
   }
 }
 
+#flatnumbers {
+  [zoom >= 17] {
+    text-name: "[addr:flats]";
+    text-placement: interior;
+    text-min-distance: 1;
+    text-wrap-width: 0;
+    text-face-name: @book-fonts;
+    text-fill: #666;
+    text-size: 8;
+  }
+}
+
 #housenumbers {
   [zoom >= 17] {
     text-name: "[addr:housenumber]";

--- a/openstreetmap-carto.style
+++ b/openstreetmap-carto.style
@@ -3,6 +3,7 @@
 
 # OsmType  Tag          DataType     Flags
 node,way   access       text         linear
+node,way   addr:flats   text         linear
 node,way   addr:housename      text  linear
 node,way   addr:housenumber    text  linear
 node,way   addr:interpolation  text  linear

--- a/project.mml
+++ b/project.mml
@@ -1789,6 +1789,32 @@
       "advanced": {}
     },
     {
+      "name": "flatnumbers",
+      "srs-name": "900913",
+      "geometry": "point",
+      "class": "",
+      "id": "flatnumbers",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    \"addr:flats\",\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:flats\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:flats\",\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE \"addr:flats\" IS NOT NULL\n  ORDER BY way_pixels DESC NULLS LAST\n) AS flatnumbers",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 17
+      },
+      "advanced": {}
+    },
+    {
       "name": "housenumbers",
       "srs-name": "900913",
       "geometry": "point",

--- a/project.yaml
+++ b/project.yaml
@@ -2024,6 +2024,33 @@ Layer:
     properties:
       minzoom: 17
     advanced: {}
+  - id: "flatnumbers"
+    name: "flatnumbers"
+    class: ""
+    geometry: "point"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            "addr:flats",
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
+          FROM planet_osm_polygon
+          WHERE "addr:flats" IS NOT NULL
+            AND building IS NOT NULL
+        UNION ALL
+        SELECT
+            way,
+            "addr:flats",
+            NULL AS way_pixels
+          FROM planet_osm_point
+          WHERE "addr:flats" IS NOT NULL
+          ORDER BY way_pixels DESC NULLS LAST
+        ) AS flatnumbers
+    properties:
+      minzoom: 17
+    advanced: {}
   - id: "housenumbers"
     name: "housenumbers"
     class: ""


### PR DESCRIPTION
This patch adds support for rendering addr:flats instead of addr:housename - which makes a lot of sense if you see things like:

![before](http://derickrethans.nl/rst/images/flatnr-before.png)

The nodes all have addr:flats, addr:housename and addr:street - but the housename shows up 20 times or so.

With this patch, it renders like:

![after](http://derickrethans.nl/rst/images/flatnr-after.png)

I've made the number one point smaller than real house numbers, but I'm happy to have it render differently - just thought it would be nice that it shows up. It makes a lot of sense in this area as there are *so* many instances. Annoyingly, it requires a new column in the database.
