### PR TITLE
larger labels for placenames

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -66,7 +66,7 @@
     [zoom >= 4][score >= 3000000],
     [zoom >= 5][score >= 400000] {
       text-name: "[name]";
-      text-size: 8;
+      text-size: 11;
       text-fill: @placenames;
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;
@@ -74,12 +74,20 @@
       text-wrap-width: 30;
       text-min-distance: 10;
       [zoom >= 5] {
-        text-size: 10;
+        text-size: 11;
         text-wrap-width: 45;
       }
       [zoom >= 6] {
         text-size: 12;
         text-wrap-width: 60;
+      }
+      [zoom >= 8] {
+        text-size: 13;
+        text-wrap-width: 60;
+      }
+      [zoom >= 9] {
+        text-size: 14;
+        text-wrap-width: 65;
       }
       [zoom >= 11] {
         text-size: 15;
@@ -94,7 +102,7 @@
     [zoom >= 6][score >= 70000],
     [zoom >= 7] {
       text-name: "[name]";
-      text-size: 9;
+      text-size: 10;
       text-fill: @placenames;
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;
@@ -102,7 +110,7 @@
       text-wrap-width: 30;
       text-min-distance: 10;
       [zoom >= 9] {
-        text-size: 11;
+        text-size: 12;
         text-wrap-width: 60;
       }
       [zoom >= 11] {
@@ -121,7 +129,7 @@
   [category = 2] {
     [zoom >= 9][zoom < 16] {
       text-name: "[name]";
-      text-size: 9;
+      text-size: 10;
       text-fill: @placenames;
       text-face-name: @book-fonts;
       text-halo-radius: 1.5;


### PR DESCRIPTION
fixes #2175 

I tested some modifications to mid-zoom levels. Increasing labels for placenames is one that is a clear improvement (at least according to my tests).

https://cloud.githubusercontent.com/assets/899988/16192682/04cd0e84-36eb-11e6-97cf-a32621eff58e.png
https://cloud.githubusercontent.com/assets/899988/16192683/04cf6198-36eb-11e6-8a43-8c41a17fbb51.png
https://cloud.githubusercontent.com/assets/899988/16192685/04d732ce-36eb-11e6-8b4d-a459f8e90a71.png
https://cloud.githubusercontent.com/assets/899988/16192684/04d6e418-36eb-11e6-87c1-3837ad132099.png
https://cloud.githubusercontent.com/assets/899988/16192686/04d89448-36eb-11e6-8132-d08095584646.png
https://cloud.githubusercontent.com/assets/899988/16192687/04da6160-36eb-11e6-8044-cfabeda5c9d0.png
https://cloud.githubusercontent.com/assets/899988/16192688/0618aec4-36eb-11e6-9469-c599e65cfd1a.png