### PR TITLE
Changing color of hunting_stand to brown

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -938,7 +938,7 @@
 
   [feature = 'amenity_hunting_stand'][zoom >= 16] {
     marker-file: url('symbols/hunting-stand.16.svg');
-    marker-fill: @man-made-icon;
+    marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
   }


### PR DESCRIPTION
I think amenities are more than only for entertainment (see also https://github.com/gravitystorm/openstreetmap-carto/issues/1642#issuecomment-120550415) and black should be left for general or maybe also for less visible things:

![hunting-brown](https://cloud.githubusercontent.com/assets/5439713/9309370/6f3ada14-4509-11e5-8d80-8de59f8b8ca1.png)
