### PR TITLE
change colour of admin boundaries to be consistent on z1-3

### DIFF
--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -1,7 +1,7 @@
 #necountries {
   [zoom >= 1][zoom < 4] {
     line-width: 0.5;
-    line-color: grey;
+    line-color: @admin-boundaries;
   }
 }
 


### PR DESCRIPTION
Fixes #1749.

I'm not sure if it is an improvement colour-wise, but out of consistency reasons admin boundaries on z1-3 should be the same colour as later on.

showing only after version:
![borders](https://cloud.githubusercontent.com/assets/3531092/9392716/948cb0cc-477e-11e5-99e6-6a9833e41897.png)
