### PR TITLE
Improving railway=halt and aerialway=station labels

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -23,7 +23,7 @@
       text-face-name: @bold-fonts;
       text-size: 9;
       text-fill: @station-text;
-      text-dy: -8;
+      text-dy: 8;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
@@ -32,11 +32,34 @@
     [zoom >= 15] {
       marker-width: 9;
       text-size: 11;
-      text-dy: -10;
+      text-dy: 10;
     }
   }
 
-  [railway = 'halt'],
+  [railway = 'halt'] {
+    [zoom >= 13] {
+      marker-file: url('symbols/square.svg');
+      marker-placement: interior;
+      marker-fill: @station-color;
+      marker-width: 4;
+      marker-clip: false;
+      [zoom >= 15] {
+        marker-width: 6;
+      }
+    }
+    [zoom >= 15] {
+      text-name: "[name]";
+      text-face-name: @bold-fonts;
+      text-size: 9;
+      text-fill: @station-text;
+      text-dy: 9;
+      text-halo-radius: 1;
+      text-halo-fill: rgba(255,255,255,0.6);
+      text-wrap-width: 0;
+      text-placement: interior;
+    }
+  }
+
   [aerialway = 'station']::aerialway {
     [zoom >= 13] {
       marker-file: url('symbols/square.svg');
@@ -53,14 +76,14 @@
       text-face-name: @book-fonts;
       text-size: 8;
       text-fill: @station-text;
-      text-dy: -8;
+      text-dy: 8;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;
       [zoom >= 15] {
         text-size: 10;
-        text-dy: -10;
+        text-dy: 10;
       }
     }
   }
@@ -72,16 +95,16 @@
       marker-fill: @station-color;
       marker-width: 4;
       marker-clip: false;
-    }
-    [zoom >= 15] {
-      marker-width: 6;
+      [zoom >= 15] {
+        marker-width: 6;
+      }
     }
     [zoom >= 16] {
       text-name: "[name]";
       text-face-name: @book-fonts;
       text-size: 10;
       text-fill: @station-text;
-      text-dy: -10;
+      text-dy: 10;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;


### PR DESCRIPTION
This is a follow up of my research which started in https://github.com/gravitystorm/openstreetmap-carto/pull/1878#issuecomment-143726126, but then went in a different direction.

I think railway=halt is somewhere between railway=station and tram_stop, but should be closer to the station. Currently they are indistinguishable from tram stops (they just start to be rendered earlier, like stations). That's why I want their labels to be bold (like the station), but with slightly smaller font size than station and visible from z15 (station is from z14 and tram stop is now from z16). I assume that aerialway=station are corresponding type (for the sake of simplicity, because they are the same now), but maybe they should be treated separately. If you have some other ideas, I'll try to test them too. 

This PR is also compacting stations code formatting to make it easier to understand.

Some examples (more to come):

**Warsaw, z16 (before/after)**
"Warszawa Srodmiescie" halt in the middle, with railway and metro stations and tram/bus stops around: 
![railway-halt-problem-16](https://cloud.githubusercontent.com/assets/5439713/10134861/72c3d77a-65e9-11e5-9751-e61115ca4d3e.png)
![railway-halt-bold-16](https://cloud.githubusercontent.com/assets/5439713/10141661/1638a95c-660e-11e5-81a7-93eeae58b746.png)

**Warsaw, z17 (before/after)**
"Warszawa Ochota" and "Warszawa Ochota WKD" halts in the middle, railway station, some tram and bus stops plus bicycle rental stations are around:
![halt-zawiszy-17](https://cloud.githubusercontent.com/assets/5439713/10141894/449bc260-660f-11e5-8210-64b211e715b0.png)
![halt-bold-zawiszy-17](https://cloud.githubusercontent.com/assets/5439713/10141897/48b43dd2-660f-11e5-9710-8cd884312f19.png)

**Katschberg (before/after)**
Aerialway stations
z14
![katchberg-14](https://cloud.githubusercontent.com/assets/5439713/10142271/f2a20408-6611-11e5-97e5-1977498cdc75.png)
![katchberg-bold-14](https://cloud.githubusercontent.com/assets/5439713/10142460/1129054c-6613-11e5-9964-088458a4c035.png)

z15
![katchberg-15](https://cloud.githubusercontent.com/assets/5439713/10142354/91865a38-6612-11e5-9ddd-6023838ee7b4.png)
![katchberg-bold-15](https://cloud.githubusercontent.com/assets/5439713/10142535/ab9813fc-6613-11e5-93ce-b1aa280d4a8e.png)
