### PR TITLE
switch admin entity rendering to using polygons

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1051,12 +1051,12 @@
     {
       "name": "admin-low-zoom",
       "srs-name": "900913",
-      "geometry": "linestring",
+      "geometry": "polygon",
       "class": "",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1077,13 +1077,13 @@
     {
       "name": "admin-mid-zoom",
       "srs-name": "900913",
-      "geometry": "linestring",
+      "geometry": "polygon",
       "class": "",
       "id": "admin-mid-zoom",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1104,13 +1104,13 @@
     {
       "name": "admin-high-zoom",
       "srs-name": "900913",
-      "geometry": "linestring",
+      "geometry": "polygon",
       "class": "",
       "id": "admin-high-zoom",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1314,7 +1314,7 @@ Layer:
   - name: "admin-low-zoom"
     id: "admin-low-zoom"
     class: ""
-    geometry: "linestring"
+    geometry: "polygon"
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -1322,7 +1322,7 @@ Layer:
         (SELECT
             way,
             admin_level
-          FROM planet_osm_roads
+          FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
           ORDER BY admin_level DESC
@@ -1333,7 +1333,7 @@ Layer:
   - id: "admin-mid-zoom"
     name: "admin-mid-zoom"
     class: ""
-    geometry: "linestring"
+    geometry: "polygon"
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -1341,7 +1341,7 @@ Layer:
         (SELECT
             way,
             admin_level
-          FROM planet_osm_roads
+          FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
           ORDER BY admin_level DESC
@@ -1353,7 +1353,7 @@ Layer:
   - id: "admin-high-zoom"
     name: "admin-high-zoom"
     class: ""
-    geometry: "linestring"
+    geometry: "polygon"
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -1361,7 +1361,7 @@ Layer:
         (SELECT
             way,
             admin_level
-          FROM planet_osm_roads
+          FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
           ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering


### PR DESCRIPTION
I'd like to switch the rendering of admin entities from lines to polygons. This is partly to unify it with admin name rendering (and others such as nature reserve boundaries), which already use polygons and to improve the mapper feedback loop. By using polygons it is easier to spot errors as broken geometries will not show up on the map. That also means that the map will often have some missing countries/states etc.

I'm assuming that we don't think it is desirable to render lines of incomplete admin entities and that we don't want to have the most complete but the most correct map.

Here is a preview of how the omission of broken geometries would look like (France and Belgium), apart from that rendering is unchanged:

![france_belgium_missing](https://cloud.githubusercontent.com/assets/3531092/10852236/fdc33938-7f2f-11e5-8148-38c600c9d03c.png)