### PR TITLE
Use binary mode for mml in yaml2mml

### DIFF
--- a/scripts/yaml2mml.py
+++ b/scripts/yaml2mml.py
@@ -17,7 +17,7 @@ try:
 
   try:
     if (args.check == False):
-      mml_file = open(mml_path, 'w')
+      mml_file = open(mml_path, 'wb')
       json.dump(yaml, mml_file, indent=2, separators=(',', ': '))
       mml_file.close()
     else:


### PR DESCRIPTION
This should keep newlines the same on Windows

Fixes #2153