### PR TITLE
rework admin boundaries and admin labels on lower zooms

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -6,48 +6,88 @@ For each zoomlevel, all borders come from a single attachment, to handle
 overlapping borders correctly.
 */
 
-#admin-low-zoom[zoom < 11],
+#admin-very-low-zoom[zoom >= 4][zoom < 5],
+#admin-low-zoom[zoom >= 5][zoom < 11],
 #admin-mid-zoom[zoom >= 11][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
-  [admin_level = '2'],
-  [admin_level = '3'] {
+  [admin_level = '2'] {
     [zoom >= 4] {
+      background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.6;
+      background/line-width: 1.2;
+      line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.6;
+      line-width: 1.2;
+    }
+    [zoom >= 5] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 6] {
+      background/line-width: 1.8;
+      line-width: 1.8;
     }
     [zoom >= 7] {
       background/line-width: 2;
       line-width: 2;
     }
     [zoom >= 10] {
-      [admin_level = '2'] {
-        background/line-width: 6;
-        line-width: 6;
-      }
-      [admin_level = '3'] {
-        background/line-width: 5;
-        line-width: 5;
-        line-dasharray: 4,2;
-        line-clip: false;
-      }
+      background/line-width: 6;
+      line-width: 6;
+    }
+  }
+  [admin_level = '3'] {
+    [zoom >= 4] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.6;
+      line-join: bevel;
+      line-color: @admin-boundaries;
+      line-width: 0.6;
+    }
+    [zoom >= 7] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    }
+    [zoom >= 10] {
+      background/line-width: 4;
+      line-width: 4;
+      line-dasharray: 4,2;
+      line-clip: false;
     }
   }
   [admin_level = '4'] {
     [zoom >= 4] {
+      background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.6;
+      background/line-width: 0.4;
+      line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.6;
+      line-width: 0.4;
       line-dasharray: 4,3;
       line-clip: false;
+    }
+    [zoom >= 5] {
+      background/line-width: 0.6;
+      line-width: 0.6;
+    }
+    [zoom >= 6] {
+      background/line-width: 0.8;
+      line-width: 0.8;
     }
     [zoom >= 7] {
       background/line-width: 1;
       line-width: 1;
     }
-    [zoom >= 11] {
+    [zoom >= 9] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+    }
+    [zoom >= 10] {
+      background/line-width: 2.5;
+      line-width: 2.5;
+    }
+    [zoom >= 12] {
       background/line-width: 3;
       line-width: 3;
     }
@@ -70,16 +110,20 @@ overlapping borders correctly.
 #admin-mid-zoom[zoom >= 11][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
   [admin_level = '5'][zoom >= 11] {
+    background/line-join: bevel;
     background/line-color: white;
     background/line-width: 2;
+    line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 2;
     line-dasharray: 6,3,2,3,2,3;
     line-clip: false;
   }
   [admin_level = '6'][zoom >= 11] {
+    background/line-join: bevel;
     background/line-color: white;
     background/line-width: 2;
+    line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 2;
     line-dasharray: 6,3,2,3;
@@ -88,8 +132,10 @@ overlapping borders correctly.
   [admin_level = '7'],
   [admin_level = '8'] {
     [zoom >= 12] {
+      background/line-join: bevel;
       background/line-color: white;
       background/line-width: 1.5;
+      line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1.5;
       line-dasharray: 5,2;
@@ -104,8 +150,10 @@ overlapping borders correctly.
   [admin_level = '9'],
   [admin_level = '10'] {
     [zoom >= 13] {
+      background/line-join: bevel;
       background/line-color: white;
       background/line-width: 2;
+      line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 2;
       line-dasharray: 2,3;

--- a/placenames.mss
+++ b/placenames.mss
@@ -1,18 +1,38 @@
 @placenames: #222;
 @placenames-light: #777777;
+@country-labels: darken(@admin-boundaries, 15%);
+@state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
 
 .country {
-  [admin_level = '2'][zoom >= 2][way_pixels > 3000][way_pixels < 196000] {
+  [admin_level = '2'][zoom >= 3][way_pixels > 1000][way_pixels < 360000] {
     text-name: "[name]";
     text-size: 9;
-    text-fill: #9d6c9d;
-    text-face-name: @book-fonts;
-    text-halo-radius: 1.5;
-    text-wrap-width: 50;
-    text-placement: interior;
-    [zoom >= 4] {
+
+    [zoom >= 3] {
       text-size: 10;
     }
+    [zoom >= 4] {
+      text-size: 11;
+    }
+    [zoom >= 5] {
+      text-size: 12;
+    }
+    [zoom >= 7] {
+      text-size: 13;
+    }
+    [zoom >= 10] {
+      text-size: 14;
+    }
+
+    text-fill: @country-labels;
+    text-face-name: @book-fonts;
+    text-halo-fill: rgba(255,255,255,0.6);
+    text-halo-radius: 1.5;
+    text-wrap-width: 35;
+    text-placement: interior;
+    text-character-spacing: 0.5;
+    text-min-distance: 3;
+    text-line-spacing: 1;
   }
 }
 
@@ -22,18 +42,20 @@
     [zoom >= 5][way_pixels > 3000][way_pixels < 196000] {
       text-name: "[ref]";
       text-size: 9;
-      text-fill: #9d6c9d;
+      text-fill: @state-labels;
       text-face-name: @oblique-fonts;
+      text-halo-fill: rgba(255,255,255,0.6);
       text-halo-radius: 1.5;
       text-wrap-width: 0;
       text-placement: interior;
+      text-min-distance: 3;
       [zoom >= 5] {
         text-name: "[name]";
-        text-wrap-width: 50;
+        text-wrap-width: 30;
       }
       [zoom >= 7] {
         text-size: 11;
-        text-wrap-width: 70;
+        text-wrap-width: 50;
       }
     }
   }
@@ -41,7 +63,6 @@
 
 #placenames-medium::high-importance {
   [category = 1][zoom < 14] {
-    [zoom >= 3][score >= 5000000],
     [zoom >= 4][score >= 3000000],
     [zoom >= 5][score >= 400000] {
       text-name: "[name]";

--- a/project.mml
+++ b/project.mml
@@ -1049,6 +1049,33 @@
       "advanced": {}
     },
     {
+      "name": "admin-very-low-zoom",
+      "srs-name": "900913",
+      "geometry": "linestring",
+      "class": "",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(l.way), p.way)\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "id": "admin-very-low-zoom",
+      "properties": {
+        "maxzoom": 4,
+        "minzoom": 4
+      },
+      "advanced": {}
+    },
+    {
       "name": "admin-low-zoom",
       "srs-name": "900913",
       "geometry": "linestring",
@@ -1056,7 +1083,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1070,7 +1097,8 @@
       ],
       "id": "admin-low-zoom",
       "properties": {
-        "maxzoom": 10
+        "maxzoom": 10,
+        "minzoom": 5
       },
       "advanced": {}
     },
@@ -1083,7 +1111,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1110,7 +1138,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND osm_id < 0\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1258,6 +1286,60 @@
       "advanced": {}
     },
     {
+      "name": "placenames-large-very-low-zoom",
+      "srs-name": "900913",
+      "geometry": "point",
+      "class": "country state",
+      "id": "placenames-large-very-low-zoom",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '2'\n    AND name IS NOT NULL\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_very_low_zoom",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 2
+      },
+      "advanced": {}
+    },
+    {
+      "name": "placenames-large-low-zoom",
+      "srs-name": "900913",
+      "geometry": "point",
+      "class": "country state",
+      "id": "placenames-large-low-zoom",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(o.way), i.way)\n          )\n      )\n    )\n  ORDER BY admin_level ASC, way_area DESC\n  ) AS placenames_large_low_zoom",
+        "geometry_field": "way",
+        "type": "postgis",
+        "key_field": "",
+        "dbname": "gis"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "maxzoom": 4,
+        "minzoom": 4
+      },
+      "advanced": {}
+    },
+    {
       "name": "placenames-large",
       "srs-name": "900913",
       "geometry": "point",
@@ -1279,7 +1361,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 2
+        "minzoom": 5
       },
       "advanced": {}
     },

