### PR TITLE
change appearance of station labels

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -21,8 +21,8 @@
       text-name: "[name]";
       text-face-name: @bold-fonts;
       text-size: 9;
-      text-fill: #66f;
-      text-dy: -8;
+      text-fill: darken(@station-color, 15%);
+      text-dy: 8;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
@@ -31,7 +31,7 @@
     [zoom >= 15] {
       marker-width: 9;
       text-size: 11;
-      text-dy: -10;
+      text-dy: 10;
     }
   }
 
@@ -50,17 +50,17 @@
     }
     [zoom >= 14] {
       text-name: "[name]";
-      text-face-name: @book-fonts;
-      text-size: 8;
-      text-fill: #66f;
-      text-dy: -8;
+      text-face-name: @bold-fonts;
+      text-size: 7;
+      text-fill: darken(@station-color, 15%);
+      text-dy: 7;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;
       [zoom >= 15] {
-        text-size: 10;
-        text-dy: -10;
+        text-size: 9;
+        text-dy: 9;
       }
     }
   }


### PR DESCRIPTION
Since I find the colour of station labels quite ugly I thought it might be better to tie them to the colour of the station markers (but slightly darker). Additionally, the label is now rendered below the marker as most other labels. Railway halts and tram stops are now rendered in bold font, but I have instead decreased the font size by 1px.

As this makes tram stops slightly more prominent it makes only sense to merge it after #1875.

city environment (metro station/railway station/tram stop)
![city_before](https://cloud.githubusercontent.com/assets/3531092/10122289/4c86d5d8-6514-11e5-9943-4b6ddcffbd25.png)
![city_after](https://cloud.githubusercontent.com/assets/3531092/10122290/4e74f096-6514-11e5-825a-37a240ab9f49.png)

rural environment (railway station/railway halt)
![rural_before](https://cloud.githubusercontent.com/assets/3531092/10122291/6045b1f2-6514-11e5-80b8-127049979f97.png)
![rural_after](https://cloud.githubusercontent.com/assets/3531092/10122295/62dbe8f0-6514-11e5-9810-97a231589d86.png)

aerialways are also affected
![aerialway_before](https://cloud.githubusercontent.com/assets/3531092/10122309/16f379ca-6515-11e5-911a-488700adfd54.png)
![aerialway_after](https://cloud.githubusercontent.com/assets/3531092/10122310/1a709df8-6515-11e5-92a7-6eefaa8756aa.png)