### PR TITLE
Add tertiary to colour script; split up roads.mss

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2092,6 +2092,7 @@
     "landcover.mss",
     "water.mss",
     "water-features.mss",
+    "road-colors-generated.mss",
     "roads.mss",
     "power.mss",
     "citywalls.mss",

--- a/project.yaml
+++ b/project.yaml
@@ -41,6 +41,7 @@ Stylesheet:
   - "landcover.mss"
   - "water.mss"
   - "water-features.mss"
+  - "road-colors-generated.mss"
   - "roads.mss"
   - "power.mss"
   - "citywalls.mss"

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -1,0 +1,32 @@
+/* This is generated code, do not change this file manually.         */
+
+/* To change these definitions, alter                                */
+/* scripts/generate_road_colours.py and run:                         */
+/*                                                                   */
+/*   ./scripts/generate_road_colours.py > road-colors-generated.mss  */
+/*                                                                   */
+@motorway-fill: #e892a2;
+@trunk-fill: #f1aca0;
+@primary-fill: #f5c8aa;
+@secondary-fill: #f6e3bf;
+@tertiary-fill: #fafbdd;
+@motorway-low-zoom: #e66e89;
+@trunk-low-zoom: #f28b7b;
+@primary-low-zoom: #f3aa77;
+@secondary-low-zoom: #ecca82;
+@tertiary-low-zoom: #e2e79b;
+@motorway-casing: #dc2a67;
+@trunk-casing: #d25347;
+@primary-casing: #bf7239;
+@secondary-casing: #a88941;
+@tertiary-casing: #959a5a;
+@motorway-low-zoom-casing: #c24e6b;
+@trunk-low-zoom-casing: #cf6153;
+@primary-low-zoom-casing: #ce7b3c;
+@secondary-low-zoom-casing: #c0972c;
+@tertiary-low-zoom-casing: #a5b332;
+@shield-motorway-fill: #620728;
+@shield-trunk-fill: #601714;
+@shield-primary-fill: #572600;
+@shield-secondary-fill: #483300;
+@shield-tertiary-fill: #3b3b3b;

--- a/roads.mss
+++ b/roads.mss
@@ -1,11 +1,5 @@
 /* For the main linear features, such as roads and railways. */
 
-//road colors for major roads were generated with scripts/generate_road_colors.py
-@motorway-fill: #e892a2; // Lch(70,35,10), error 0.5
-@trunk-fill: #f9b29c; // Lch(79,33,42), error 0.7
-@primary-fill: #fcd6a4; // Lch(88,31,74), error 1.7
-@secondary-fill: #f7fabf; // Lch(97,29,106), error 1.7
-@tertiary-fill: #ffffff;
 @residential-fill: #ffffff;
 @service-fill: @residential-fill;
 @living-street-fill: #ededed;
@@ -22,16 +16,7 @@
 @taxiway-fill: @aeroway-fill;
 @helipad-fill: @aeroway-fill;
 
-@motorway-low-zoom: #e66e89; // Lch(62,50,10), error 0.7
-@trunk-low-zoom: #fa9476; // Lch(72,50,42), error 0.8
-@primary-low-zoom: #f8c171; // Lch(82,50,74), error 2.1
-@secondary-low-zoom: #e6ef89; // Lch(92,50,106), error 2.2
-
 @default-casing: white;
-@motorway-casing: #dc2a67; // Lch(50,70,10), error 1.1
-@trunk-casing: #c84e2f; // Lch(50,65,42), error 0.7
-@primary-casing: #a06b00; // Lch(50,60,74), error 1.6
-@secondary-casing: #707d05; // Lch(50,55,106), error 1.9
 @tertiary-casing: #8f8f8f;
 @residential-casing: #bbb;
 @road-casing: @residential-casing;
@@ -44,11 +29,6 @@
 @cycleway-casing: @default-casing;
 @bridleway-casing: @default-casing;
 @track-casing: @default-casing;
-
-@motorway-low-zoom-casing: #c24e6b; // Lch(50,50,10), error 0.8
-@trunk-low-zoom-casing: #cf6649; // Lch(56,55,42), error 0.9
-@primary-low-zoom-casing: #c38a27; // Lch(62,60,74), error 2.1
-@secondary-low-zoom-casing: #9eae23; // Lch(68,65,106), error 2.3
 
 @unimportant-road: @residential-casing;
 
