### PR TITLE
fix oneway arrow colour for highway=path/footway and bicycle/horse=designated

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -3047,6 +3047,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [feature = 'highway_footway'],
         [feature = 'highway_path'] {
           marker-fill: @footway-oneway-arrow-color;
+          [horse = 'designated'] {
+            marker-fill: @bridleway-oneway-arrow-color;
+          }
+          [bicycle = 'designated'] {
+            marker-fill: @cycleway-oneway-arrow-color;
+          }
         }
         [feature = 'highway_steps'] {
           marker-fill: @steps-oneway-arrow-color;


### PR DESCRIPTION
Fixes #2054.
Thanks @daganzdaanda for reporting.

before
![designated_before](https://cloud.githubusercontent.com/assets/3531092/13230287/0d8bd530-d9a5-11e5-98ed-75f4bbf4a17d.png)

after
![designated_after](https://cloud.githubusercontent.com/assets/3531092/13230292/13cdb56c-d9a5-11e5-9937-f03e6b4b748f.png)
