### PR TITLE
Switch to ocean polygons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ node_js:
   - "0.10"
 install:
   - npm install carto@0.12.1
-  - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/ne_10m_populated_places data/land-polygons-split-3857
-  - touch data/world_boundaries/builtup_area.shp data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/land-polygons-split-3857/land_polygons.shp
+  - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/simplified-water-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/ne_10m_populated_places data/land-polygons-split-3857 data/water-polygons-split-3857
+  - touch data/world_boundaries/builtup_area.shp data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/land-polygons-split-3857/land_polygons.shp data/water-polygons-split-3857/water_polygons.shp
 script:
   - jsonlint project.mml
   - ./node_modules/carto/bin/carto project.mml | xmllint - | wc -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ node_js:
   - "0.10"
 install:
   - npm install carto@0.12.1
-  - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/simplified-water-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/ne_10m_populated_places data/land-polygons-split-3857 data/water-polygons-split-3857
-  - touch data/world_boundaries/builtup_area.shp data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/land-polygons-split-3857/land_polygons.shp data/water-polygons-split-3857/water_polygons.shp
+  - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/simplified-water-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/ne_10m_populated_places data/water-polygons-split-3857
+  - touch data/world_boundaries/builtup_area.shp data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/ne_10m_populated_places/ne_10m_populated_places_fixed.shp data/water-polygons-split-3857/water_polygons.shp
 script:
   - jsonlint project.mml
   - ./node_modules/carto/bin/carto project.mml | xmllint - | wc -l

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,9 @@ To download the shapefiles you can run the following script from this directory.
 You can also download them manually at the following paths:
 
 * [`simplified-land-polygons.shp`](http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip) (updated daily)