@@ -107,7 +87,7 @@
 @trunk-width-z13:                 6;
 @primary-width-z13:               5;
 @secondary-width-z13:             5;
-@tertiary-width-z13:              4;
+@tertiary-width-z13:              3.75;
 @residential-width-z13:           2.5;
 @living-street-width-z13:         2;
 @pedestrian-width-z13:            2;
@@ -121,7 +101,7 @@
 @steps-width-z13:                 0.7;
 
 @secondary-width-z14:             5;
-@tertiary-width-z14:              5;
+@tertiary-width-z14:              4;
 @residential-width-z14:           3;
 @living-street-width-z14:         3;
 @pedestrian-width-z14:            3;
@@ -147,7 +127,7 @@
 @steps-width-z15:                 3;
 
 @secondary-width-z16:            10;
-@tertiary-width-z16:             10;
+@tertiary-width-z16:              8;
 @residential-width-z16:           6;
 @living-street-width-z16:         6;
 @pedestrian-width-z16:            6;
@@ -162,7 +142,7 @@
 @trunk-width-z17:                18;
 @primary-width-z17:              18;
 @secondary-width-z17:            18;
-@tertiary-width-z17:             18;
+@tertiary-width-z17:             15;
 @residential-width-z17:          12;
 @living-street-width-z17:        12;
 @pedestrian-width-z17:           12;
@@ -175,7 +155,7 @@
 @trunk-width-z18:                21;
 @primary-width-z18:              21;
 @secondary-width-z18:            21;
-@tertiary-width-z18:             21;
+@tertiary-width-z18:             17;
 @residential-width-z18:          13;
 @living-street-width-z18:        13;
 @pedestrian-width-z18:           13;
@@ -188,7 +168,7 @@
 @trunk-width-z19:                27;
 @primary-width-z19:              27;
 @secondary-width-z19:            27;
-@tertiary-width-z19:             27;
+@tertiary-width-z19:             22;
 @residential-width-z19:          17;
 @living-street-width-z19:        17;
 @pedestrian-width-z19:           17;

--- a/scripts/generate_road_colours.py
+++ b/scripts/generate_road_colours.py
@@ -3,120 +3,159 @@
 from colormath.color_conversions import convert_color
 from colormath.color_objects import LabColor, LCHabColor, sRGBColor
 from colormath.color_diff import delta_e_cie2000
-import numpy
+import sys
 
 from collections import OrderedDict, namedtuple
 
 class Color:
-  def __init__(self, lch_tuple):
-    self.m_lch = LCHabColor(*lch_tuple)
+    """A color in the CIE lch color space."""
 
-  def lch(self):
-    return "Lch({:.0f},{:.0f},{:.0f})".format(*(self.m_lch.get_value_tuple()))
+    def __init__(self, lch_tuple):
+        self.m_lch = LCHabColor(*lch_tuple)
 
-  def rgb(self):
-    rgb = convert_color(self.m_lch, sRGBColor)
-    if (rgb.rgb_r != rgb.clamped_rgb_r or rgb.rgb_g != rgb.clamped_rgb_g or rgb.rgb_b != rgb.clamped_rgb_b):
-      raise Exception("Colour {} is outside sRGB".format(self.lch()))
-    return rgb.get_rgb_hex()
+    def lch(self):
+        return "Lch({:.0f},{:.0f},{:.0f})".format(*(self.m_lch.get_value_tuple()))
 
-  def rgb_error(self):
-    return delta_e_cie2000(convert_color(self.m_lch, LabColor),
-                           convert_color(sRGBColor.new_from_rgb_hex(self.rgb()), LabColor))
+    def rgb(self):
+        rgb = convert_color(self.m_lch, sRGBColor)
+        if (rgb.rgb_r != rgb.clamped_rgb_r or rgb.rgb_g != rgb.clamped_rgb_g or rgb.rgb_b != rgb.clamped_rgb_b):
+            raise Exception("Colour {} is outside sRGB".format(self.lch()))
+        return rgb.get_rgb_hex()
 
