### PR TITLE
Font size 10 for junction names

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2402,19 +2402,13 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'traffic_signals'] {
     [zoom >= 14] {
       text-name: "[name]";
-      text-size: 8;
+      text-size: 10;
       text-fill: black;
       text-face-name: @book-fonts;
       text-halo-radius: 1;
       text-halo-fill: rgba(255,255,255,0.6);
       text-wrap-width: 30;
       text-min-distance: 2;
-      [zoom >= 14] {
-        text-size: 9;
-      }
-      [zoom >= 15] {
-        text-size: 10;
-      }
       [zoom >= 17] {
         text-size: 11;
         /* Offset name on traffic_signals on zoomlevels where they are displayed


### PR DESCRIPTION
Resolves part of #2209 

Uses font size 10 at zoom level 14. Other zoom levels unchanged.

Alternative might be to drop rendering of this feature at z14.

Before:
![screenshot 1](https://cloud.githubusercontent.com/assets/6830724/17084379/7c1e7efc-51ab-11e6-8eba-8f641bfd7973.png)

After:
![screenshot 2](https://cloud.githubusercontent.com/assets/6830724/17084382/8011b38a-51ab-11e6-901b-51d2a47bb33e.png)
