### PR TITLE
rework living street and pedestrian

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -8,8 +8,8 @@
 @tertiary-fill: #f8f8ba;
 @residential-fill: #ffffff;
 @service-fill: @residential-fill;
-@living-street-fill: #ccc;
-@pedestrian-fill: #ededed;
+@living-street-fill: #ededed;
+@pedestrian-fill: #efdfe2;
 @raceway-fill: pink;
 @road-fill: #ddd;
 @path-fill: black;
@@ -31,8 +31,8 @@
 @tertiary-casing: #c6c68a;
 @residential-casing: #bbb;
 @service-casing: @residential-casing;
-@living-street-casing: #999;
-@pedestrian-casing: @residential-casing;
+@living-street-casing: @residential-casing;
+@pedestrian-casing: #999;
 @path-casing: @default-casing;
 @footway-casing: @default-casing;
 @steps-casing: @default-casing;
@@ -56,6 +56,7 @@
 @tertiary-tunnel-fill: lighten(@tertiary-fill, 5%);
 @residential-tunnel-fill: darken(@residential-fill, 5%);
 @living-street-tunnel-fill: lighten(@living-street-fill, 10%);
+@pedestrian-tunnel-fill: #EFE3E6;
 
 @motorway-width-z12:              3.5;
 @motorway-link-width-z12:         1.5;
@@ -1232,6 +1233,9 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 16] { line-width: @pedestrian-width-z16 - 2 * @casing-width-z16; }
         [zoom >= 17] { line-width: @pedestrian-width-z17 - 2 * @casing-width-z17; }
         line-color: @pedestrian-fill;
+        .tunnels-fill {
+          line-color: @pedestrian-tunnel-fill;
+        }
         .bridges-fill {
           line-width: @pedestrian-width-z13 - 2 * @casing-width-z13;
           [zoom >= 14] { line-width: @pedestrian-width-z14 - 2 * @bridge-casing-width-z14; }
@@ -1839,11 +1843,24 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 
+  [feature = 'highway_living_street'] {
+    [zoom >= 14] {
+      line-color: @living-street-casing;
+      line-width: 1;
+    }
+  }
+
   [feature = 'highway_pedestrian'],
-  [feature = 'highway_service'],
   [feature = 'highway_footway'],
   [feature = 'highway_cycleway'],
   [feature = 'highway_path'] {
+    [zoom >= 14] {
+      line-color: @pedestrian-casing;
+      line-width: 1;
+    }
+  }
+
+  [feature = 'highway_service'] {
     [zoom >= 14] {
       line-color: grey;
       line-width: 1;
@@ -1871,7 +1888,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
 #highway-area-fill {
   [feature = 'highway_living_street'][zoom >= 14] {
-    polygon-fill: #ccc;
+    polygon-fill: @living-street-fill;
   }
 
   [feature = 'highway_residential'],
@@ -1887,7 +1904,7 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
   [feature = 'highway_cycleway'],
   [feature = 'highway_path'] {
     [zoom >= 14] {
-      polygon-fill: #ededed;
+      polygon-fill: @pedestrian-fill;
     }
   }
 


### PR DESCRIPTION
highway=living_street is now closer to normal roads, rather than completely different (more than highway=pedestrian)
make highway=pedestrian pinkish to make it different from other roads (it is better than rather ugly old colour for living street)

In addition, on lower zooms living street is less visible on landuse=residential what is also beneficial - previously it was more visible than more important highway=residential.

New reddish highway=pedestrian is now closer to highway=footway than before what is a good think but also closer to highway=primary what is a bad thing. But it is also more distanced from other road types, especially highway=residential/unclassified/road.

![selection_001](https://cloud.githubusercontent.com/assets/899988/8890344/769b6192-32fe-11e5-8ade-2ded9c3cf625.png)

It is slightly better with red used for more important road than highway=primary but I think that it is also clear improvement independently from other GSoC changes.

https://cloud.githubusercontent.com/assets/899988/8890346/7b32c3d0-32fe-11e5-84fe-ebe29083cc41.png
https://cloud.githubusercontent.com/assets/899988/8890349/7b720a9a-32fe-11e5-8b86-a023b8b23c12.png
https://cloud.githubusercontent.com/assets/899988/8890348/7b714d58-32fe-11e5-99b2-0b1bfffc3326.png
https://cloud.githubusercontent.com/assets/899988/8890352/7b73d726-32fe-11e5-947c-482e2fe39b51.png
https://cloud.githubusercontent.com/assets/899988/8890350/7b729b7c-32fe-11e5-9bc5-ce1b5cd7e7bd.png
https://cloud.githubusercontent.com/assets/899988/8890351/7b730a9e-32fe-11e5-99d6-9705c490034b.png
https://cloud.githubusercontent.com/assets/899988/8890347/7b52e2be-32fe-11e5-9eca-33663cc36829.png
https://cloud.githubusercontent.com/assets/899988/8890353/7b8f0366-32fe-11e5-9d77-b17e1751c728.png
https://cloud.githubusercontent.com/assets/899988/8890354/7b9136b8-32fe-11e5-8fdb-cfd327162d00.png
https://cloud.githubusercontent.com/assets/899988/8890355/7b925be2-32fe-11e5-8334-4763d8831c29.png
https://cloud.githubusercontent.com/assets/899988/8890356/7b93362a-32fe-11e5-98f5-9fca6a308e1f.png
