### PR TITLE
remove line barrier catch-all rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -666,7 +666,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, barrier\n  FROM planet_osm_line\n  WHERE barrier IS NOT NULL\n) AS line_barriers",
+        "table": "(SELECT\n    way, barrier\n  FROM planet_osm_line\n  WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',\n          'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')\n    AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi'))\n) AS line_barriers",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -679,7 +679,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 16
+        "minzoom": 14
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -665,10 +665,12 @@ Layer:
         (SELECT
             way, barrier
           FROM planet_osm_line
-          WHERE barrier IS NOT NULL
+          WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
+            AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi'))
         ) AS line_barriers
     properties:
-      minzoom: 16
+      minzoom: 14
     advanced: {}
   - id: "cliffs"
     name: "cliffs"


### PR DESCRIPTION
Removes line-barrier catch-all rendering and fixes a bug where the line-barrier layer was displayed from z16, but a rendering rule for z14 was present.

Line barrier values > 1000 uses (with taginfo usage and comments):

fence           1 748 621 ok
wall              1 306 878 ok
hedge            646 979 ok
retaining_wall  93 566 ok
yes                   47 152 no wiki page, too general
kerb                 44 915 ok
ditch                 20 143 ok
city_wall           19 589 ok
guard_rail        17 077 ok
hedge_bank    14 508 only german wiki page available
wire_fence       10 379 no wiki page, should be fence
line                    8 166 no wiki page, not a barrier (access=no?), tagging for the renderer
chain                 5 405 ok
embankment     4 599 no wiki page, but included since rendering rule already present
field_boundary  3 847 no wiki page
wood_fence       2 171 no wiki page, should be fence
avalanche_protection 1 865 no wiki page
handrail 969 ok