### PR TITLE
Make residential and tertiary slightly narrower on z13

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -107,8 +107,8 @@
 @trunk-width-z13:                 6;
 @primary-width-z13:               5;
 @secondary-width-z13:             5;
-@tertiary-width-z13:              5;
-@residential-width-z13:           3;
+@tertiary-width-z13:              4;
+@residential-width-z13:           2.5;
 @living-street-width-z13:         2;
 @pedestrian-width-z13:            2;
 @bridleway-width-z13:             0.3;


### PR DESCRIPTION
* Make residential/unclassified 0.5 px narrower on z13
* Make tertiary 1 px narrower on z13

Before:
![screenshot from 2015-11-01 22 02 52](https://cloud.githubusercontent.com/assets/5251909/10871361/05132c46-80e5-11e5-8a0b-c3b31889235c.png)

After:
![screenshot from 2015-11-01 22 02 51](https://cloud.githubusercontent.com/assets/5251909/10871360/fe56d2cc-80e4-11e5-9718-fe4757b7c9bc.png)
