### PR TITLE
Pushing small amenities to higher zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -32,7 +32,7 @@
     point-placement: interior;
   }
 
-  [feature = 'amenity_atm'][zoom >= 17] {
+  [feature = 'amenity_atm'][zoom >= 18] {
     marker-file: url('symbols/atm.16.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -95,7 +95,7 @@
     marker-clip: false;
   }
 
-  [feature = 'highway_traffic_signals'][zoom >= 17] {
+  [feature = 'highway_traffic_signals'][zoom >= 19] {
     marker-file: url('symbols/traffic_light.svg');
     marker-fill: #0a0a0a;
     marker-placement: interior;
@@ -399,7 +399,7 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_post_box'][zoom >= 17] {
+  [feature = 'amenity_post_box'][zoom >= 18] {
     marker-file: url('symbols/post_box-12.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -452,14 +452,14 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_telephone'][zoom >= 17] {
+  [feature = 'amenity_telephone'][zoom >= 18] {
     marker-file: url('symbols/telephone.16.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
   }
 
-  [feature = 'amenity_emergency_phone'][zoom >= 17] {
+  [feature = 'amenity_emergency_phone'][zoom >= 19] {
     marker-file: url('symbols/emergency_phone.16.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -473,14 +473,14 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_toilets'][zoom >= 17] {
+  [feature = 'amenity_toilets'][zoom >= 18] {
     marker-file: url('symbols/toilets.16.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
   }
 
-  [feature = 'amenity_drinking_water'][zoom >= 17] {
+  [feature = 'amenity_drinking_water'][zoom >= 18] {
     marker-file: url('symbols/drinking_water.16.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -1208,7 +1208,7 @@
   [feature = 'amenity_car_wash'][zoom >= 17],
   [feature = 'amenity_community_centre'][zoom >= 17],
   [feature = 'amenity_fire_station'][zoom >= 17],
-  [feature = 'amenity_drinking_water'][zoom >= 17],
+  [feature = 'amenity_drinking_water'][zoom >= 18],
   [feature = 'tourism_picnic_site'][zoom >= 17],
   [feature = 'leisure_picnic_table'][zoom >= 17],
   [feature = 'amenity_post_office'][zoom >= 17] {
@@ -1347,7 +1347,6 @@
       text-placement: interior;
     }
   }
-
 
   [feature = 'leisure_miniature_golf'][zoom >= 17],
   [feature = 'leisure_golf_course'][zoom >= 15] {
@@ -1757,7 +1756,7 @@
   }
 
   [feature = 'amenity_bank'][zoom >= 17],
-  [feature = 'amenity_atm'][zoom >= 17] {
+  [feature = 'amenity_atm'][zoom >= 18] {
     text-name: "[name]";
     [feature = 'amenity_atm'] {
       text-name: "[operator]";

--- a/project.mml
+++ b/project.mml
@@ -1997,7 +1997,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name,\n    CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio\n  FROM planet_osm_point p\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')\n     OR historic = 'wayside_cross'\n     OR man_made = 'cross'\n  ORDER BY prio\n  ) AS amenity_low_priority",
+        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name,\n    CASE WHEN amenity='waste_basket' THEN 4\n         WHEN amenity IN ('bench', 'emergency_phone') THEN 3 \n         WHEN amenity IN ('atm', 'telephone', 'post_box') THEN 1 \n         ELSE 2 END\n    AS prio\n  FROM planet_osm_point p\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n     OR amenity IN ('atm', 'parking', 'bicycle_parking', 'motorcycle_parking', 'bench', \n                    'waste_basket', 'telephone', 'emergency_phone', 'post_box')\n     OR historic = 'wayside_cross'\n     OR man_made = 'cross'\n  ORDER BY prio\n  ) AS amenity_low_priority",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -2023,7 +2023,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name\n  FROM planet_osm_polygon\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n         OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n  ) AS amenity_low_priority_poly",
+        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name\n  FROM planet_osm_polygon\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n  ) AS amenity_low_priority_poly",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -2456,12 +2456,17 @@ Layer:
             historic,
             access,
             name,
-            CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio
+            CASE WHEN amenity='waste_basket' THEN 4
+                 WHEN amenity IN ('bench', 'emergency_phone') THEN 3 
+                 WHEN amenity IN ('atm', 'telephone', 'post_box') THEN 1 
+                 ELSE 2 END
+            AS prio
           FROM planet_osm_point p
           WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
              OR highway IN ('mini_roundabout')
              OR railway = 'level_crossing'
-             OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')
+             OR amenity IN ('atm', 'parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 
+                            'waste_basket', 'telephone', 'emergency_phone', 'post_box')
              OR historic = 'wayside_cross'
              OR man_made = 'cross'
           ORDER BY prio
@@ -2491,7 +2496,7 @@ Layer:
           WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
              OR highway IN ('mini_roundabout')
              OR railway = 'level_crossing'
-                 OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')
+             OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')
           ) AS amenity_low_priority_poly
     properties:
       minzoom: 14


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1745.

Objects moved down to z>=18:
- amenity=atm
- amenity=post_box
- amenity=telephone
- amenity=toilets
- amenity=drinking_water

Objects moved down to z>=19:
- amenity=emergency_phone
- highway=traffic_signals

Examples:

Warsaw, z17 (21.0843,52.2430,21.0878,52.2451), before/after
![small-amenities-universam-before-17](https://cloud.githubusercontent.com/assets/5439713/10174072/180709ec-66e8-11e5-97ad-ab395c9aafa9.png)
![small-amenities-universam-17](https://cloud.githubusercontent.com/assets/5439713/10173639/9a903cce-66e5-11e5-8777-b5be26ff31df.png)

Warsaw, z17 (21.0098,52.2484,21.0144,52.2512), before/after
![small-amenities-starowka-before-17](https://cloud.githubusercontent.com/assets/5439713/10174282/4cef87d2-66e9-11e5-8fe1-520d17e537db.png)
![small-amenities-starowka-17](https://cloud.githubusercontent.com/assets/5439713/10173825/ae6a2862-66e6-11e5-99a5-dc0929c7670a.png)


However I am not sure if the code related to priorities works as expected - please correct me if I made any mistakes, I'll try to learn how to use it. The biggest problem is that it's hard to test them.