### PR TITLE
Changing color of shop=car_repair to brown 

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -678,7 +678,7 @@
     marker-file: url('symbols/shopping_car_repair.16.svg');
     marker-placement: interior;
     marker-clip: false;
-    marker-fill: @shop-icon;
+    marker-fill: @amenity-brown;
   }
 
   [feature = 'shop_bicycle'][zoom >= 17] {
@@ -1996,6 +1996,9 @@
       text-halo-fill: rgba(255, 255, 255, 0.6);
       text-wrap-width: @standard-wrap-width;
       text-placement: interior;
+      [feature = 'shop_car_repair'] {
+        text-fill: @amenity-brown;
+      }
     }
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/gravitystorm/openstreetmap-carto/pull/1777: shop=car_repair is in fact amenity, so it should be rendered in brown, since it sells services rather than goods:

![car_repair-brown-19](https://cloud.githubusercontent.com/assets/5439713/9426434/e634d684-4940-11e5-8688-1e0e3caddee8.png)