### PR TITLE
rework oneway arrows

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -238,9 +238,24 @@
 @paths-bridge-casing-width:       0.5;
 @paths-tunnel-casing-width:       1;
 
-@oneway-arrow-color: #404040;
-@junction-text-color: #960000;
+@junction-text-color:             #960000;
 @halo-color-for-minor-road: white;
+
+@motorway-oneway-arrow-color:     darken(@motorway-casing, 25%);
+@trunk-oneway-arrow-color:        darken(@trunk-casing, 25%);
+@primary-oneway-arrow-color:      darken(@primary-casing, 15%);
+@secondary-oneway-arrow-color:    darken(@secondary-casing, 10%);
+@tertiary-oneway-arrow-color:     darken(@tertiary-casing, 30%);
+@residential-oneway-arrow-color:  darken(@residential-casing, 40%);
+@living-street-oneway-arrow-color: darken(@residential-casing, 30%);
+@pedestrian-oneway-arrow-color:   darken(@pedestrian-casing, 25%);
+@raceway-oneway-arrow-color:      darken(@raceway-fill, 50%);
+@footway-oneway-arrow-color:      darken(@footway-fill, 35%);
+@steps-oneway-arrow-color:        darken(@steps-fill, 35%);
+@cycleway-oneway-arrow-color:     darken(@cycleway-fill, 25%);
+@track-oneway-arrow-color:        darken(@track-fill, 15%);
+@bridleway-oneway-arrow-color:    darken(@track-fill, 10%);
+
 
 .roads-casing, .bridges-casing, .tunnels-casing {
   ::casing {
@@ -2780,49 +2795,93 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 .directions::directions {
   [zoom >= 16] {
-    [oneway = 'yes'] {
-      dira/line-width: 1;
-      dira/line-dasharray: 0,12,10,152;
-      dira/line-color: @oneway-arrow-color;
-      dira/line-join: bevel;
-      dira/line-clip: false;
-      dirb/line-width: 2;
-      dirb/line-dasharray: 0,12,9,153;
-      dirb/line-color: @oneway-arrow-color;
-      dirb/line-join: bevel;
-      dirb/line-clip: false;
-      dirc/line-width: 3;
-      dirc/line-dasharray: 0,18,2,154;
-      dirc/line-color: @oneway-arrow-color;
-      dirc/line-join: bevel;
-      dirc/line-clip: false;
-      dird/line-width: 4;
-      dird/line-dasharray: 0,18,1,155;
-      dird/line-color: @oneway-arrow-color;
-      dird/line-join: bevel;
-      dird/line-clip: false;
-    }
-    [oneway = '-1'] {
-      dira/line-width: 1;
-      dira/line-dasharray: 0,12,10,152;
-      dira/line-color: @oneway-arrow-color;
-      dira/line-join: bevel;
-      dira/line-clip: false;
-      dirb/line-width: 2;
-      dirb/line-dasharray: 0,13,9,152;
-      dirb/line-color: @oneway-arrow-color;
-      dirb/line-join: bevel;
-      dirb/line-clip: false;
-      dirc/line-width: 3;
-      dirc/line-dasharray: 0,14,2,158;
-      dirc/line-color: @oneway-arrow-color;
-      dirc/line-join: bevel;
-      dirc/line-clip: false;
-      dird/line-width: 4;
-      dird/line-dasharray: 0,15,1,158;
-      dird/line-color: @oneway-arrow-color;
-      dird/line-join: bevel;
-      dird/line-clip: false;
+    // intentionally omitting highway_platform, highway_construction
+    [feature = 'highway_motorway'],
+    [feature = 'highway_motorway_link'],
+    [feature = 'highway_trunk'],
+    [feature = 'highway_trunk_link'],
+    [feature = 'highway_primary'],
+    [feature = 'highway_primary_link'],
+    [feature = 'highway_secondary'],
+    [feature = 'highway_secondary_link'],
+    [feature = 'highway_tertiary'],
+    [feature = 'highway_tertiary_link'],
+    [feature = 'highway_residential'],
+    [feature = 'highway_unclassified'],
+    [feature = 'highway_living_street'],
+    [feature = 'highway_road'],
+    [feature = 'highway_service'],
+    [feature = 'highway_pedestrian'],
+    [feature = 'highway_raceway'],
+    [feature = 'highway_cycleway'],
+    [feature = 'highway_footway'],
+    [feature = 'highway_path'],
+    [feature = 'highway_steps'],
+    [feature = 'highway_track'],
+    [feature = 'highway_bridleway'] {
+      [oneway = 'yes'],
+      [oneway = '-1'] {
+        marker-placement: line;
+        marker-spacing: 180;
+        marker-max-error: 0.5;
+
+        marker-file: url('symbols/oneway.svg');
+        [oneway = '-1'] {
+          marker-file: url('symbols/oneway-reverse.svg');
+        }
+
+        [feature = 'highway_motorway'],
+        [feature = 'highway_motorway_link'] {
+          marker-fill: @motorway-oneway-arrow-color;
+        }
+        [feature = 'highway_trunk'],
+        [feature = 'highway_trunk_link'] {
+          marker-fill: @trunk-oneway-arrow-color;
+        }
+        [feature = 'highway_primary'],
+        [feature = 'highway_primary_link'] {
+          marker-fill: @primary-oneway-arrow-color;
+        }
+        [feature = 'highway_secondary'],
+        [feature = 'highway_secondary_link'] {
+          marker-fill: @secondary-oneway-arrow-color;
+        }
+        [feature = 'highway_tertiary'],
+        [feature = 'highway_tertiary_link'] {
+          marker-fill: @tertiary-oneway-arrow-color;
+        }
+        [feature = 'highway_residential'],
+        [feature = 'highway_unclassified'],
+        [feature = 'highway_road'],
+        [feature = 'highway_service'] {
+          marker-fill: @residential-oneway-arrow-color;
+        }
+        [feature = 'highway_living_street'] {
+          marker-fill: @living-street-oneway-arrow-color;
+        }
+        [feature = 'highway_pedestrian'] {
+          marker-fill: @pedestrian-oneway-arrow-color;
+        }
+        [feature = 'highway_raceway'] {
+          marker-fill: @raceway-oneway-arrow-color;
+        }
+        [feature = 'highway_footway'],
+        [feature = 'highway_path'] {
+          marker-fill: @footway-oneway-arrow-color;
+        }
+        [feature = 'highway_steps'] {
+          marker-fill: @steps-oneway-arrow-color;
+        }
+        [feature = 'highway_cycleway'] {
+          marker-fill: @cycleway-oneway-arrow-color;
+        }
+        [feature = 'highway_track'] {
+          marker-fill: @track-oneway-arrow-color;
+        }
+        [feature = 'highway_bridleway'] {
+          marker-fill: @bridleway-oneway-arrow-color;
+        }
+      }
     }
   }
 }

--- a/symbols/oneway-reverse.svg
+++ b/symbols/oneway-reverse.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="12"
+   height="5"
+   id="svg2">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 12,3 5,3 5,5 0,2.5 5,0 5,2 12,2 z"
+     id="oneway"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/symbols/oneway.svg
+++ b/symbols/oneway.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="12"
+   height="5"
+   id="svg2">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 0,2 7,2 7,0 12,2.5 7,5 7,3 0,3 z"
+     id="oneway"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
This PR moves rendering of oneway arrows from a dasharray representation towards a SVG marker symbolizer. This has the disadvantage of losing the ability to have bent arrows but results in a clearer representation, improves arrow positioning and avoids overlap with road labels. Additionally, rendering arrows for construction roads are dropped and arrows are coloured corresponding to either the casing colour or the fill colour of the road type they are rendered on, which leads to more visual consistency.

Fixes #606 by using SVG markers.
Fixes #681 as using markers prevents collision with labels.
Fixes #597 by dropping arrows for `highway=construction`.

Might fix #595 and #284, but I cannot definitely confirm, testing is welcome.

I think there is no change for #706.

Possible problems: roundabouts?

Previews (all examples within Vienna, Austria or close by)

motorway
![motorway](https://cloud.githubusercontent.com/assets/3531092/9977480/28d40a76-5f0a-11e5-8eba-55a054d42076.png)

trunk
![trunk](https://cloud.githubusercontent.com/assets/3531092/9977483/39d78d02-5f0a-11e5-95d6-ca8c3ef9f3dd.png)

primary
![primary](https://cloud.githubusercontent.com/assets/3531092/9977484/4035ad28-5f0a-11e5-9829-c369d06ed501.png)

secondary
![secondary](https://cloud.githubusercontent.com/assets/3531092/9977485/4598d538-5f0a-11e5-96c0-be1c2faeda04.png)

tertiary/residential/unclassified/road/living_street/pedestrian
![tertiary_residential_living_street_pedestrian](https://cloud.githubusercontent.com/assets/3531092/9977486/5653d7f6-5f0a-11e5-8477-4149e88def2c.png)

service/raceway
![service_raceway](https://cloud.githubusercontent.com/assets/3531092/9977493/7aea0b08-5f0a-11e5-8da0-1a9a237d2ec7.png)

track
![track](https://cloud.githubusercontent.com/assets/3531092/9977490/6ada26d0-5f0a-11e5-87ea-199edca2f105.png)

footway/path
![footway](https://cloud.githubusercontent.com/assets/3531092/9977488/625ba6aa-5f0a-11e5-9856-1f78af89f2fd.png)

cycleway
![cycleway](https://cloud.githubusercontent.com/assets/3531092/9977489/66b6fe0c-5f0a-11e5-9704-d9343f3904e2.png)

steps
![steps](https://cloud.githubusercontent.com/assets/3531092/9977491/70b4aaa8-5f0a-11e5-9210-16d596392ade.png)




------- outdated, only for reference --------

Minor tweak to the new road style that was discussed e.g. in https://github.com/gravitystorm/openstreetmap-carto/pull/1736#issuecomment-135539161.

Instead of using the same colour for all road types chroma and hue for the arrows are taken from the casing colour of the respective road type, residential/tertiary is kept unchanged. This leads to minor differences in colour, but increases visual consistency.

Previews:
motorway
https://cloud.githubusercontent.com/assets/3531092/9944605/b48a5364-5d88-11e5-83f9-83fd25588277.png

trunk
https://cloud.githubusercontent.com/assets/3531092/9944607/b74515f8-5d88-11e5-8ca6-17ce30431f0a.png

primary
https://cloud.githubusercontent.com/assets/3531092/9944608/b976ddde-5d88-11e5-81ff-be0ef0a0e0d9.png

secondary
https://cloud.githubusercontent.com/assets/3531092/9944612/bdba7f0e-5d88-11e5-9e50-625d1a32b400.png

residential/tertiary
https://cloud.githubusercontent.com/assets/3531092/9944616/c2ffca28-5d88-11e5-8100-776bab241ec6.png