### PR TITLE
Update fonts list for Ubuntu 16.04

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 * Unifont, as a last resort fallback (`ttf-unifont`)
 
 ### Southeast Asia
-* Arundina Sans, for Thai (`fonts-sipa-arundina`)
+* Arundina, for Thai (`fonts-sipa-arundina`)
 * Padauk, for Burmese (`fonts-sil-padauk`)
 * Khmer OS Metal Chrieng Regular, for Khmer (`fonts-khmeros`)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ If a font is missing, it will skip to the next available font which contains tho
 
 * Mukti Narrow, for Bangali (`fonts-beng-extra`)
 * Gargi Medium, for Devanagari (`fonts-gargi`)
-* TSCu_Paranar, for Tamil (`ttf-tamil-fonts` or ``fonts-taml-tscu``, depending on your Ubuntu version)
+* TSCu_Paranar, for Tamil (`fonts-taml-tscu`)
 
 On Ubuntu you can install all the fonts with
 
@@ -68,7 +68,6 @@ On Ubuntu you can install all the fonts with
 sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
 fonts-beng-extra fonts-gargi fonts-taml-tscu
 ```
-In Ubuntu 13.10 (Saucy) and lower, replace fonts-taml-tscu with ttf-tamil-fonts.
 
 ## Dependencies
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,8 +65,9 @@ If a font is missing, it will skip to the next available font which contains tho
 On Ubuntu you can install all the fonts with
 
 ```
-sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
-fonts-beng-extra fonts-gargi fonts-taml-tscu
+sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont \
+  fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
+  fonts-beng-extra fonts-gargi fonts-taml-tscu
 ```
 
 ## Dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,15 +58,15 @@ If a font is missing, it will skip to the next available font which contains tho
 
 ### South Asia
 
-* Mukti Narrow, for Bangali (`ttf-indic-fonts-core`)
-* Gargi Medium, for Devanagari (`ttf-indic-fonts-core`)
+* Mukti Narrow, for Bangali (`fonts-beng-extra`)
+* Gargi Medium, for Devanagari (`fonts-gargi`)
 * TSCu_Paranar, for Tamil (`ttf-tamil-fonts` or ``fonts-taml-tscu``, depending on your Ubuntu version)
 
 On Ubuntu you can install all the fonts with
 
 ```
 sudo apt-get install ttf-dejavu fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
-ttf-indic-fonts-core fonts-taml-tscu
+fonts-beng-extra fonts-gargi fonts-taml-tscu
 ```
 In Ubuntu 13.10 (Saucy) and lower, replace fonts-taml-tscu with ttf-tamil-fonts.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,9 +42,11 @@ The repeated www.naturalearthdata.com in the Natural Earth shapefiles is correct
 Put these shapefiles at `path/to/openstreetmap-carto/data`.
 
 ## Fonts
-The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu is indicated.
+The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu 14.04 is indicated.
 
-If a font is missing, it will skip to the next available font which contains those characters. If you are not concerned with a particular language, you do not need its fonts. DejaVu Sans and Unifont are the two required fonts, and included on most systems.
+If a font is missing, it will skip to the next available font which contains those characters. If you are not concerned with a particular script, you do not need its fonts. DejaVu Sans and Unifont are the two required fonts, and included on most systems.
+
+Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particularly those with complicated diacritics and tone marks.
 
 ### Global
 * DejaVu Sans, for most languages (`fonts-dejavu-core`)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,13 +61,12 @@ If a font is missing, it will skip to the next available font which contains tho
 * Mukti Narrow, for Bangali (`ttf-indic-fonts-core`)
 * Gargi Medium, for Devanagari (`ttf-indic-fonts-core`)
 * TSCu_Paranar, for Tamil (`ttf-tamil-fonts` or ``fonts-taml-tscu``, depending on your Ubuntu version)
-* Mallige, for Kannada (`ttf-indic-fonts-core` for normal and bold and `ttf-kannada-fonts` for oblique) *The filename uses "Malige" but the font name uses "Mallige"*
 
 On Ubuntu you can install all the fonts with
 
 ```
 sudo apt-get install ttf-dejavu fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
