### PR TITLE
reverts #2142 as it led to wrong admin labelling

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1945,7 +1945,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n    AND osm_id < 0\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
+        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -2429,11 +2429,10 @@ Layer:
             way,
             name,
             admin_level
-          FROM planet_osm_roads
+          FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
-            AND osm_id < 0
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:


### PR DESCRIPTION
originally reported by @mmd-osm in https://github.com/gravitystorm/openstreetmap-carto/pull/2142#issuecomment-233179715.

My analysis led to the outcome that ...

> I think the problem is that in planet_osm_polygon the text placement depends on the complete outline and in planet_osm_roads on the individual lines. While the winding order of polygons is defined and so two adjacent lines end up with different orientation in case of lines the same line might be shared and so the orientation is the same. That results in wrong text placement.

The only way I see to fix this and to fix the line and label mismatch is to switch all admin boundaries to `planet_osm_polygon`. Input on possible implications is welcome.

A release 2.41.1 might be necessary.