-road_classes = ["motorway", "trunk", "primary", "secondary"]
-colour_divisions = len(road_classes) - 1
-hues = OrderedDict()
-
-# The minimum and maximum hue for the road colours
-# Because hue is a circle, it may be needed to add/subtract 360 to the min or
-# max when changing them
-
-min_h = 10
-max_h = 106
-delta_h = (max_h - min_h) / colour_divisions
-
-h = min_h
-for name in road_classes:
-  hues[name] = h
-  h = (h + delta_h) % 360
-
-print hues
-# A class to hold information for each line
-ColourInfo = namedtuple("ColourInfo", ["start_l", "end_l", "start_c", "end_c"])
-
-line_colour_infos = OrderedDict()
-
-# The saturation and lightness for each type of line
-line_colour_infos["fill"] = ColourInfo(start_l = 70, end_l = 97, start_c = 35, end_c = 29)
-line_colour_infos["low-zoom"] = ColourInfo(start_l = 62, end_l = 92, start_c = 50, end_c = 50)
-
-line_colour_infos["casing"] = ColourInfo(start_l = 50, end_l = 50, start_c = 70, end_c = 55)
-line_colour_infos["low-zoom-casing"] = ColourInfo(start_l = 50, end_l = 70, start_c = 50, end_c = 65)
-
-# Colours for the MSS
-colours = OrderedDict()
-
-for line_name, line_colour_info in line_colour_infos.iteritems():
-  c = line_colour_info.start_c
-  delta_c = (line_colour_info.end_c - line_colour_info.start_c) / colour_divisions
-  l = line_colour_info.start_l
-  delta_l = (line_colour_info.end_l - line_colour_info.start_l) / colour_divisions
-
-  for name in road_classes:
-    colours[name + "-" + line_name] = Color((l, c, hues[name]))
-    c += delta_c
-    l += delta_l
-
-for name, colour in colours.iteritems():
-  print "@{name}: {rgb}; // {lch}, error {delta:.1f}".format(name = name, rgb = colour.rgb(), lch = colour.lch(), delta = colour.rgb_error())
-
-# Generate colours for the shields
-shield_colour_info = {}
-shield_colour_info["fill"] = ColourInfo(start_l = 85, end_l = 95, start_c = 12, end_c = 14)
-shield_colour_info["stroke_fill"] = ColourInfo(start_l = 70, end_l = 80, start_c = 22, end_c = 24)
-shield_colour_info["text"] = ColourInfo(start_l = 20, end_l = 25, start_c = 40, end_c = 42)
-shield_colours = OrderedDict()
+    def rgb_error(self):
+        return delta_e_cie2000(convert_color(self.m_lch, LabColor),
+                               convert_color(sRGBColor.new_from_rgb_hex(self.rgb()), LabColor))
 
 
-c1 = shield_colour_info["fill"].start_c
-delta_c1 = (shield_colour_info["fill"].end_c - shield_colour_info["fill"].start_c) / colour_divisions
-l1 = shield_colour_info["fill"].start_l
-delta_l1 = (shield_colour_info["fill"].end_l - shield_colour_info["fill"].start_l) / colour_divisions
+def main():
+    # Print a warning about the nature of these definitions.
+    print "/* This is generated code, do not change this file manually.         */"
+    print
+    print "/* To change these definitions, alter                                */"
+    print "/* scripts/generate_road_colours.py and run:                         */"
+    print "/*                                                                   */"
+    print "/*   ./scripts/generate_road_colours.py > road-colors-generated.mss  */"
+    print "/*                                                                   */"
 
-c2 = shield_colour_info["stroke_fill"].start_c
-delta_c2 = (shield_colour_info["stroke_fill"].end_c - shield_colour_info["stroke_fill"].start_c) / colour_divisions
-l2 = shield_colour_info["stroke_fill"].start_l
-delta_l2 = (shield_colour_info["stroke_fill"].end_l - shield_colour_info["stroke_fill"].start_l) / colour_divisions
+    verbose = False
+    if len(sys.argv) == 2:
+        if sys.argv[1] == "-v":
+            verbose = True
 
-c3 = shield_colour_info["text"].start_c
-delta_c3 = (shield_colour_info["text"].end_c - shield_colour_info["text"].start_c) / colour_divisions
-l3 = shield_colour_info["text"].start_l
-delta_l3 = (shield_colour_info["text"].end_l - shield_colour_info["text"].start_l) / colour_divisions
+    # All road classes colours will be generated for, in order of importance (biggest first).
+    road_classes = ["motorway", "trunk", "primary", "secondary", "tertiary"]
+    colour_divisions = len(road_classes) - 1
+    hues = OrderedDict()
+    
+    # The minimum and maximum hue for the road colours
+    # Because hue is a circle, it may be needed to add/subtract 360 to the min or
+    # max when changing them
 
