### PR TITLE
change colour of station labels

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -1,5 +1,5 @@
 @station-color: #7981b0;
-@station-text: #66f;
+@station-text: darken(saturate(@station-color, 15%), 10%);
 
 .stations {
   [railway = 'subway_entrance'][zoom >= 18] {
@@ -24,7 +24,7 @@
       text-size: 9;
       text-fill: @station-text;
       text-dy: 8;
-      text-halo-radius: 1;
+      text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;
@@ -53,7 +53,7 @@
       text-size: 9;
       text-fill: @station-text;
       text-dy: 9;
-      text-halo-radius: 1;
+      text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;
@@ -77,7 +77,7 @@
       text-size: 8;
       text-fill: @station-text;
       text-dy: 8;
-      text-halo-radius: 1;
+      text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;
@@ -105,7 +105,7 @@
       text-size: 10;
       text-fill: @station-text;
       text-dy: 10;
-      text-halo-radius: 1;
+      text-halo-radius: 1.5;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 0;
       text-placement: interior;


### PR DESCRIPTION
Follow-up of #1881.

Since I find the colour of station labels quite ugly I thought it might be better to tie them to the colour of the station markers (but slightly darker and slightly more saturated). To improve readability of tram stop labels the halo is increased from 1 to 1.5.

Previews

City, z15
![station_labels_city_z15_before](https://cloud.githubusercontent.com/assets/3531092/10419036/307175e4-706b-11e5-85ec-69b7270217ac.png)
![station_labels_city_z15_after](https://cloud.githubusercontent.com/assets/3531092/10419037/321f510e-706b-11e5-88d0-43987d233a17.png)

City (tram stops), z16
![tram_labels_z16_before](https://cloud.githubusercontent.com/assets/3531092/10419038/3a9b0cec-706b-11e5-9d55-28c444b31314.png)
![tram_labels_z16_after](https://cloud.githubusercontent.com/assets/3531092/10419039/3c02ba08-706b-11e5-9221-49fda4153436.png)

Railway halt/station, z15
![railway_station_labels_z15_before](https://cloud.githubusercontent.com/assets/3531092/10419041/4416737e-706b-11e5-8a0b-4059bcc9cff5.png)
![railway_station_label_z15_after](https://cloud.githubusercontent.com/assets/3531092/10419042/458f6328-706b-11e5-8610-b0ff157a67d4.png)

Aerialways, z15
![aerialway_labels_z15_before](https://cloud.githubusercontent.com/assets/3531092/10419043/4be015a6-706b-11e5-93e6-f25872be6935.png)
![aerialway_label_z15_after](https://cloud.githubusercontent.com/assets/3531092/10419044/4d6c4c50-706b-11e5-9360-d84563e2b1c1.png)
