### PR TITLE
Render cutline as thicker line with some green color

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -542,12 +542,15 @@
 /* man_made=cutline */
 #landcover-line {
   [zoom >= 14] {
-    line-width: 1.5;
+    line-width: 3;
     line-join: round;
     line-cap: square;
-    line-color: @land-color;
+    line-color: @grass;
     [zoom >= 16] {
-      line-width: 2;
+      line-width: 6;
+      [zoom >= 18] {
+        line-width: 12;
+      }
     }
   }
 }


### PR DESCRIPTION
Taking over https://github.com/gravitystorm/openstreetmap-carto/pull/1526.

My take is that we can use "scrub green" as the color for cutlines, which works in many ways:
- it doesn't look like a road any more...
- ...which gives us the opportunity to make the cutline wider than before (to be visible under footway/path)...
- ...and looks more like typical cutline surface (low green plants, like scrub), while not using scrub symbols (because we're not sure it's really scrub, not the grass or something else)

For comparison: the vertical line is not a cutline, but real scrub area about 10 m wide.

z14:
![cutline2-14](https://cloud.githubusercontent.com/assets/5439713/9336153/4fdb2bf4-45d8-11e5-848b-fd9de7a044aa.png)

z16:
![cutline2-16-wide](https://cloud.githubusercontent.com/assets/5439713/9336156/58939b1e-45d8-11e5-870c-84d2f36ff95e.png)

z19:
![cutline2-19](https://cloud.githubusercontent.com/assets/5439713/9336163/63de23e0-45d8-11e5-8a0d-2eead34ac189.png)
