### PR TITLE
consider airport size in rendering decisions

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -16,6 +16,8 @@
 @landcover-wrap-width-size-bigger: 45;
 @landcover-face-name: @oblique-fonts;
 
+@max-labeling-area-in-pixels: 900000;
+
 @standard-wrap-width: 30;
 
 /* Note that .points is also used in water-features.mss */
@@ -873,7 +875,9 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome'][zoom >= 10][zoom < 14] {
+  [feature = 'aeroway_aerodrome'][zoom >= 14][way_pixels < @max-labeling-area-in-pixels],
+  [feature = 'aeroway_aerodrome'][zoom >= 14][way_pixels = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 10][way_pixels > 5][way_pixels < @max-labeling-area-in-pixels] {
     marker-file: url('symbols/aerodrome.svg');
     marker-placement: interior;
     marker-clip: false;
@@ -1024,10 +1028,10 @@
 /* Note that .text is also used in water.mss */
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
-  [feature = 'place_island'][zoom >= 7][way_pixels > 3000][way_pixels < 800000],
-  [feature = 'place_island'][zoom >= 16][way_pixels < 800000],
-  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000][way_pixels < 800000],
-  [feature = 'place_islet'][zoom >= 17][way_pixels < 800000] {
+  [feature = 'place_island'][zoom >= 7][way_pixels > 3000][way_pixels < @max-labeling-area-in-pixels],
+  [feature = 'place_island'][zoom >= 16][way_pixels < @max-labeling-area-in-pixels],
+  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000][way_pixels < @max-labeling-area-in-pixels],
+  [feature = 'place_islet'][zoom >= 17][way_pixels < @max-labeling-area-in-pixels] {
     text-name: "[name]";
     text-fill: #000;
     text-size: 10;
@@ -2242,7 +2246,9 @@
     text-wrap-width: @standard-wrap-width;
   }
 
-  [feature = 'aeroway_aerodrome'][zoom >= 10][zoom < 14] {
+  [feature = 'aeroway_aerodrome'][zoom >= 14][way_pixels < @max-labeling-area-in-pixels],
+  [feature = 'aeroway_aerodrome'][zoom >= 14][way_pixels = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 10][way_pixels > 5][way_pixels < @max-labeling-area-in-pixels] {
     text-name: "[name]";
     text-size: 8;
     text-fill: darken(@airtransport, 15%);


### PR DESCRIPTION
consider airport size in rendering decision, includes mall change to island label rendering

small airports are rendered later, small and medium airports are not losing labels too early
fixes #1143

![world z 10 10 _ master -_ airport-unify 39 6316 -86 0889 10 10 master - airport-unify 250px](https://cloud.githubusercontent.com/assets/899988/9156854/a055faa6-3ee8-11e5-963c-c46540164938.png)

https://cloud.githubusercontent.com/assets/899988/9156855/a24e9d86-3ee8-11e5-9cd8-c2bb1290cf98.png
https://cloud.githubusercontent.com/assets/899988/9156857/a273b5da-3ee8-11e5-8303-813d9d4c95ef.png
https://cloud.githubusercontent.com/assets/899988/9156858/a276731a-3ee8-11e5-89d9-a6827dcf4d12.png
https://cloud.githubusercontent.com/assets/899988/9156860/a277224c-3ee8-11e5-8b3f-6bd158a9d9e0.png
https://cloud.githubusercontent.com/assets/899988/9156859/a276d4b8-3ee8-11e5-90f9-335d131d9d8d.png
https://cloud.githubusercontent.com/assets/899988/9156856/a266fa16-3ee8-11e5-9587-476a198c77e8.png
