### PR TITLE
Start rendering of minor roads later

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -10,7 +10,7 @@
 
 
 #buildings {
-  [zoom >= 12] {
+  [zoom >= 13] {
     polygon-fill: @building-low-zoom;
     polygon-clip: false;
     [zoom >= 15] {
@@ -23,7 +23,7 @@
 }
 
 #buildings-major {
-  [zoom >= 12] {
+  [zoom >= 13] {
     [aeroway = 'terminal'] {
       polygon-fill: @building-aeroway-fill;
       polygon-clip: false;

--- a/landcover.mss
+++ b/landcover.mss
@@ -153,7 +153,7 @@
     }
   }
 
-  [feature = 'amenity_place_of_worship'] {
+  [feature = 'amenity_place_of_worship'][zoom >= 13] {
     polygon-fill: @place_of_worship;
     polygon-clip: false;
     [zoom >= 15] {

--- a/roads.mss
+++ b/roads.mss
@@ -1094,7 +1094,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_residential'],
     [feature = 'highway_unclassified'] {
-      [zoom >= 10][feature = 'highway_unclassified'] {
+      [zoom >= 11][feature = 'highway_unclassified'] {
         line-color: @residential-casing;
         line-width: 1;
       }

--- a/roads.mss
+++ b/roads.mss
@@ -1094,7 +1094,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_residential'],
     [feature = 'highway_unclassified'] {
-      [zoom >= 10] {
+      [zoom >= 10][feature = 'highway_unclassified'] {
         line-color: @residential-casing;
         line-width: 1;
       }
@@ -1159,10 +1159,6 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_living_street'] {
-      [zoom >= 12] {
-        line-color: @residential-casing;
-        line-width: 1;
-      }
       [zoom >= 13] {
         line-width: @living-street-width-z13 - 2 * @casing-width-z13;
         [zoom >= 14] { line-width: @living-street-width-z14 - 2 * @casing-width-z14; }


### PR DESCRIPTION
Currently both highway=residential and highway=unclassified is rendered too early, leading to clutter on the map and poor display of available data. 

Default maps style vs Google maps in London
![](http://i.imgur.com/VGdzyVW.png)

Default OSM style should not only show how many roads are mapped, it should also demonstrate that OSM data is able to distinguish minor and major roads.

before/after images

Large city (London)
550px: https://cloud.githubusercontent.com/assets/899988/8889566/8a5fa04a-32df-11e5-9d62-2d8dac82f958.png
1000px: http://www.mediafire.com/convkey/84d9/3v26frfg92zwaw7zg.jpg

Rural area in forested mountains (Slovakia)
550px: https://cloud.githubusercontent.com/assets/899988/8889567/924ec628-32df-11e5-8a37-f05be0cfb414.png
1000px: https://cloud.githubusercontent.com/assets/899988/8889568/9729bce8-32df-11e5-8a78-41314d403b20.png

Medium-sized city (Kraków)
550px: https://cloud.githubusercontent.com/assets/899988/8889569/9d8fc8f2-32df-11e5-8cbd-32e8a3357126.png
1000px: https://cloud.githubusercontent.com/assets/899988/8889571/a30e9632-32df-11e5-996d-4a5b636ae534.png

Ceasing to render highway=residential on zoom levels 12 makes noise created by small buildings noticeable. These buildings are too small to be rendered in useful way but big enough to create noticeable changes.

![](http://i.imgur.com/rtrsloV.png)

I hoped that arbitrary cutoffs (show buildings larger than x pixels) will be solution to remove noise and show big buildings that still may be usefully displayed but it failed. No matter what threshold was used it either failed to stop noise (too small buildings from appearing in some areas) or it was obvious that one building was not displayed despite fact that nearly the same next to it was displayed (one was slightly larger with size greater than threshold)

At z12 there are some buildings worth displaying - for example http://www.openstreetmap.org/?mlat=33.3097&mlon=44.3892#map=12/33.3097/44.3892 or http://www.openstreetmap.org/?mlat=33.6634&mlon=73.0289#map=12/33.6634/73.0289 http://www.openstreetmap.org/?mlat=39.8988&mlon=116.3123#map=12/39.8988/116.3123 or http://www.openstreetmap.org/?mlat=39.8762&mlon=32.9301#map=12/39.8762/32.9301 or http://www.openstreetmap.org/?mlat=35.7057&mlon=51.3261#map=12/35.7057/51.3261 (OK, this one may be tagging error)

Maybe it would be a good idea to display only major buildings, but as currently it is limited to PoW it would be rather poor selection. And even then to achieve good results it would be necessary to filter out small buildings what is causing already desribed problems.

Therefore I think that of all solutions (show all buildings, show buildings larger than x pixels, show only major buildings larger than x pixels, show no buildings) for z12 the last one is the best.

Stopping to display buildings makes noticeable other effect - scattered small, many in subpixel sized amenity=place_of_worship. Especially polygons [building=*; amenity=place_of_worship] ones big enough to be noticeable cause weird effect - small gray areas on z12 turning into brown areas on zooming it. Therefore also PoW are rendered from z13.

before/after images (minor roads rendered later compared with minor roads, buildings, PoW rendered later)

Large city (London)
550px: https://cloud.githubusercontent.com/assets/899988/8889598/d262439c-32e0-11e5-9551-f4ae0e7335fd.png
1000px: https://cloud.githubusercontent.com/assets/899988/8889622/21ce834a-32e2-11e5-8f43-2f630f6efb81.png


Rural area in forested mountains (Slovakia)
550px: https://cloud.githubusercontent.com/assets/899988/8889600/d883daa6-32e0-11e5-87c9-62c70bd87d22.png
1000px: https://cloud.githubusercontent.com/assets/899988/8889623/254fa864-32e2-11e5-83fc-d77b0da652ef.png


Medium-sized city (Kraków)
550px: https://cloud.githubusercontent.com/assets/899988/8889631/8ad1067e-32e2-11e5-9dbd-6b5f7f692f5a.png
1000px: https://cloud.githubusercontent.com/assets/899988/8889621/1e2589f0-32e2-11e5-9ea3-b3525dcc4408.png



I am aware that it will make map display worse in areas where only roads and largest buildings is mapped and most other features (especially landuse and minor buildings) are not mapped without that change mapping small building makes map worse on z12

I am aware that some people like noise display of highway=residential and minor buildings on z12, but I think that overall opinion is that relying on landuse=residential to display residential landuse on lower zoom levels.

From other now (more) noticeable problems - see #1679, it may be better to display landuse=commercial/retail like landuse=residential as in most places these areas are too small for individual colors, value of displaying amenity=parking areas from z10 is dubious... But it is visible because even worse problem was removed and tuning everything in this PR seems to be a poor idea (except the worst issues, and I think that building=* noise on z12 is the only one that qualifies).

Effect of this change depends on location.

It should not make map worse in areas with low density of features. It may map a bit worse near poles, as due to different scale highway=unclassified may be introduced zoom level later. It highly improves rendering in cities.

In addition effect of this change depends on quality of mapping. In places with mapped roads and unmapped landuse it will map display worse until landuse is mapped (what I am considering as a good change). In places with both landuse and roads it will improve map.

This change will also reveal highway=residential misused to tag roads between settlements and ways where residential/unclassified alternates on the same road. 