### PR TITLE
add shop=winery to list of ignored shop values

### DIFF
--- a/scripts/shop_values.rb
+++ b/scripts/shop_values.rb
@@ -15,7 +15,8 @@ EXCEPTIONS = [
    "FIXME",
    "FixMe",
    "other",
-   "*"
+   "*",
+   "winery", #see discussion in https://github.com/gravitystorm/openstreetmap-carto/pull/1632
 ]
 
 


### PR DESCRIPTION
as discussed in #1632 (it is not changing rendering but should protect against accidental reintroduction on updating list of shops displayed as dot)