+* [`simplified-water-polygons.shp`](http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip) (updated daily)
 * [`land-polygon.shp`](http://data.openstreetmapdata.com/land-polygons-split-3857.zip) (updated daily)
+* [`water-polygon.shp`](http://data.openstreetmapdata.com/water-polygons-split-3857.zip) (updated daily)
 * [`builtup_area.shp`](http://planet.openstreetmap.org/historical-shapefiles/world_boundaries-spherical.tgz)
 * [`ne_110m_admin_0_boundary_lines_land.shp`](http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip)
 

--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -28,6 +28,18 @@ unzip $UNZIP_OPTS data/simplified-land-polygons-complete-3857.zip \
   simplified-land-polygons-complete-3857/simplified_land_polygons.cpg \
   -d data/
 
+# simplified-land-polygons-complete-3857
+echo "downloading simplified-water-polygons-complete-3857..."
+curl -z "data/simplified-water-polygons-complete-3857.zip" -L -o "data/simplified-water-polygons-complete-3857.zip" "http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip"
+echo "simplified-water-polygons-complete-3857..."
+unzip $UNZIP_OPTS data/simplified-water-polygons-complete-3857.zip \
+  simplified-water-polygons-complete-3857/simplified_water_polygons.shp \
+  simplified-water-polygons-complete-3857/simplified_water_polygons.shx \
+  simplified-water-polygons-complete-3857/simplified_water_polygons.prj \
+  simplified-water-polygons-complete-3857/simplified_water_polygons.dbf \
+  simplified-water-polygons-complete-3857/simplified_water_polygons.cpg \
+  -d data/
+
 # ne_110m_admin_0_boundary_lines_land
 echo "downloading ne_110m_admin_0_boundary_lines_land..."
 curl -z data/ne_110m_admin_0_boundary_lines_land.zip -L -o data/ne_110m_admin_0_boundary_lines_land.zip http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip
@@ -49,6 +61,17 @@ unzip $UNZIP_OPTS data/land-polygons-split-3857.zip \
   land-polygons-split-3857/land_polygons.prj \
   land-polygons-split-3857/land_polygons.dbf \
   land-polygons-split-3857/land_polygons.cpg \
+  -d data/
+
+echo "downloading water-polygons-split-3857..."
+curl -z "data/water-polygons-split-3857.zip" -L -o "data/water-polygons-split-3857.zip" "http://data.openstreetmapdata.com/water-polygons-split-3857.zip"
+echo "expanding water-polygons-split-3857..."
+unzip $UNZIP_OPTS data/water-polygons-split-3857.zip \
+  water-polygons-split-3857/water_polygons.shp \
+  water-polygons-split-3857/water_polygons.shx \
+  water-polygons-split-3857/water_polygons.prj \
+  water-polygons-split-3857/water_polygons.dbf \
+  water-polygons-split-3857/water_polygons.cpg \
   -d data/
 
 # antarctica-icesheet-polygons-3857
@@ -77,7 +100,9 @@ unzip $UNZIP_OPTS data/antarctica-icesheet-outlines-3857.zip \
 echo "indexing shapefiles"
 shapeindex --shape_files \
 data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp \
+data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp \
 data/land-polygons-split-3857/land_polygons.shp \
+data/water-polygons-split-3857/water_polygons.shp \
 data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp \
 data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp \
 data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp

--- a/get-shapefiles.sh
+++ b/get-shapefiles.sh
@@ -6,9 +6,9 @@ UNZIP_OPTS=-qqun
 # create and populate data dir
 mkdir -p data/
 mkdir -p data/world_boundaries
-mkdir -p data/simplified-land-polygons-complete-3857
+mkdir -p data/simplified-water-polygons-complete-3857
 mkdir -p data/ne_110m_admin_0_boundary_lines_land
-mkdir -p data/land-polygons-split-3857
+mkdir -p data/water-polygons-split-3857
 
 # world_boundaries
 echo "downloading world_boundaries..."
@@ -16,19 +16,7 @@ curl -z "data/world_boundaries-spherical.tgz" -L -o "data/world_boundaries-spher
 echo "expanding world_boundaries..."
 tar -xzf data/world_boundaries-spherical.tgz -C data/
 
-# simplified-land-polygons-complete-3857
-echo "downloading simplified-land-polygons-complete-3857..."
-curl -z "data/simplified-land-polygons-complete-3857.zip" -L -o "data/simplified-land-polygons-complete-3857.zip" "http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip"
-echo "simplified-land-polygons-complete-3857..."
-unzip $UNZIP_OPTS data/simplified-land-polygons-complete-3857.zip \
-  simplified-land-polygons-complete-3857/simplified_land_polygons.shp \
-  simplified-land-polygons-complete-3857/simplified_land_polygons.shx \
-  simplified-land-polygons-complete-3857/simplified_land_polygons.prj \
-  simplified-land-polygons-complete-3857/simplified_land_polygons.dbf \
-  simplified-land-polygons-complete-3857/simplified_land_polygons.cpg \
-  -d data/
-
-# simplified-land-polygons-complete-3857
+# simplified-water-polygons-complete-3857
 echo "downloading simplified-water-polygons-complete-3857..."
 curl -z "data/simplified-water-polygons-complete-3857.zip" -L -o "data/simplified-water-polygons-complete-3857.zip" "http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip"
 echo "simplified-water-polygons-complete-3857..."
@@ -51,18 +39,7 @@ unzip $UNZIP_OPTS data/ne_110m_admin_0_boundary_lines_land.zip \
   ne_110m_admin_0_boundary_lines_land.dbf \
   -d data/ne_110m_admin_0_boundary_lines_land/
 
-# land-polygons-split-3857
-echo "downloading land-polygons-split-3857..."
-curl -z "data/land-polygons-split-3857.zip" -L -o "data/land-polygons-split-3857.zip" "http://data.openstreetmapdata.com/land-polygons-split-3857.zip"
-echo "expanding land-polygons-split-3857..."
-unzip $UNZIP_OPTS data/land-polygons-split-3857.zip \
-  land-polygons-split-3857/land_polygons.shp \
-  land-polygons-split-3857/land_polygons.shx \
-  land-polygons-split-3857/land_polygons.prj \
-  land-polygons-split-3857/land_polygons.dbf \
-  land-polygons-split-3857/land_polygons.cpg \
-  -d data/
-
+# water-polygons-split-3857
 echo "downloading water-polygons-split-3857..."
 curl -z "data/water-polygons-split-3857.zip" -L -o "data/water-polygons-split-3857.zip" "http://data.openstreetmapdata.com/water-polygons-split-3857.zip"
 echo "expanding water-polygons-split-3857..."
@@ -99,9 +76,7 @@ unzip $UNZIP_OPTS data/antarctica-icesheet-outlines-3857.zip \
 #index
 echo "indexing shapefiles"
 shapeindex --shape_files \
-data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp \
 data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp \
-data/land-polygons-split-3857/land_polygons.shp \
 data/water-polygons-split-3857/water_polygons.shp \
 data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp \
 data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp \

--- a/project.mml
+++ b/project.mml
@@ -2,6 +2,50 @@
   "interactivity": false,
   "Layer": [
     {
+      "name": "ocean-lz",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "ocean",
+      "id": "ocean-lz",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "maxzoom": 9
+      },
+      "advanced": {}
+    },
+    {
+      "name": "ocean",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "ocean",
+      "id": "ocean",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/water-polygons-split-3857/water_polygons.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 10
+      },
+      "advanced": {}
+    },
+    {
       "name": "builtup",
       "srs-name": "mercator",
       "geometry": "polygon",
@@ -197,50 +241,6 @@
       ],
       "properties": {
         "minzoom": 4
-      },
-      "advanced": {}
-    },
-    {
-      "name": "ocean-lz",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "ocean",
-      "id": "ocean-lz",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "type": "shape",
-        "file": "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "maxzoom": 9
-      },
-      "advanced": {}
-    },
-    {
-      "name": "ocean",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "ocean",
-      "id": "ocean",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "type": "shape",
-        "file": "data/water-polygons-split-3857/water_polygons.shp"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
       },
       "advanced": {}
     },

