### PR TITLE
make highway=residential at z12 thinner

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1097,7 +1097,11 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_residential'],
     [feature = 'highway_unclassified'] {
-      [zoom >= 12] {
+      [zoom >= 12][feature = 'highway_residential'] {
+        line-color: @residential-casing;
+        line-width: 0.4;
+      }
+      [zoom >= 12][feature = 'highway_unclassified'] {
         line-color: @residential-casing;
         line-width: 1;
       }


### PR DESCRIPTION
to prevent potential confusion:
In version currently used on OSM website both highway=unclassified and highway=residential are rendered from z10.
#1682 proposed rendering highway=unclassified from z11 and highway=residential from z12
@pnorman merged this pull requested and added commit https://github.com/gravitystorm/openstreetmap-carto/commit/93789b6bac94e7c13bae6fb4a6d8ee7df02aaf3f - that set both unclassified and residential to render from z12

This pull requests makes highway=residential thinner (0.4 width instead of 1.0).

550px preview:
https://cloud.githubusercontent.com/assets/899988/8900694/d49ea19c-3442-11e5-86b6-07d6d5c8f12d.png
https://cloud.githubusercontent.com/assets/899988/8900696/d4a387b6-3442-11e5-851c-09b88a3eebd6.png
https://cloud.githubusercontent.com/assets/899988/8900695/d4a36178-3442-11e5-8f36-4688f1bc099d.png
https://cloud.githubusercontent.com/assets/899988/8900697/d4a3bd12-3442-11e5-8e52-b906a01805a2.png
https://cloud.githubusercontent.com/assets/899988/8900698/d4a665da-3442-11e5-9a25-0d239a2e9562.png

1000px preview:
https://cloud.githubusercontent.com/assets/899988/8900701/d7e785c6-3442-11e5-9d4e-ddaf5129ab71.png
https://cloud.githubusercontent.com/assets/899988/8900700/d7e71c58-3442-11e5-93d5-31326264d8e7.png
https://cloud.githubusercontent.com/assets/899988/8900702/d7e8c5da-3442-11e5-8554-0f790e7cdf96.png
https://cloud.githubusercontent.com/assets/899988/8900703/d7ea547c-3442-11e5-8b55-ba3b2ed7f6cc.png
https://cloud.githubusercontent.com/assets/899988/8900704/d7eed4e8-3442-11e5-9fb3-737b30de0af2.png
