### PR TITLE
better labels for bridges

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2083,9 +2083,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [man_made = 'bridge'] {
     [zoom >= 12][way_pixels > 4] {
       text-name: "[name]";
-      text-size: 7;
+      text-size: 8;
       text-fill: black;
-      text-face-name: @oblique-fonts;
+      text-face-name: @book-fonts;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-min-distance: 2;


### PR DESCRIPTION
stop using italics - bridge is not landcover

smallest labels are slightly larger to make them more readable


I recommend merging it before release (in the nearest one man_made=bridge will be rendered for the first time).

https://cloud.githubusercontent.com/assets/899988/9503315/68ccd914-4c36-11e5-8f0f-a4f19cae9e90.png
https://cloud.githubusercontent.com/assets/899988/9503314/68cabb98-4c36-11e5-9192-3ef8c0f03580.png
https://cloud.githubusercontent.com/assets/899988/9503316/68cfe85c-4c36-11e5-8a5f-1b5155999425.png