-for name in road_classes:
-  shield_colours[name] = {}
-  shield_colours[name]["fill"] = Color((l1, c1, hues[name]))
-  shield_colours[name]["stroke_fill"] = Color((l2, c2, hues[name]))
-  shield_colours[name]["text"] = Color((l3, c3, hues[name]))
-  c1 += delta_c1
-  l1 += delta_l1
-  c2 += delta_c2
-  l2 += delta_l2
-  c3 += delta_c3
-  l3 += delta_l3
+    # Red
+    min_h = 10
+    # Yellow-ish
+    max_h = 106
 
-shield_colours["tertiary"] = {}
-shield_colours["tertiary"]["fill"] = Color((shield_colour_info["fill"].end_l, 0, 0))
-shield_colours["tertiary"]["stroke_fill"] = Color((shield_colour_info["stroke_fill"].end_l, 0, 0))
-shield_colours["tertiary"]["text"] = Color((shield_colour_info["text"].end_l, 0, 0))
+    delta_h = (max_h - min_h) / colour_divisions
+    
+    h = min_h
+    for name in road_classes:
+        hues[name] = h
+        h = (h + delta_h) % 360
 
-print "\n\nRoad shield information\n\n"
-for name, colour in shield_colours.iteritems():
-  print "@shield-{name}-fill: {rgb}; // {lch}, error {delta:.1f}".format(name = name, rgb = colour["text"].rgb(), lch = colour["text"].lch(), delta = colour["text"].rgb_error())
+    # A class to hold information for each line
+    ColourInfo = namedtuple("ColourInfo", ["start_l", "end_l", "start_c", "end_c"])
 