-ttf-indic-fonts-core fonts-taml-tscu ttf-kannada-fonts
+ttf-indic-fonts-core fonts-taml-tscu
 ```
 In Ubuntu 13.10 (Saucy) and lower, replace fonts-taml-tscu with ttf-tamil-fonts.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ The repeated www.naturalearthdata.com in the Natural Earth shapefiles is correct
 Put these shapefiles at `path/to/openstreetmap-carto/data`.
 
 ## Fonts
-The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu 14.04 is indicated.
+The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu 16.04 is indicated.
 
 If a font is missing, it will skip to the next available font which contains those characters. If you are not concerned with a particular script, you do not need its fonts. DejaVu Sans and Unifont are the two required fonts, and included on most systems.
 
@@ -50,7 +50,7 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 
 ### Global
 * DejaVu Sans, for most languages (`fonts-dejavu-core`)
-* Droid Sans Fallback, as a reasonable fallback (`fonts-droid`)
+* Droid Sans Fallback, as a reasonable fallback (`fonts-droid-fallback`)
 * Unifont, as a last resort fallback (`ttf-unifont`)
 
 ### Southeast Asia
@@ -68,10 +68,12 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 On Ubuntu you can install all the fonts with
 
 ```
-sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont \
+sudo apt-get install fonts-dejavu-core fonts-droid-fallback ttf-unifont \
   fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
   fonts-beng-extra fonts-gargi fonts-taml-tscu fonts-tibetan-machine
 ```
+
+On Ubuntu 14.04, replace `fonts-droid-fallback` with `fonts-droid`.
 
 ## Dependencies
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ The repeated www.naturalearthdata.com in the Natural Earth shapefiles is correct
 Put these shapefiles at `path/to/openstreetmap-carto/data`.
 
 ## Fonts
-The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu 16.04 is indicated.
+The stylesheet depends on a number of openly licensed fonts for support of all the languages found on the map. The package which supplies these fonts on Ubuntu 16.04 or Debian Testing is indicated.
 
 If a font is missing, it will skip to the next available font which contains those characters. If you are not concerned with a particular script, you do not need its fonts. DejaVu Sans and Unifont are the two required fonts, and included on most systems.
 
@@ -65,7 +65,7 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 * TSCu_Paranar, for Tamil (`fonts-taml-tscu`)
 * Tibetan Machine Uni, for Tibetian (`fonts-tibetan-machine`)
 
-On Ubuntu you can install all the fonts with
+On Ubuntu 16.04 or Debian Testing you can install all the fonts with
 
 ```
 sudo apt-get install fonts-dejavu-core fonts-droid-fallback ttf-unifont \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,13 +63,14 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 * Mukti Narrow, for Bangali (`fonts-beng-extra`)
 * Gargi Medium, for Devanagari (`fonts-gargi`)
 * TSCu_Paranar, for Tamil (`fonts-taml-tscu`)
+* Tibetan Machine Uni, for Tibetian (`fonts-tibetan-machine`)
 
 On Ubuntu you can install all the fonts with
 
 ```
 sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont \
   fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
-  fonts-beng-extra fonts-gargi fonts-taml-tscu
+  fonts-beng-extra fonts-gargi fonts-taml-tscu fonts-tibetan-machine
 ```
 
 ## Dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ The stylesheet depends on a number of openly licensed fonts for support of all t
 If a font is missing, it will skip to the next available font which contains those characters. If you are not concerned with a particular language, you do not need its fonts. DejaVu Sans and Unifont are the two required fonts, and included on most systems.
 
 ### Global
-* DejaVu Sans, for most languages (`ttf-dejavu`)
+* DejaVu Sans, for most languages (`fonts-dejavu-core`)
 * Droid Sans Fallback, as a reasonable fallback (`fonts-droid`)
 * Unifont, as a last resort fallback (`ttf-unifont`)
 