--- a/project.mml
+++ b/project.mml
@@ -2,50 +2,6 @@
   "interactivity": false,
   "Layer": [
     {
-      "name": "world",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "world",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "type": "shape",
-        "file": "data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "maxzoom": 9
-      },
-      "advanced": {}
-    },
-    {
-      "name": "coast-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "coast-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "type": "shape",
-        "file": "data/land-polygons-split-3857/land_polygons.shp"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
-      },
-      "advanced": {}
-    },
-    {
       "name": "builtup",
       "srs-name": "mercator",
       "geometry": "polygon",
@@ -241,6 +197,50 @@
       ],
       "properties": {
         "minzoom": 4
+      },
+      "advanced": {}
+    },
+    {
+      "name": "ocean-lz",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "ocean",
+      "id": "ocean-lz",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "maxzoom": 9
+      },
+      "advanced": {}
+    },
+    {
+      "name": "ocean",
+      "srs-name": "900913",
+      "geometry": "polygon",
+      "class": "ocean",
+      "id": "ocean",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "Datasource": {
+        "type": "shape",
+        "file": "data/water-polygons-split-3857/water_polygons.shp"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "minzoom": 10
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -53,6 +53,28 @@ Stylesheet:
   - "admin.mss"
   - "addressing.mss"
 Layer:
+  - id: "ocean-lz"
+    name: "ocean-lz"
+    class: "ocean"
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      file: "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
+      type: "shape"
+    advanced: {}
+    properties:
+      maxzoom: 9
+  - id: "ocean"
+    name: "ocean"
+    class: "ocean"
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      file: "data/water-polygons-split-3857/water_polygons.shp"
+      type: "shape"
+    properties:
+      minzoom: 10
+    advanced: {}
   - id: "builtup"
     name: "builtup"
     geometry: "polygon"
@@ -218,28 +240,6 @@ Layer:
       type: "shape"
     properties:
       minzoom: 4
-    advanced: {}
-  - id: "ocean-lz"
-    name: "ocean-lz"
-    class: "ocean"
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      file: "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
-      type: "shape"
-    advanced: {}
-    properties:
-      maxzoom: 9
-  - id: "ocean"
-    name: "ocean"
-    class: "ocean"
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      file: "data/water-polygons-split-3857/water_polygons.shp"
-      type: "shape"
-    properties:
-      minzoom: 10
     advanced: {}
   - id: "water-areas"
     name: "water-areas"

--- a/project.yaml
+++ b/project.yaml
@@ -53,28 +53,6 @@ Stylesheet:
   - "admin.mss"
   - "addressing.mss"
 Layer:
-  - id: "world"
-    name: "world"
-    class: ""
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      file: "data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp"
-      type: "shape"
-    advanced: {}
-    properties:
-      maxzoom: 9
-  - id: "coast-poly"
-    name: "coast-poly"
-    class: ""
-    geometry: "polygon"
-    <<: *extents
-    Datasource:
-      file: "data/land-polygons-split-3857/land_polygons.shp"
-      type: "shape"
-    properties:
-      minzoom: 10
-    advanced: {}
   - id: "builtup"
     name: "builtup"
     geometry: "polygon"
@@ -240,6 +218,28 @@ Layer:
       type: "shape"
     properties:
       minzoom: 4
+    advanced: {}
+  - id: "ocean-lz"
+    name: "ocean-lz"
+    class: "ocean"
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      file: "data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp"
+      type: "shape"
+    advanced: {}
+    properties:
+      maxzoom: 9
+  - id: "ocean"
+    name: "ocean"
+    class: "ocean"
+    geometry: "polygon"
+    <<: *extents
+    Datasource:
+      file: "data/water-polygons-split-3857/water_polygons.shp"
+      type: "shape"
+    properties:
+      minzoom: 10
     advanced: {}
   - id: "water-areas"
     name: "water-areas"

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -11,18 +11,6 @@
   }
 }
 