--- a/project.mml
+++ b/project.mml
@@ -1056,7 +1056,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(l.way, p.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(o.way, i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1321,7 +1321,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(o.way, i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_low_zoom",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level = '2'\n      OR (admin_level = '4'\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(o.way, i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1311,6 +1311,38 @@ Layer:
     properties:
       minzoom: 13
     advanced: {}
+  - name: "admin-very-low-zoom"
+    id: "admin-very-low-zoom"
+    class: ""
+    geometry: "linestring"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            admin_level
+          FROM planet_osm_roads l
+          WHERE boundary = 'administrative'
+            AND (admin_level IN ('0', '1', '2')
+              OR (admin_level IN ('3', '4')
+                AND EXISTS
+                  (SELECT 1
+                    FROM planet_osm_polygon p
+                    WHERE boundary = 'administrative'
+                      AND admin_level = '2'
+                      AND way_area > 9e+12
+                      AND ST_Within(ST_Centroid(l.way), p.way)
+                  )
+              )
+            )
+            AND osm_id < 0
+          ORDER BY admin_level DESC
+          ) AS admin_very_low_zoom
+    properties:
+      minzoom: 4
+      maxzoom: 4
+    advanced: {}
   - name: "admin-low-zoom"
     id: "admin-low-zoom"
     class: ""
@@ -1325,9 +1357,11 @@ Layer:
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
+            AND osm_id < 0
           ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
+      minzoom: 5
       maxzoom: 10
     advanced: {}
   - id: "admin-mid-zoom"
@@ -1344,6 +1378,7 @@ Layer:
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
+            AND osm_id < 0
           ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
@@ -1364,6 +1399,7 @@ Layer:
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
+            AND osm_id < 0
           ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
@@ -1463,6 +1499,64 @@ Layer:
     properties:
       minzoom: 16
     advanced: {}
+  - id: "placenames-large-very-low-zoom"
+    name: "placenames-large-very-low-zoom"
+    class: "country state"
+    geometry: "point"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            name,
+            ref,
+            admin_level
+          FROM planet_osm_polygon
+          WHERE boundary = 'administrative'
+            AND admin_level = '2'
+            AND name IS NOT NULL
+          ORDER BY admin_level ASC, way_area DESC
+        ) AS placenames_large_very_low_zoom
+    properties:
+      minzoom: 2
+      maxzoom: 3
+    advanced: {}
+  - id: "placenames-large-low-zoom"
+    name: "placenames-large-low-zoom"
+    class: "country state"
+    geometry: "point"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            name,
+            ref,
+            admin_level
+          FROM planet_osm_polygon o
+          WHERE boundary = 'administrative'
+            AND (admin_level IN ('0', '1', '2')
+              OR (admin_level IN ('3', '4')
+                AND EXISTS
+                  (SELECT 1
+                    FROM planet_osm_polygon i
+                    WHERE boundary = 'administrative'
+                      AND admin_level = '2'
+                      AND way_area > 9e+12
+                      AND ST_Within(ST_Centroid(o.way), i.way)
+                  )
+              )
+            )
+          ORDER BY admin_level ASC, way_area DESC
+          ) AS placenames_large_low_zoom
+    properties:
+      minzoom: 4
+      maxzoom: 4
+    advanced: {}
   - id: "placenames-large"
     name: "placenames-large"
     class: "country state"
