### PR TITLE
Changing color of service shop=* POIs to amenity-brown

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -533,7 +533,7 @@
 
   [feature = 'shop_beauty'][zoom >= 17] {
     marker-file: url('symbols/beauty-14.svg');
-    marker-fill: @shop-icon;
+    marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -627,7 +627,7 @@
       marker-file: url('symbols/laundry-14.svg');
       marker-placement: interior;
       marker-clip: false;
-      marker-fill: @shop-icon;
+      marker-fill: @amenity-brown;
     }
   }
 
@@ -669,7 +669,7 @@
     marker-file: url('symbols/shop_hairdresser.16.svg');
     marker-placement: interior;
     marker-clip: false;
-    marker-fill: @shop-icon;
+    marker-fill: @amenity-brown;
   }
 
   [feature = 'shop_hifi'][zoom >= 17] {
@@ -829,7 +829,7 @@
     marker-file: url('symbols/travel_agency-14.svg');
     marker-placement: interior;
     marker-clip: false;
-    marker-fill: @shop-icon;
+    marker-fill: @amenity-brown;
   }
 
   [feature = 'shop_stationery'][zoom >= 17] {
@@ -2039,7 +2039,12 @@
       text-halo-fill: rgba(255, 255, 255, 0.6);
       text-wrap-width: @standard-wrap-width;
       text-placement: interior;
-      [feature = 'shop_car_repair'] {
+      [feature = 'shop_car_repair'],
+      [feature = 'shop_beauty'],
+      [feature = 'shop_dry_cleaning'],
+      [feature = 'shop_hairdresser'],
+      [feature = 'shop_laundry'], 
+      [feature = 'shop_travel_agency'] {
         text-fill: @amenity-brown;
       }
     }


### PR DESCRIPTION
The same story as https://github.com/gravitystorm/openstreetmap-carto/issues/1642 and https://github.com/gravitystorm/openstreetmap-carto/pull/1778.

Changing color of POIs which are not selling goods, but rather services:
* shop=beauty
* shop=dry_cleaning
* shop=hairdresser
* shop=laundry 
* shop=travel_agency

![brown-beauty-laundry](https://cloud.githubusercontent.com/assets/5439713/10049325/4e5d4db0-6217-11e5-8214-02654f886de6.png)
![brown-travel-hairdresser-19](https://cloud.githubusercontent.com/assets/5439713/10049329/5149ccba-6217-11e5-967f-da0991d3d02a.png)
