### PR TITLE
thinner power=line and power=minor_line

### DIFF
--- a/power.mss
+++ b/power.mss
@@ -2,24 +2,33 @@
 
 #power-line {
   [zoom >= 14] {
-    line-width: 0.8;
+    line-width: 0.5;
     line-color: @power-line-color;
     [zoom >= 15] {
-      line-width: 0.9;
+      line-width: 0.6;
     }
     [zoom >= 16] {
-      line-width: 1.3;
+      line-width: 0.7;
     }
     [zoom >= 18] {
-      line-width: 1.5;
+      line-width: 1;
+    }
+    [zoom >= 19] {
+      line-width: 1.2;
     }
   }
 }
 
 #power-minorline {
   [zoom >= 16] {
-    line-width: 0.5;
+    line-width: 0.3;
     line-color: @power-line-color;
+    [zoom >= 17] {
+      line-width: 0.4;
+    }
+    [zoom >= 18] {
+      line-width: 0.5;
+    }
   }
 }
 


### PR DESCRIPTION
idea by @SomeoneElseOSM

In this version it is less radical to keep power lines readable also on busy background (typically - in cities).

fixes #1260

https://cloud.githubusercontent.com/assets/899988/15992477/b206ef6c-30cd-11e6-9283-958b1aa0803e.png
https://cloud.githubusercontent.com/assets/899988/15992470/a8f65958-30cd-11e6-8715-c68894c6392f.png
https://cloud.githubusercontent.com/assets/899988/15992476/b203e04c-30cd-11e6-9748-d32999848e41.png
https://cloud.githubusercontent.com/assets/899988/15992478/b207862a-30cd-11e6-9cdf-b465270d8619.png
https://cloud.githubusercontent.com/assets/899988/15992474/b1db5d98-30cd-11e6-8e87-fe5cd98945f5.png
https://cloud.githubusercontent.com/assets/899988/15992475/b1f3560a-30cd-11e6-888b-483980599b9e.png
https://cloud.githubusercontent.com/assets/899988/15992480/b208922c-30cd-11e6-8224-eee459a7b7a2.png
https://cloud.githubusercontent.com/assets/899988/15992479/b208bb44-30cd-11e6-85ab-4ef8191d2ce9.png
https://cloud.githubusercontent.com/assets/899988/15992481/b20a57ec-30cd-11e6-9951-e84155b010f7.png
