### PR TITLE
Show national park boundaries from higher zoomlevel and larger size

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -190,7 +190,7 @@ overlapping borders correctly.
 }
 
 #nature-reserve-boundaries {
-  [way_pixels > 100][zoom >= 8] {
+  [way_pixels > 3000][zoom >= 8] {
     [zoom < 10] {
       ::fill {
         opacity: 0.05;


### PR DESCRIPTION
With this commit, national park boundaries will be shown from the
same zoomlevel and size as their label, effectively eradicating
small unlabelled national parks from the rendering.

Such small national parks seem to contribute to a crowded feel of
the map in the areas and zoom levels where they occur.
