### PR TITLE
fix outdated comment

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -852,7 +852,7 @@
 /* Data on z<10 comes from osm_planet_roads, data on z>=10 comes from
 osm_planet_line. This is for performance reasons: osm_planet_roads contains less
 data, and is thus faster. Chosen is for zoom level 10 as cut-off, because
-residential is rendered from z10 and is not included in osm_planet_roads. */
+tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #roads-low-zoom[zoom < 10],
 .roads-fill[zoom >= 10],


### PR DESCRIPTION
It affects also current version. Residential now appears from z12. I am not 100% sure what will be in osm_planet_roads - link in http://gis.stackexchange.com/questions/37099/in-osm2pgsql-how-is-the-planet-osm-roads-table-populated/84913#84913 is dead (@pnorman, maybe you can update it?). According to my check tertiary is not appearing in osm_planet_roads (at least it happens this way for my local databases) and it is rendered from z10.