### PR TITLE
Drop incorrect text class from text-line

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1732,7 +1732,7 @@
       "name": "text-line",
       "srs-name": "900913",
       "geometry": "linestring",
-      "class": "text",
+      "class": "",
       "id": "text-line",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {

--- a/project.yaml
+++ b/project.yaml
@@ -2096,7 +2096,7 @@ Layer:
     advanced: {}
   - id: "text-line"
     name: "text-line"
-    class: "text"
+    class: ""
     geometry: "linestring"
     <<: *extents
     Datasource:

--- a/water-features.mss
+++ b/water-features.mss
@@ -114,7 +114,8 @@
   }
 }
 
-.text {
+.text,
+#text-line {
   [feature = 'waterway_dam'],
   [feature = 'waterway_weir'] {
     #text-poly[zoom >= 15],


### PR DESCRIPTION
This saves 4 out 20 seconds on ever Carto-run on my system, and was a bug
anyway.

See also #1941.