### PR TITLE
Significantly increase minimum zoom level for bridge names

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2420,7 +2420,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #bridge-text  {
   [man_made = 'bridge'] {
-    [zoom >= 12][way_pixels > 4] {
+    [zoom >= 12][way_pixels > 62.5] {
       text-name: "[name]";
       text-size: 8;
       text-fill: black;
@@ -2429,7 +2429,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-fill: rgba(255,255,255,0.6);
       text-min-distance: 2;
       text-wrap-width: 30;
-      [way_pixels > 100] {
+      [way_pixels > 250] {
         text-size: 9;
       }
       [way_pixels > 1000] {
@@ -2439,7 +2439,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [way_pixels > 4000] {
         text-size: 12;
       }
-      [way_pixels > 10000] {
+      [way_pixels > 16000] {
         text-size: 13;
         text-halo-radius: 2;
       }


### PR DESCRIPTION
Also make sure that the progression for font size minimum sizes increases with
a factor of 4 (this makes sure that every zoom level is one size bigger).

Bridge names currently show up way too early, see for example [here](http://www.openstreetmap.org/#map=14/52.0899/5.1238) with Viebrug and Lucasbrug.