-#world {
-  [zoom >= 0][zoom < 10] {
-    polygon-fill: @land-color;
-  }
-}
-
-#coast-poly {
-  [zoom >= 10] {
-    polygon-fill: @land-color;
-  }
-}
-
 #icesheet-poly {
   [zoom >= 6] {
     polygon-fill: @glacier;

--- a/style.mss
+++ b/style.mss
@@ -1,5 +1,5 @@
 Map {
-  background-color: @water-color;
+  background-color: @land-color;
 }
 
 @book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",

--- a/water.mss
+++ b/water.mss
@@ -56,6 +56,9 @@
   }
 }
 
+.ocean {
+  polygon-fill: @water-color;
+}
 #water-lines-casing {
   [waterway = 'stream'],
   [waterway = 'ditch'],

--- a/water.mss
+++ b/water.mss
@@ -17,48 +17,31 @@
       }
     }
   }
-
-  [waterway = 'dock'],
-  [waterway = 'canal'] {
-    [zoom >= 9]::waterway {
-      polygon-fill: @water-color;
-      [way_pixels >= 4] {
-        polygon-gamma: 0.75;
-      }
-      [way_pixels >= 64] {
-        polygon-gamma: 0.6;
-      }
-    }
-  }
-
-  [landuse = 'basin'][zoom >= 7]::landuse {
-    polygon-fill: @water-color;
-    [way_pixels >= 4] {
-      polygon-gamma: 0.75;
-    }
-    [way_pixels >= 64] {
-      polygon-gamma: 0.6;
-    }
-  }
-
-  [natural = 'water']::natural,
-  [landuse = 'reservoir']::landuse,
-  [waterway = 'riverbank']::waterway {
-    [zoom >= 6] {
-      polygon-fill: @water-color;
-      [way_pixels >= 4] {
-        polygon-gamma: 0.75;
-      }
-      [way_pixels >= 64] {
-        polygon-gamma: 0.6;
-      }
-    }
-  }
 }
 
+/*
+ * Water areas, of all types. Because they are rendered all the same,
+ * attachments can be used to reduce combinational rules
+ */
+
+#water-areas[waterway = 'dock'][zoom >= 9]::waterway,
+#water-areas[waterway = 'canal'][zoom >= 9]::waterway,
+#water-areas[landuse = 'basin'][zoom >= 7]::landuse,
+#water-areas[natural = 'water'][zoom >= 6]::natural,
+#water-areas[landuse = 'reservoir'][zoom >= 6]::landuse,
+#water-areas[waterway = 'riverbank'][zoom >= 6]::waterway,
 .ocean {
   polygon-fill: @water-color;
+
+  // Only the SQL layers have way_pixels
+  #water-areas[way_pixels >= 4] {
+    polygon-gamma: 0.75;
+  }
+  #water-areas[way_pixels >= 64] {
+    polygon-gamma: 0.6;
+  }
 }
+
 #water-lines-casing {
   [waterway = 'stream'],
   [waterway = 'ditch'],


### PR DESCRIPTION
This should have no rendering changes, as the base land and base ocean are still the first things drawn.

We may want to re-order later to put water polygons by ocean polygons, but this will require consideration of what landuse should appear on oceans

Fixes #1982.