### PR TITLE
it is not necessary to query buildings for z12, as buildings are not displayed on z12

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -548,7 +548,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 12
+        "minzoom": 13
       },
       "advanced": {}
     },
@@ -574,7 +574,7 @@
         85.05112877980659
       ],
       "properties": {
-        "minzoom": 12
+        "minzoom": 13
       },
       "advanced": {}
     },

--- a/project.yaml
+++ b/project.yaml
@@ -460,7 +460,7 @@ Layer:
           ORDER BY z_order, way_area DESC
         ) AS buildings
     properties:
-      minzoom: 12
+      minzoom: 13
     advanced: {}
   - id: "buildings-major"
     name: "buildings-major"
@@ -483,7 +483,7 @@ Layer:
           ORDER BY z_order, way_area DESC)
         AS buildings_major
     properties:
-      minzoom: 12
+      minzoom: 13
     advanced: {}
   - id: "tunnels"
     name: "tunnels"


### PR DESCRIPTION
see https://github.com/gravitystorm/openstreetmap-carto/blob/d789bdac60a17ff8fe18e6d8b978423147c21c53/buildings.mss#L13

it makes z12 significantly faster