### PR TITLE
Change and unify colors for stadium/track/pitch to be less dominating

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1624,7 +1624,7 @@
       }
       [feature = 'leisure_sports_centre'],
       [feature = 'leisure_stadium'] {
-        text-fill: darken(@stadium, 30%);
+        text-fill: darken(@stadium, 70%);
       }
       [feature = 'leisure_track'] {
         text-fill: darken(@track, 40%);

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1610,7 +1610,7 @@
       [feature = 'amenity_school'],
       [feature = 'amenity_college'],
       [feature = 'amenity_university'] {
-        text-fill: darken(@educational_areas_and_hospital, 70%);
+        text-fill: darken(@societal_amenities, 70%);
       }
       [feature = 'natural_heath'] {
         text-fill: darken(@heath, 40%);

--- a/landcover.mss
+++ b/landcover.mss
@@ -46,7 +46,7 @@
 @power-line: darken(@industrial-line, 5%);
 @rest_area: #efc8c8; // also services
 @sand: #f5e9c6;
-@educational_areas_and_hospital: #f0f0d8;
+@societal_amenities: #f0f0d8;
 @station: #d4aaaa;
 @tourism: #734a08;
 @quarry: #c5c3c3;
@@ -57,7 +57,7 @@
 
 @pitch: #80d7b5;
 @track: @pitch;
-@stadium: @educational_areas_and_hospital; // also sports_centre
+@stadium: @societal_amenities; // also sports_centre
 @golf_course: #b5e3b5;
 
 #landcover-low-zoom[zoom < 10],
@@ -450,7 +450,7 @@
     [zoom >= 10] {
       polygon-fill: @residential;
       [zoom >= 12] {
-        polygon-fill: @educational_areas_and_hospital;
+        polygon-fill: @societal_amenities;
         [zoom >= 13] {
           line-width: 0.3;
           line-color: brown;

--- a/landcover.mss
+++ b/landcover.mss
@@ -1,18 +1,11 @@
 // --- Parks, woods, other green things ---
 
 @grass: #cdebb0; // also meadow, common, garden, village_green
-@golf_course: #b5e3b5;
 @scrub: #b5e3b5;
 @forest: #add19e;       // Lch(80,30,135)
 @forest-text: #46673b;  // Lch(40,30,135)
 @park: #c8facc;         // Lch(94,30,145) also recreation_ground
 @orchard: #aedfa3;
-
-// --- sports ---
-
-@stadium: #3c9; // also sports_centre
-@track: #74dcba;
-@pitch: #8ad3af;
 
 // --- "base" landuses ---
 
@@ -59,6 +52,13 @@
 @quarry: #c5c3c3;
 @military: #f55;
 @beach: #fff1ba;
+
+// --- sports ---
+
+@pitch: #80d7b5;
+@track: @pitch;
+@stadium: @educational_areas_and_hospital; // also sports_centre
+@golf_course: #b5e3b5;
 
 #landcover-low-zoom[zoom < 10],
 #landcover[zoom >= 10] {
@@ -520,7 +520,7 @@
     polygon-fill: @track;
     [zoom >= 15] {
       line-width: 0.5;
-      line-color: saturate(darken(@track, 40%), 20%);
+      line-color: saturate(darken(@track, 30%), 20%);
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -530,7 +530,7 @@
     polygon-fill: @pitch;
     [zoom >= 15] {
       line-width: 0.5;
-      line-color: saturate(darken(@pitch, 40%), 20%);
+      line-color: saturate(darken(@pitch, 30%), 20%);
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }


### PR DESCRIPTION
This change replaces the very strong and dark color for stadium/sports_centre with the bright education/hospital color and unifies track/pitch into an intermediate green tone.

![before](http://www.imagico.de/files/sports-colors-before.png)![after](http://www.imagico.de/files/sports-colors-after.png)

This is based on the following considerations:

* the dark and strong color of stadium/sports_centre was a major problem since it stands out very strongly putting  a lot of emphasis on  these features and it does not comply with the general concept of using brighter and more muted colors for large features and stronger colors for small features.  Using the education color seems fitting since there are a lot of similarities.
* having a bright, neutral base color for stadium also encourages micromapping of features within - which currently often look ugly against the strong dark green.
* having different colors for track and pitch makes the map less readable and it is a quite special and culturally specific distinction anyway.
* removing two distinct colors from the style helps map clarity in general.

The line color for track/pitch was also brightened a bit because contrast to stadium is already strong with the new colors and this way mapped barriers can be better distinguished from plain edges.