### PR TITLE
fix state name labels are displayed up to z19

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -18,7 +18,7 @@
 
 .state {
   [admin_level = '4'] {
-    [zoom >= 4][zoom < 5][way_pixels > 750][way_pixels < 196000],
+    [zoom >= 4][zoom < 5][way_pixels > 750],
     [zoom >= 5][way_pixels > 3000][way_pixels < 196000] {
       text-name: "[ref]";
       text-size: 9;


### PR DESCRIPTION
Fixes #1913.

I removed the upper limit for the rendering of refs since on z4 we can easily go without it. That fixes a potential carto bug. Removing the upper limit may cause the refs of some large Russian or Canadian provinces to appear, which I regard as improvement.