### PR TITLE
Move rendering of railway=tram_stop labels later

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -1,4 +1,5 @@
 @station-color: #7981b0;
+@station-text: #66f;
 
 .stations {
   [railway = 'subway_entrance'][zoom >= 18] {
@@ -21,7 +22,7 @@
       text-name: "[name]";
       text-face-name: @bold-fonts;
       text-size: 9;
-      text-fill: #66f;
+      text-fill: @station-text;
       text-dy: -8;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
@@ -36,7 +37,6 @@
   }
 
   [railway = 'halt'],
-  [railway = 'tram_stop'],
   [aerialway = 'station']::aerialway {
     [zoom >= 13] {
       marker-file: url('symbols/square.svg');
@@ -52,7 +52,7 @@
       text-name: "[name]";
       text-face-name: @book-fonts;
       text-size: 8;
-      text-fill: #66f;
+      text-fill: @station-text;
       text-dy: -8;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
@@ -62,6 +62,30 @@
         text-size: 10;
         text-dy: -10;
       }
+    }
+  }
+
+  [railway = 'tram_stop'] {
+    [zoom >= 13] {
+      marker-file: url('symbols/square.svg');
+      marker-placement: interior;
+      marker-fill: @station-color;
+      marker-width: 4;
+      marker-clip: false;
+    }
+    [zoom >= 15] {
+      marker-width: 6;
+    }
+    [zoom >= 16] {
+      text-name: "[name]";
+      text-face-name: @book-fonts;
+      text-size: 10;
+      text-fill: @station-text;
+      text-dy: -10;
+      text-halo-radius: 1;
+      text-halo-fill: rgba(255,255,255,0.6);
+      text-wrap-width: 0;
+      text-placement: interior;
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1834.

Moving only the tram_stop labels (not touching dots) from z>=14 to z>=16 works for me.

**Wroclaw**
z14 (before/after):
![wroclaw-tram-labels-14](https://cloud.githubusercontent.com/assets/5439713/10099452/0e4c882a-638a-11e5-8c85-afd21b258cc3.png)
![wroclaw-tram-14](https://cloud.githubusercontent.com/assets/5439713/10099455/157c1bba-638a-11e5-8dad-0063e488c691.png)

z15 (before/after):
![wroclaw-tram-labels-15](https://cloud.githubusercontent.com/assets/5439713/10099464/291285a6-638a-11e5-955d-97849e8ecde3.png)
![wroclaw-tram-15](https://cloud.githubusercontent.com/assets/5439713/10099465/2b885162-638a-11e5-9fed-8891cdced532.png)

**Warsaw** 
It's even better - some (currently obscured) metro/railway stations and cemetery name start being visible.

z14 (before/after):
![warsaw-tram-labels-14](https://cloud.githubusercontent.com/assets/5439713/10100207/38838e26-6390-11e5-8255-ae78b54d06f2.png)
![warsaw-tram-14](https://cloud.githubusercontent.com/assets/5439713/10100213/40f7c9f0-6390-11e5-9b48-8c4979f93067.png)

z15 (before/after):
![warsaw-tram-labels-15](https://cloud.githubusercontent.com/assets/5439713/10100222/50b1d692-6390-11e5-8965-5b2e7876968a.png)
![warsaw-tram-15](https://cloud.githubusercontent.com/assets/5439713/10100223/5342bde0-6390-11e5-8aee-0323214d40b3.png)
