### PR TITLE
Order place layers by place type

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1222,7 +1222,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    place,\n    name,\n    ref\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND capital IN ('yes', '4')\n    AND name IS NOT NULL\n) AS placenames_capital",
+        "table": "(SELECT\n    way,\n    place,\n    name,\n    ref\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND capital IN ('yes', '4')\n    AND name IS NOT NULL\n  ORDER BY CASE\n      WHEN place = 'city' THEN 1\n      WHEN place = 'town' THEN 2\n    END ASC\n) AS placenames_capital",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1249,7 +1249,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    place,\n    name\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND (capital IS NULL OR capital NOT IN ('yes', '4'))\n    AND name IS NOT NULL\n) AS placenames_medium",
+        "table": "(SELECT\n    way,\n    place,\n    name\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND (capital IS NULL OR capital NOT IN ('yes', '4'))\n    AND name IS NOT NULL\n  ORDER BY CASE\n      WHEN place = 'city' THEN 1\n      WHEN place = 'town' THEN 2\n    END ASC\n) AS placenames_medium",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1275,7 +1275,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    place,\n    name\n  FROM planet_osm_point\n  WHERE place IN ('suburb', 'village', 'hamlet', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')\n    AND name IS NOT NULL\n) AS placenames_small",
+        "table": "(SELECT\n    way,\n    place,\n    name\n  FROM planet_osm_point\n  WHERE place IN ('suburb', 'village', 'hamlet', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')\n    AND name IS NOT NULL\n  ORDER BY CASE\n      WHEN place = 'suburb' THEN 3\n      WHEN place = 'village' THEN 4\n      WHEN place = 'hamlet' THEN 5\n      WHEN place = 'neighbourhood' THEN 6\n      WHEN place = 'locality' THEN 7\n      WHEN place = 'isolated_dwelling' THEN 8\n      WHEN place = 'farm' THEN 9\n    END ASC\n) AS placenames_small",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1388,6 +1388,10 @@ Layer:
           WHERE place IN ('city', 'town')
             AND capital IN ('yes', '4')
             AND name IS NOT NULL
+          ORDER BY CASE
+              WHEN place = 'city' THEN 1
+              WHEN place = 'town' THEN 2
+            END ASC
         ) AS placenames_capital
     properties:
       minzoom: 5
@@ -1409,6 +1413,10 @@ Layer:
           WHERE place IN ('city', 'town')
             AND (capital IS NULL OR capital NOT IN ('yes', '4'))
             AND name IS NOT NULL
+          ORDER BY CASE
+              WHEN place = 'city' THEN 1
+              WHEN place = 'town' THEN 2
+            END ASC
         ) AS placenames_medium
     properties:
       minzoom: 6
@@ -1428,6 +1436,15 @@ Layer:
           FROM planet_osm_point
           WHERE place IN ('suburb', 'village', 'hamlet', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
             AND name IS NOT NULL
+          ORDER BY CASE
+              WHEN place = 'suburb' THEN 3
+              WHEN place = 'village' THEN 4
+              WHEN place = 'hamlet' THEN 5
+              WHEN place = 'neighbourhood' THEN 6
+              WHEN place = 'locality' THEN 7
+              WHEN place = 'isolated_dwelling' THEN 8
+              WHEN place = 'farm' THEN 9
+            END ASC
         ) AS placenames_small
     properties:
       minzoom: 12


### PR DESCRIPTION
The unordered layers were leading to artifacts on MT boundaries, and oddities where towns were rendered on top of cities.

Similar to #1461, but does not adjust low zoom or go as far.