### PR TITLE
placenames-medium is not used on z3

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1306,7 +1306,7 @@
       ],
       "properties": {
         "maxzoom": 15,
-        "minzoom": 3
+        "minzoom": 4
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -1533,7 +1533,7 @@ Layer:
           ORDER BY score DESC, length(name) DESC, name
         ) AS placenames_medium
     properties:
-      minzoom: 3
+      minzoom: 4
       maxzoom: 15
     advanced: {}
   - id: "placenames-small"


### PR DESCRIPTION
No rendering change as nothing from this layer is rendered on z3 - see https://github.com/gravitystorm/openstreetmap-carto/blob/master/placenames.mss

Makes rendering on z3 slightly faster.