### PR TITLE
Make major power lines less prominent

### DIFF
--- a/power.mss
+++ b/power.mss
@@ -1,8 +1,16 @@
+@power-line-color: #888;
+
 #power-line {
   [zoom >= 14] {
-    line-width: 1;
-    line-color: #777;
+    line-width: 0.8;
+    line-color: @power-line-color;
+    [zoom >= 15] {
+      line-width: 0.9;
+    }
     [zoom >= 16] {
+      line-width: 1.3;
+    }
+    [zoom >= 18] {
       line-width: 1.5;
     }
   }
@@ -11,7 +19,7 @@
 #power-minorline {
   [zoom >= 16] {
     line-width: 0.5;
-    line-color: #777;
+    line-color: @power-line-color;
   }
 }
 


### PR DESCRIPTION
I think major power lines are slightly too prominent. This was amplified by the recent colour change of forest. I made them a bit lighter and slightly thinner.

z14 (left = before)
![power_z14](https://cloud.githubusercontent.com/assets/3531092/9316909/5b6a4ac2-4538-11e5-87f9-08ce18f4a2a3.png)

z16
![power_z16](https://cloud.githubusercontent.com/assets/3531092/9316912/5f55e132-4538-11e5-8489-ff78ebc77b2c.png)