### PR TITLE
render man_made=bridge like man_made=pier

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -47,6 +47,8 @@
 
 #bridge {
   [zoom >= 12] {
-    polygon-fill: #B8B8B8;
+    polygon-fill: @land-color;
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 }


### PR DESCRIPTION
For me it seemed a good idea to render `man_made=bridge` like land colour. I see the rationale by emphasising the man_made aspect, but as we also render `man_made=pier` like land colour it seems logical to also render bridges like that.

In the preview note the pier between the two bridges.

before
![man_made_bridge_before](https://cloud.githubusercontent.com/assets/3531092/9980515/f838c422-5f9c-11e5-870d-ee93b5d36ec1.png)

after
![man_made_bridge](https://cloud.githubusercontent.com/assets/3531092/9980516/fd8c133e-5f9c-11e5-8e2c-6650f21f3abb.png)