### PR TITLE
remove duplicated amenity=recycling label

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1137,7 +1137,6 @@
   [feature = 'amenity_community_centre'][zoom >= 17],
   [feature = 'amenity_fire_station'][zoom >= 17],
   [feature = 'amenity_drinking_water'][zoom >= 17],
-  [feature = 'amenity_recyling'][zoom >= 17],
   [feature = 'tourism_picnic_site'][zoom >= 17],
   [feature = 'leisure_picnic_table'][zoom >= 17],
   [feature = 'amenity_post_office'][zoom >= 17] {


### PR DESCRIPTION
Anyway it was not working due to typo. It is defined correctly later.

Rendering is not changed.
![amenity recycling name eeeeee eeeeee ref 1 ele 8000 operator ee ee ee operator brand ee ee ee brand closed_way master - duplicate 200px](https://cloud.githubusercontent.com/assets/899988/9616298/a826c5c2-50fd-11e5-9706-cb6b785fcd2f.png)


