### PR TITLE
make residential refs less prominent

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2680,13 +2680,21 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'residential'] {
     [zoom >= 15] {
       text-name: "[refs]";
-      text-size: 10;
+      text-size: 8;
+
+      [zoom >= 16] {
+        text-size: 9;
+      }
+      [zoom >= 18] {
+        text-size: 10;
+      }
+
       text-fill: #000;
-      text-face-name: @bold-fonts;
-      text-min-distance: 18;
-      text-halo-radius: 1;
+      text-face-name: @book-fonts;
+      text-min-distance: 40;
+      text-halo-radius: 2;
       text-halo-fill: rgba(255,255,255,0.6);
-      text-spacing: 750;
+      text-spacing: 760;
       text-clip: false;
     }
   }


### PR DESCRIPTION
Follow-up to #1871.

Makes residential/unclassified refs stand out less, by removing the bold font, keeping the font size 1px below shielded refs (means decreasing by 2px on z15), increasing the spacing between texts so that less refs appear on z15 and increasing the halo width as replacement for a proper shield.

Previews are for a location that was mentioned in https://github.com/gravitystorm/openstreetmap-carto/issues/285#issuecomment-30535756 for having exceptionally many such refs.

before
![residential_ref_z15_before](https://cloud.githubusercontent.com/assets/3531092/10412390/6c0549c4-6f84-11e5-823c-eac02be39032.png)

after - current road shields
![residential_ref_z15_old_shields](https://cloud.githubusercontent.com/assets/3531092/10412392/74dc969c-6f84-11e5-8e6a-29e3c693a3f6.png)

after - proposed road shields
![residential_ref_new_shields_z15](https://cloud.githubusercontent.com/assets/3531092/10412393/7dd8130c-6f84-11e5-8306-31796d1db70b.png)