### PR TITLE
improved rendering for peaks and saddles using shield symbolizers

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -951,27 +951,6 @@
     marker-fill: @transportation-icon;
   }
 
-  [feature = 'natural_peak'][zoom >= 11] {
-    marker-file: url('symbols/peak.svg');
-    marker-fill: @landform-color;
-    marker-placement: interior;
-    marker-clip: false;
-  }
-
-  [feature = 'natural_volcano'][zoom >= 11] {
-    marker-file: url('symbols/peak.svg');
-    marker-fill: #d40000;
-    marker-placement: interior;
-    marker-clip: false;
-  }
-
-  [feature = 'natural_saddle'][zoom >= 15] {
-    marker-file: url('symbols/saddle.svg');
-    marker-fill: @landform-color;
-    marker-placement: interior;
-    marker-clip: false;
-  }
-
   [feature = 'natural_cave_entrance'][zoom >= 15] {
     point-file: url('symbols/poi_cave.p.16.png');
     point-placement: interior;
@@ -1237,21 +1216,53 @@
     text-placement: interior;
   }
 
-  [feature = 'natural_peak'][zoom >= 13],
-  [feature = 'natural_volcano'][zoom >= 13],
-  [feature = 'natural_saddle'][zoom >= 15],
   [feature = 'tourism_viewpoint'][zoom >= 16] {
     text-name: "[name]";
     text-size: 10;
     text-fill: darken(@landform-color, 30%);
-    [feature = 'natural_volcano'] { text-fill: #d40000; }
-    text-dy: 7;
-    [feature = 'tourism_viewpoint'] { text-dy: 11; }
+    text-dy: 11;
     text-face-name: @book-fonts;
     text-halo-radius: 1;
     text-halo-fill: rgba(255,255,255,0.6);
     text-wrap-width: @standard-wrap-width;
     text-placement: interior;
+  }
+
+  [feature = 'natural_peak'][zoom >= 11],
+  [feature = 'natural_volcano'][zoom >= 11],
+  [feature = 'natural_saddle'][zoom >= 13] {
+    [feature = 'natural_peak'] {
+      shield-file: url('symbols/peak.svg');
+    }
+    [feature = 'natural_volcano'] {
+      shield-file: url('symbols/volcano.svg');
+    }
+    [feature = 'natural_saddle'] {
+      shield-file: url('symbols/saddle.svg');
+    }
+    shield-name: '[name]';
+    shield-face-name: @book-fonts;
+    shield-fill: darken(@landform-color, 30%);
+    [feature = 'natural_volcano'] {
+      shield-fill: #d40000;
+    }
+    shield-size: 9;
+    shield-text-dy: 7;
+    shield-text-dx: 8;
+
+    [zoom >= 13] {
+      shield-size: 10;
+      shield-text-dy: 8;
+      shield-text-dx: 9;
+    }
+    shield-min-distance: 50;
+    shield-wrap-width: @standard-wrap-width;
+    shield-halo-fill: rgba(255,255,255,0.6);
+    shield-halo-radius: 1;
+    shield-placement-type: simple;
+    shield-placements: 'S,E,W';
+    shield-unlock-image: true;
+    shield-min-padding: 1;
   }
 
   [feature = 'man_made_cross'][zoom >= 17],

--- a/symbols/saddle.svg
+++ b/symbols/saddle.svg
@@ -4,5 +4,5 @@
    version="1.1"
    width="8"
    height="8">
-	<path d="M 0,3 0,8 8,8 8,3 4,5 z" />
+	<path d="M 0,3 0,8 8,8 8,3 4,5 z" style="fill: #d08f55; fill-opacity: 1;" />
 </svg>

--- a/symbols/volcano.svg
+++ b/symbols/volcano.svg
@@ -4,5 +4,5 @@
    version="1.1"
    width="8"
    height="8">
-	<path d="M 4,1 0,8 8,8 z" style="fill: #d08f55; fill-opacity: 1;" />
+	<path d="M 4,1 0,8 8,8 z" style="fill: #d40000; fill-opacity: 1;" />
 </svg>


### PR DESCRIPTION
This improves peak rendering in mountainous areas by showing less peaks first but labeling them earlier. Implements also a more dynamic display of saddles when there is space. Labels are tied to symbols by using shield symbolizers. Labels are displayed either S, W or E of the symbol. Thanks to the sorting based on elevation that was already in important (higher) peaks should be displayed first. From z14 on all peaks also in areas with quite a lot of peaks (such as the one in the preview) should be displayed.

Drawbacks: We lose the ability to re-colour the SVG symbols in the code.

I have added the shield symbolizer code to the text layer but left the query for the symbol layer as it is.

A problem I just noticed: glacier labels seem to take precedence over peaks now.

Previews

z11
![before_z11](https://cloud.githubusercontent.com/assets/3531092/11350365/7cab9d58-9231-11e5-90bf-9e2ede796a5d.png)
![after_z11](https://cloud.githubusercontent.com/assets/3531092/11350306/296a1d04-9231-11e5-9f21-229efd428823.png)

z12
![before_z12](https://cloud.githubusercontent.com/assets/3531092/11350366/7cb2ffee-9231-11e5-8a50-6ca2d030589d.png)
![after_z12](https://cloud.githubusercontent.com/assets/3531092/11350305/2966561a-9231-11e5-8252-bae440c2d230.png)

z13
![before_z13](https://cloud.githubusercontent.com/assets/3531092/11350367/7cb3d9e6-9231-11e5-9294-71a788307b5d.png)
![after_z13](https://cloud.githubusercontent.com/assets/3531092/11350307/296f5986-9231-11e5-871e-e0a00d4cecb0.png)
