### PR TITLE
fixed display of residential and unclassified roads at z13

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1097,11 +1097,11 @@ residential is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_residential'],
     [feature = 'highway_unclassified'] {
-      [zoom >= 12][feature = 'highway_residential'] {
+      [zoom = 12][feature = 'highway_residential'] {
         line-color: @residential-casing;
         line-width: 0.4;
       }
-      [zoom >= 12][feature = 'highway_unclassified'] {
+      [zoom = 12][feature = 'highway_unclassified'] {
         line-color: @residential-casing;
         line-width: 1;
       }


### PR DESCRIPTION
After recent changes to residential/unclassified a regression appeared. On z13 these roads turned grey what was neither wanted nor expected.

I found (very ugly) change that fixes that problem, but unfortunately I have no idea why rendering at z13 was affected by these changes and why this PR fixes problem.

It would be preferable to solve it properly.

These definitions are affecting

> #roads-low-zoom[zoom < 10],
> .roads-fill[zoom >= 10],
> .bridges-fill[zoom >= 10],
> .tunnels-fill[zoom >= 10] {


> #roads-low-zoom[zoom < 10]

problem happened on z13, so [zoom < 10] is a good alibi

.roads-fill[zoom >= 10], 
.bridges-fill[zoom >= 10],

>        .roads-fill, .bridges-fill {
>          line-color: @residential-fill;
>        }

should override gray color for these two layers


>        .tunnels-fill {
>          line-color: @residential-tunnel-fill;
>         }

this should handle .tunnels-fill

Overall I have no idea what caused this problem. See https://github.com/gravitystorm/openstreetmap-carto/blob/4b087d2435d6fbac46203e8b693a94d45ee16399/roads.mss#L1133 that works and https://github.com/gravitystorm/openstreetmap-carto/blob/1397a58d419f28acafc3ba8c5947a91cfae6cbd9/roads.mss#L1098 that glitches.

It is possible that it is triggering a bug in Carto (see for example https://github.com/mapbox/carto/issues/351).

before/after

https://cloud.githubusercontent.com/assets/899988/8928844/698ed914-3521-11e5-9511-764337d6943a.png
https://cloud.githubusercontent.com/assets/899988/8928845/69916bc0-3521-11e5-99a6-46ec80561777.png

before/after across 4-20
https://cloud.githubusercontent.com/assets/899988/8928902/cdacc186-3521-11e5-8037-b4e79f315601.png
https://cloud.githubusercontent.com/assets/899988/8928903/cdd5d4f4-3521-11e5-9d07-9f3cf05c6d75.png