@@ -65,7 +65,7 @@ If a font is missing, it will skip to the next available font which contains tho
 On Ubuntu you can install all the fonts with
 
 ```
-sudo apt-get install ttf-dejavu fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
+sudo apt-get install fonts-dejavu-core fonts-droid ttf-unifont fonts-sipa-arundina fonts-sil-padauk fonts-khmeros \
 fonts-beng-extra fonts-gargi fonts-taml-tscu
 ```
 In Ubuntu 13.10 (Saucy) and lower, replace fonts-taml-tscu with ttf-tamil-fonts.

--- a/style.mss
+++ b/style.mss
@@ -3,7 +3,7 @@ Map {
 }
 
 @book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
-                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
+                "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 @bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "Mukti Narrow Bold", "TSCu_Paranar Bold",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
@@ -12,7 +12,7 @@ Map {
 
 @oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
-                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
+                "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
 @water-color: #b5d0d0;

--- a/style.mss
+++ b/style.mss
@@ -2,16 +2,16 @@ Map {
   background-color: @water-color;
 }
 
-@book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+@book-fonts:    "DejaVu Sans Book", "Arundina Regular", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
-@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "TSCu_Paranar Bold",
-                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+@bold-fonts:    "DejaVu Sans Bold", "Arundina Bold", "Arundina Sans Bold", "Padauk Bold", "TSCu_Paranar Bold",
+                "DejaVu Sans Book", "Arundina Regular", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
-@oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic",
-                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+@oblique-fonts: "DejaVu Sans Oblique", "Arundina Italic", "Arundina Sans Italic", "TSCu_Paranar Italic",
+                "DejaVu Sans Book", "Arundina Regular", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 

--- a/style.mss
+++ b/style.mss
@@ -3,16 +3,16 @@ Map {
 }
 
 @book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
-                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
-@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "Mukti Narrow Bold", "TSCu_Paranar Bold", "Mallige Bold",
+@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "Mukti Narrow Bold", "TSCu_Paranar Bold",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
-                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
 @oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
-                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
 @water-color: #b5d0d0;

--- a/style.mss
+++ b/style.mss
@@ -5,12 +5,12 @@ Map {
 @book-fonts:    "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
-@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "Mukti Narrow Bold", "TSCu_Paranar Bold",
+@bold-fonts:    "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "TSCu_Paranar Bold",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
-@oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
+@oblique-fonts: "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic",
                 "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
                 "Mukti Narrow Regular", "Gargi Regular", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular",
                 "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";


### PR DESCRIPTION
Fixes #2200 by removing fonts that have disappeared, updating package names, and updating font names.

-----

Running ``python -c "from mapnik import FontEngine as e;print '\n'.join(e.instance().face_names())"`` gives a list of fonts known to Mapnik. Doing this with 16.04 and eliminating Serif and Mono fonts gives

```
Ani Regular
Arundina Bold
Arundina Bold Italic
Arundina Italic
Arundina Regular
DejaVu Sans Bold
DejaVu Sans Bold Oblique
DejaVu Sans Book
DejaVu Sans Condensed
DejaVu Sans Condensed Bold
DejaVu Sans Condensed Bold Oblique
DejaVu Sans Condensed Oblique
DejaVu Sans ExtraLight
DejaVu Sans Oblique
Droid Sans Fallback Regular
Gargi Regular
Jamrul Normal
Khmer OS Battambang Regular
Khmer OS Bokor Regular
Khmer OS Content Regular
Khmer OS Fasthand Regular
Khmer OS Freehand Regular
Khmer OS Metal Chrieng Regular
Khmer OS Muol Light Regular
Khmer OS Muol Pali Regular
Khmer OS Muol Regular
Khmer OS Regular
Khmer OS Siemreap Regular
Khmer OS System Regular
Likhan Normal
Mukti Narrow Regular
Padauk Bold
Padauk Book Bold
Padauk Book Regular
Padauk Regular
TSCu_Comic Normal
TSCu_Paranar Bold
TSCu_Paranar Italic
TSCu_Paranar Regular
TSCu_Times Normal
Tibetan Machine Uni Regular
Unifont CSUR Medium
Unifont Medium
Unifont Sample Medium
Unifont Upper CSUR Medium
Unifont Upper Medium
```

The same on 14.04 gives
```
Ani Regular
Arundina Sans Bold
Arundina Sans Bold Italic
Arundina Sans Italic
Arundina Sans Regular
DejaVu Sans Bold
DejaVu Sans Bold Oblique
DejaVu Sans Book
DejaVu Sans Condensed
DejaVu Sans Condensed Bold
DejaVu Sans Condensed Bold Oblique
DejaVu Sans Condensed Oblique
DejaVu Sans ExtraLight
DejaVu Sans Oblique
Droid Arabic Naskh Bold
Droid Arabic Naskh Regular
Droid Sans Armenian Regular
Droid Sans Bold
Droid Sans Ethiopic Bold
Droid Sans Ethiopic Regular
Droid Sans Fallback Regular
Droid Sans Georgian Regular
Droid Sans Hebrew Bold
Droid Sans Hebrew Regular
Droid Sans Japanese Regular
Droid Sans Regular
Droid Sans Thai Regular
Gargi Regular
Jamrul Normal
Khmer OS Battambang Regular
Khmer OS Bokor Regular
Khmer OS Content Regular
Khmer OS Fasthand Regular
Khmer OS Freehand Regular
Khmer OS Metal Chrieng Regular
Khmer OS Muol Light Regular
Khmer OS Muol Pali Regular
Khmer OS Muol Regular
Khmer OS Regular
Khmer OS Siemreap Regular
Khmer OS System Regular
Likhan Normal
Mukti Narrow Regular
Padauk Bold
Padauk Book Bold
Padauk Book Regular
Padauk Regular
TSCu_Comic Normal
TSCu_Paranar Bold
TSCu_Paranar Italic
TSCu_Paranar Regular
TSCu_Times Normal
Tibetan Machine Uni Regular
Unifont Sample Medium
unifont Medium
```

The diff is

```diff
--- a/1404.txt
+++ b/1604.txt
@@ -1,8 +1,8 @@
 Ani Regular
-Arundina Sans Bold
-Arundina Sans Bold Italic
-Arundina Sans Italic
-Arundina Sans Regular
+Arundina Bold
+Arundina Bold Italic
+Arundina Italic
+Arundina Regular
 DejaVu Sans Bold
 DejaVu Sans Bold Oblique
 DejaVu Sans Book
@@ -12,19 +12,7 @@ DejaVu Sans Condensed Bold Oblique
 DejaVu Sans Condensed Oblique
 DejaVu Sans ExtraLight
 DejaVu Sans Oblique
-Droid Arabic Naskh Bold
-Droid Arabic Naskh Regular
-Droid Sans Armenian Regular
-Droid Sans Bold
-Droid Sans Ethiopic Bold
-Droid Sans Ethiopic Regular
 Droid Sans Fallback Regular
-Droid Sans Georgian Regular
-Droid Sans Hebrew Bold
-Droid Sans Hebrew Regular
-Droid Sans Japanese Regular
-Droid Sans Regular
-Droid Sans Thai Regular
 Gargi Regular
 Jamrul Normal
 Khmer OS Battambang Regular
@@ -51,5 +39,8 @@ TSCu_Paranar Italic
 TSCu_Paranar Regular
 TSCu_Times Normal
 Tibetan Machine Uni Regular
+Unifont CSUR Medium
+Unifont Medium
 Unifont Sample Medium
-unifont Medium
+Unifont Upper CSUR Medium
+Unifont Upper Medium
```