### PR TITLE
Make tertiary road yellowish

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -5,7 +5,7 @@
 @trunk-fill: #f9b29c; // Lch(79,33,42), error 0.7
 @primary-fill: #fcd6a4; // Lch(88,31,74), error 1.7
 @secondary-fill: #f7fabf; // Lch(97,29,106), error 1.7
-@tertiary-fill: #ffffff;
+@tertiary-fill: #feffdf;
 @residential-fill: #ffffff;
 @service-fill: @residential-fill;
 @living-street-fill: #ededed;


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1974.

Trivial patch with non-trivial consequences, please propose some testing places from different parts of the world to see. Some screenshot samples around Warsaw for the start (click to see the full resolution):

1) City with residential, secondary and parking areas:
![zatiq0u3](https://cloud.githubusercontent.com/assets/5439713/13555830/fd19919e-e3ca-11e5-8249-6eb0864b9446.png)

2) City with school and hospital area around:
![uody0wgv](https://cloud.githubusercontent.com/assets/5439713/13555834/264c1640-e3cb-11e5-8f04-91eb5e23ca2a.png)

3) Outside the city with current (new) farmland color:
![soqg3vnv](https://cloud.githubusercontent.com/assets/5439713/13555842/562e338e-e3cb-11e5-8267-72687167fb81.png)
