### PR TITLE
move tree layer below placename layer (fixes #1470)

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1232,6 +1232,32 @@
       "advanced": {}
     },
     {
+      "name": "trees",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "",
+      "id": "trees",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way, \"natural\"\n  FROM planet_osm_point\n  WHERE \"natural\" = 'tree'\nUNION ALL\nSELECT\n    way, \"natural\"\n  FROM planet_osm_line\n  WHERE \"natural\" = 'tree_row'\n) AS trees",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 16
+      },
+      "advanced": {}
+    },
+    {
       "name": "placenames-large",
       "srs-name": "900913",
       "geometry": "point",
@@ -1359,32 +1385,6 @@
       ],
       "properties": {
         "minzoom": 12
-      },
-      "advanced": {}
-    },
-    {
-      "name": "trees",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "trees",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, \"natural\"\n  FROM planet_osm_point\n  WHERE \"natural\" = 'tree'\nUNION ALL\nSELECT\n    way, \"natural\"\n  FROM planet_osm_line\n  WHERE \"natural\" = 'tree_row'\n) AS trees",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 16
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -1442,6 +1442,27 @@ Layer:
     properties:
       minzoom: 10
     advanced: {}
+  - id: "trees"
+    name: "trees"
+    class: ""
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way, "natural"
+          FROM planet_osm_point
+          WHERE "natural" = 'tree'
+        UNION ALL
+        SELECT
+            way, "natural"
+          FROM planet_osm_line
+          WHERE "natural" = 'tree_row'
+        ) AS trees
+    properties:
+      minzoom: 16
+    advanced: {}
   - id: "placenames-large"
     name: "placenames-large"
     class: "country state"
@@ -1586,27 +1607,6 @@ Layer:
         ) AS stations_poly
     properties:
       minzoom: 12
-    advanced: {}
-  - id: "trees"
-    name: "trees"
-    class: ""
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way, "natural"
-          FROM planet_osm_point
-          WHERE "natural" = 'tree'
-        UNION ALL
-        SELECT
-            way, "natural"
-          FROM planet_osm_line
-          WHERE "natural" = 'tree_row'
-        ) AS trees
-    properties:
-      minzoom: 16
     advanced: {}
   - id: "amenity-points-poly"
     name: "amenity-points-poly"


### PR DESCRIPTION
Trees were covering station labels, so the layer has been moved down below the placenames layers.

before
![tree_before](https://cloud.githubusercontent.com/assets/3531092/10525884/910ba252-7387-11e5-925c-9d510730a357.png)

after
![tree_after](https://cloud.githubusercontent.com/assets/3531092/10525854/67d991e6-7387-11e5-9c2d-2d29a963085c.png)