-print "\n"
-for name, colour in shield_colours.iteritems():
-  # note that the two additional blanks at the beginning are intentional
-  print "  config['{name}']['fill'] = '{rgb}' # {lch}, error {delta:.1f}".format(name = name, rgb = colour["fill"].rgb(), lch = colour["fill"].lch(), delta = colour["fill"].rgb_error())
-  print "  config['{name}']['stroke_fill'] = '{rgb}' # {lch}, error {delta:.1f}".format(name = name, rgb = colour["stroke_fill"].rgb(), lch = colour["stroke_fill"].lch(), delta = colour["stroke_fill"].rgb_error())
+    line_colour_infos = OrderedDict()
+
+    # The lightness (l) and chroma (c; also known as saturation) for each type of colour.
+    # Lightness ranges from 0 to 100; dark to bright.
+    # Chroma ranges from 0 to 100 too; unsaturated to fully saturated.
+
+    # The higher the road classification, the higher its saturation. Conversely,
+    # the roads get brighter towards the lower end of the classification.
+    line_colour_infos["fill"] = ColourInfo(start_l = 70, end_l = 99, start_c = 35, end_c = 16)
+    line_colour_infos["low-zoom"] = ColourInfo(start_l = 62, end_l = 92, start_c = 50, end_c = 40)
+
+    line_colour_infos["casing"] = ColourInfo(start_l = 50, end_l = 65, start_c = 70, end_c = 36)
+    line_colour_infos["low-zoom-casing"] = ColourInfo(start_l = 50, end_l = 70, start_c = 50, end_c = 65)
+
+    # Colours for the MSS
+    colours = OrderedDict()
+
+    for line_name, line_colour_info in line_colour_infos.iteritems():
+        c = line_colour_info.start_c
+        delta_c = (line_colour_info.end_c - line_colour_info.start_c) / colour_divisions
+        l = line_colour_info.start_l
+        delta_l = (line_colour_info.end_l - line_colour_info.start_l) / colour_divisions
+
+        for name in road_classes:
+            colours[name + "-" + line_name] = Color((l, c, hues[name]))
+            c += delta_c
+            l += delta_l
+
+    for name, colour in colours.iteritems():
+        if verbose:
+            line = "@{name}: {rgb}; // {lch}, error {delta:.1f}"
+        else:
+            line = "@{name}: {rgb};"
+        print line.format(name = name, rgb = colour.rgb(), lch = colour.lch(), delta = colour.rgb_error())
+
+    # Generate colours for the shields
+    shield_colour_info = {}
+    shield_colour_info["fill"] = ColourInfo(start_l = 85, end_l = 95, start_c = 12, end_c = 14)
+    shield_colour_info["stroke_fill"] = ColourInfo(start_l = 70, end_l = 80, start_c = 22, end_c = 24)
+    shield_colour_info["text"] = ColourInfo(start_l = 20, end_l = 25, start_c = 40, end_c = 42)
+    shield_colours = OrderedDict()
+
+
+    c1 = shield_colour_info["fill"].start_c
+    delta_c1 = (shield_colour_info["fill"].end_c - shield_colour_info["fill"].start_c) / colour_divisions
+    l1 = shield_colour_info["fill"].start_l
+    delta_l1 = (shield_colour_info["fill"].end_l - shield_colour_info["fill"].start_l) / colour_divisions
+
+    c2 = shield_colour_info["stroke_fill"].start_c
+    delta_c2 = (shield_colour_info["stroke_fill"].end_c - shield_colour_info["stroke_fill"].start_c) / colour_divisions
+    l2 = shield_colour_info["stroke_fill"].start_l
+    delta_l2 = (shield_colour_info["stroke_fill"].end_l - shield_colour_info["stroke_fill"].start_l) / colour_divisions
+
+    c3 = shield_colour_info["text"].start_c
+    delta_c3 = (shield_colour_info["text"].end_c - shield_colour_info["text"].start_c) / colour_divisions
+    l3 = shield_colour_info["text"].start_l
+    delta_l3 = (shield_colour_info["text"].end_l - shield_colour_info["text"].start_l) / colour_divisions
+
+    for name in road_classes:
+        shield_colours[name] = {}
+        shield_colours[name]["fill"] = Color((l1, c1, hues[name]))
+        shield_colours[name]["stroke_fill"] = Color((l2, c2, hues[name]))
+        shield_colours[name]["text"] = Color((l3, c3, hues[name]))
+        c1 += delta_c1
+        l1 += delta_l1
+        c2 += delta_c2
+        l2 += delta_l2
+        c3 += delta_c3
+        l3 += delta_l3
+
+    shield_colours["tertiary"] = {}
+    shield_colours["tertiary"]["fill"] = Color((shield_colour_info["fill"].end_l, 0, 0))
+    shield_colours["tertiary"]["stroke_fill"] = Color((shield_colour_info["stroke_fill"].end_l, 0, 0))
+    shield_colours["tertiary"]["text"] = Color((shield_colour_info["text"].end_l, 0, 0))
+
+    #print "\n\nRoad shield information\n\n"
+    for name, colour in shield_colours.iteritems():
+        if verbose:
+            line = "@shield-{name}-fill: {rgb}; // {lch}, error {delta:.1f}"
+        else:
+            line = "@shield-{name}-fill: {rgb};"
+        print line.format(name = name, rgb = colour["text"].rgb(), lch = colour["text"].lch(), delta = colour["text"].rgb_error())
+
+    if verbose:
+        print "\n"
+        for name, colour in shield_colours.iteritems():
+            # note that the two additional blanks at the beginning are intentional
+            print "  config['{name}']['fill'] = '{rgb}' # {lch}, error {delta:.1f}".format(name = name, rgb = colour["fill"].rgb(), lch = colour["fill"].lch(), delta = colour["fill"].rgb_error())
+            print "  config['{name}']['stroke_fill'] = '{rgb}' # {lch}, error {delta:.1f}".format(name = name, rgb = colour["stroke_fill"].rgb(), lch = colour["stroke_fill"].lch(), delta = colour["stroke_fill"].rgb_error())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tertiary roads are now the fifth and final road that has its colours
generated by generate_road_colours.py. The script is amended to
facilitate this.

The generated colour values now reside in road-colors-generated.mss, and
have been removed from roads.mms. road-colors-generated.mms is generated
by the colour script, and should not be edited manually. To regenerate
it:

```
./scripts/generate_road_colours.py > road-colors-generated.mss
```

The original output of the colour script included configuration values
not used by us directly. To get this output as well as the generated
colours, call the script with the `-v` flag (for verbose).

This attempts to solve #2085.