### PR TITLE
render swing_gate like lift_gate

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1073,7 +1073,8 @@
     }
   }
 
-  [barrier = 'lift_gate'][zoom >= 16]::barrier {
+  [barrier = 'lift_gate'][zoom >= 16]::barrier,
+  [barrier = 'swing_gate'][zoom >= 16]::barrier {
     marker-file: url('symbols/liftgate.svg');
     marker-fill: #3f3f3f;
     marker-placement: interior;

--- a/project.mml
+++ b/project.mml
@@ -1997,7 +1997,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name,\n    CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio\n  FROM planet_osm_point p\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')\n     OR historic = 'wayside_cross'\n     OR man_made = 'cross'\n  ORDER BY prio\n  ) AS amenity_low_priority",
+        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name,\n    CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio\n  FROM planet_osm_point p\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')\n     OR historic = 'wayside_cross'\n     OR man_made = 'cross'\n  ORDER BY prio\n  ) AS amenity_low_priority",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -2023,7 +2023,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name\n  FROM planet_osm_polygon\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n         OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n  ) AS amenity_low_priority_poly",
+        "table": "(SELECT\n    way,\n    amenity,\n    railway,\n    highway,\n    barrier,\n    man_made,\n    historic,\n    access,\n    name\n  FROM planet_osm_polygon\n  WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n     OR highway IN ('mini_roundabout')\n     OR railway = 'level_crossing'\n         OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n  ) AS amenity_low_priority_poly",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -2448,7 +2448,7 @@ Layer:
             name,
             CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio
           FROM planet_osm_point p
-          WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
+          WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')
              OR highway IN ('mini_roundabout')
              OR railway = 'level_crossing'
              OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')
@@ -2478,7 +2478,7 @@ Layer:
             access,
             name
           FROM planet_osm_polygon
-          WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'block')
+          WHERE barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')
              OR highway IN ('mini_roundabout')
              OR railway = 'level_crossing'
                  OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')


### PR DESCRIPTION
fixes #2014 

swing_gate, lift_gate, whatever_gate instead of using simple barrier=gate, gate=detailed_values is not my favourite tagging scheme but it seems to be popular enough to be considered standard tagging, it is also supported by other data consumers.

https://cloud.githubusercontent.com/assets/899988/13266365/15bb3d58-da78-11e5-982a-59b08243a8d3.png
https://cloud.githubusercontent.com/assets/899988/13266368/15bd98e6-da78-11e5-857f-b68885a6fbee.png
https://cloud.githubusercontent.com/assets/899988/13266366/15bd24c4-da78-11e5-97d5-5175b1d46e8d.png
https://cloud.githubusercontent.com/assets/899988/13266367/15bd8c7a-da78-11e5-9c33-86f593a56fd9.png
https://cloud.githubusercontent.com/assets/899988/13266369/15bdcdf2-da78-11e5-8cd4-f1b22a738d63.png
