### PR TITLE
fix possible admin label and line rendering mismatch

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1945,7 +1945,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
+        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n    AND osm_id < 0\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -2398,10 +2398,11 @@ Layer:
             way,
             name,
             admin_level
-          FROM planet_osm_polygon
+          FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
+            AND osm_id < 0
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:


### PR DESCRIPTION
Using `planet_osm_polygon` for admin labels while using `planet_osm_roads` for admin lines might lead to a mismatch between lines and labels where labels are rendered without lines. This PR changes the table to `planet_osm_roads` to match both parts.

before
![label_before](https://cloud.githubusercontent.com/assets/3531092/15689591/fa4253cc-277f-11e6-8853-2dcbee5e6e88.png)

after
![label_after](https://cloud.githubusercontent.com/assets/3531092/15689602/065748c0-2780-11e6-976f-9cca28d2615f.png)