@@ -1484,7 +1578,7 @@ Layer:
           ORDER BY admin_level ASC, way_area DESC
         ) AS placenames_large
     properties:
-      minzoom: 2
+      minzoom: 5
     advanced: {}
   - id: "placenames-medium"
     name: "placenames-medium"

--- a/project.yaml
+++ b/project.yaml
@@ -1322,17 +1322,17 @@ Layer:
         (SELECT
             way,
             admin_level
-          FROM planet_osm_roads l
+          FROM planet_osm_roads o
           WHERE boundary = 'administrative'
             AND (admin_level IN ('0', '1', '2')
               OR (admin_level IN ('3', '4')
                 AND EXISTS
                   (SELECT 1
-                    FROM planet_osm_polygon p
+                    FROM planet_osm_polygon i
                     WHERE boundary = 'administrative'
                       AND admin_level = '2'
                       AND way_area > 9e+12
-                      AND ST_Within(l.way, p.way)
+                      AND ST_Within(o.way, i.way)
                       AND osm_id < 0
                   )
               )
@@ -1541,8 +1541,8 @@ Layer:
             admin_level
           FROM planet_osm_polygon o
           WHERE boundary = 'administrative'
-            AND (admin_level IN ('0', '1', '2')
-              OR (admin_level IN ('3', '4')
+            AND (admin_level = '2'
+              OR (admin_level = '4'
                 AND EXISTS
                   (SELECT 1
                     FROM planet_osm_polygon i

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -1,6 +1,12 @@
 #necountries {
   [zoom >= 1][zoom < 4] {
-    line-width: 0.5;
+    line-width: 0.2;
+    [zoom >= 2] {
+      line-width: 0.3;
+    }
+    [zoom >= 3] {
+      line-width: 0.4;
+    }
     line-color: @admin-boundaries;
   }
 }


### PR DESCRIPTION
Fixes #907, #1571.
Adresses part of #622 (the part that is similar to #907, #1571)

Changes are concerned with reduction of complexity and better rendering of country/state labels as well as boundary lines, especially in maintaining a visual hierarchy of admin levels 2,3,4.

Details:
* country lines are thinner on z1,2,3 but get thicker quickly and maintain a hierarchy with level 3 and 4
* level 3 and 4 are much thinner earlier
* line thickness of admin entities on higher zooms is unchanged
* line rendering only uses data derived from relations (osm_id < 0) which seems to avoid some duplicate rendering
* ~~simplification of admin lines starting at z4 using `ST_simplify` with a initial tolerance of ~ 7800 and decreasing linearly with scale denominator until the layer no longer gets rendered at z10~~
* omission of admin levels 3,4 for smaller countries on z4, using a `way_area` factor of 9000000000000, which should only include Russia, Canada, China (?), United States of America, Brazil, Australia and Greenland (only if their country geometries are correct and therefore in the polygon table)
* placename labels (city, town)
 * are dropped from z3 as I think it is too early to show them
* country labels
 * are dropped from z2 (here e.g. continent labels could be rendered)
 * are darker with more char and line spacing
 * have now a semi-transparent halo
 * they wrap earlier and have larger font-size from z3
 * generally they stay bigger than state labels all the time
 * they are rendered for smaller countries earlier and stay longer (I tuned it so that the US is visible on z4)
* state labels
 * have a semi-transparent halo now
 * wrap earlier
* all boundary lines use now bevel joins as suggested by @imagico 

Problems:
* ~~usage of ST_simplify is not undisputed (see #907), but I think it is a usable possibility until we have something better~~
* ~~performance of SQL query deciding if subnational entities should be rendered on z4 seems suboptimal~~ fixed, thanks @pnorman, @imagico 
* since country boundaries are thicker later on sea boundaries are further emphasised

possible Improvements:
* ~~exponential decline of tolerance parameter when using ST_simplify - if somebody wants to experiment with it~~


Previews (only after the changes, available data: admin entities incl. names and place names [city, town]):

z1
![world_z1](https://cloud.githubusercontent.com/assets/3531092/10865936/e8419b20-801c-11e5-9783-db73dbfdf01d.png)

z2
![world_z2](https://cloud.githubusercontent.com/assets/3531092/10865937/ec5a19b2-801c-11e5-866e-596b031f65a3.png)

z3
![world_z3](https://cloud.githubusercontent.com/assets/3531092/10865939/eff74a36-801c-11e5-9621-d3d51affd9d0.png)

z4
Europe
![europe_z4](https://cloud.githubusercontent.com/assets/3531092/10865978/407f804e-801e-11e5-80e4-6bd0ddf77035.png)

Africa
![africa_z4](https://cloud.githubusercontent.com/assets/3531092/10865979/44d14970-801e-11e5-86e6-dbb654823e47.png)

Americas
![americas_z4](https://cloud.githubusercontent.com/assets/3531092/10865980/487b3f86-801e-11e5-8829-6f6c4c028b02.png)

unfortunately the USA geometry seems to be broken, but see this other screenshot in https://github.com/gravitystorm/openstreetmap-carto/issues/907#issuecomment-152655418.

Oceania/Asia
![oceania_z4](https://cloud.githubusercontent.com/assets/3531092/10865992/81ba93c8-801e-11e5-995d-3ad5b25d6f49.png)

z5 (from here roads are missing)
![europe_z5](https://cloud.githubusercontent.com/assets/3531092/10865998/98505000-801e-11e5-8b6b-0da880303008.png)

z6
![europe_z6](https://cloud.githubusercontent.com/assets/3531092/10866030/a0c89ab6-801f-11e5-85dc-7ef7a0002c0c.png)

Testing:
If you need test data you can download it from http://gmgeo.at/admin_place.osm.pbf (118 MB). This file contains global admin boundaries of level 2,3,4 as well as place nodes of cities and towns. Some country geometries like France, Belgium ... and unfortunately also the US are broken so their name (and sub-national entities at z4 in case of US) won't appear.