### PR TITLE
new farmland color - makes farmland less prominent

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -26,8 +26,8 @@
 @industrial-line: #C6B3C3;  // Lch(75,11,330)
 @railway: @industrial;
 @railway-line: @industrial-line;
-@farmland: #EDDDC9;         // Lch(89,12,80) (Also used for farm)
-@farmland-line: #C8B69E;    // Lch(75,15,80)
+@farmland: #fbecd7;         // Lch(94,12,80) (Also used for farm)
+@farmland-line: #d6c4ab;    // Lch(80,15,80)
 
 @farmyard: #EFD6B5;         // Lch(87,20,80)
 @farmyard-line: #D1B48C;    // Lch(75,25,80)


### PR DESCRIPTION
![new_farmland](https://cloud.githubusercontent.com/assets/899988/8958274/30488176-3604-11e5-9dac-16e906fe29f9.png)

Currently mapping landuse=farmland in most locations results in worse and less readable map. It is caused by too strong color and large size of landuse=farmland areas. In result it is frequently the most noticeable (or at least one of the most noticeable) features. Frequently it is more prominent than far more important features like villages or towns. There is also problem of residential, industrial, farmyard and other landuses not visible enough in sea of landuse=farmland. This problem is larger than implied by color difference computations due to differences in size of typical landuses and distribution of obscuring features. Density of buildings, names, roads etc are significantly higher on landuse=residential/industrial etc than on landuse=farmland.

All distances are in delta_e94 metric, as compute by color gem for ruby. Following data describes how close colors for current (first entry) or potential (next) are close to other landcovers. It is preferable to keep this values high to make landcovers differentiable. Colors rejected on grounds of clearly too small color differences or resulting in an ugly map were omitted from list below.

current style - lch(89, 12, 80)
landuse=garages: 4.55
foreground of @bare_ground: 4.84
landuse=farmyard: 5.45
amenity=prison hatches: 6.25
/////
natural=sand: 6.48
unmapped land: 8.05


farmland lch(91, 12, 80)
foreground of @bare_ground: 4.13
landuse=garages: 5.39
natural=sand: 5.64
aeroway=aerodrome: 6.18
/////
unmapped land: 6.72

farmland lch(93, 12, 80)
foreground of @bare_grounde: 4.65
natural=sand: 5.11
hospital/educational area: 5.27
/////
unmapped land: 6.07

farmland lch(94, 12, 80)
hospital/educational area: 4.85
foreground of @bare_ground: 5.02
natural=sand: 5.23
unmapped land: 5.8

farmland imagico #1
foreground of @bare_ground: 3.92
landuse=garages: 4.45
amenity=prison hatches: 5.72
aeroway=aerodrome: 5.92
/////
natural=sand: 6.13
unmapped land: 6.86

farmland imagico #2
natural=sand: 4.02
landuse=garages: 4.48
hospital/educational area: 4.49
foreground of @bare_ground: 5.18
/////
unmapped land: 7.16

farmland imagico #3
natural=sand: 3.47
hospital/educational area: 3.85
landuse=garages: 5.7
leisure=nature_reserve border: 6.09
/////
unmapped land: 8.31

raw data for distances: https://gist.github.com/matkoniecz/3d59bfde1aefb75a6596

Overall lch(94, 12, 80) [#fbecd7] was the most promising. In my tests it was an improvement - farmland is no longer so dominating. It is quite bright what may be not liked by some - but it also makes features on it more visible. Areas of other landuses neighbouring with farmland are now more visible.

https://cloud.githubusercontent.com/assets/899988/8958284/3962b8bc-3604-11e5-80b1-abe95e6ab0e8.png
https://cloud.githubusercontent.com/assets/899988/8958283/3962b934-3604-11e5-8ccf-1b5d18600e18.png
https://cloud.githubusercontent.com/assets/899988/8958285/3965307e-3604-11e5-9752-61f51d933d1d.png
https://cloud.githubusercontent.com/assets/899988/8958286/396ccb72-3604-11e5-81d6-a7839518307d.png
https://cloud.githubusercontent.com/assets/899988/8958287/396e5dd4-3604-11e5-8f65-e2860b756007.png
