### PR TITLE
Different color for playground

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -41,7 +41,7 @@
 @parking: #f7efb7;
 @place_of_worship: #cdccc9;
 @place_of_worship_outline: #111;
-@playground: #ccfff1;
+@playground: lighten(@park, 5%);
 @power: darken(@industrial, 5%);
 @power-line: darken(@industrial-line, 5%);
 @rest_area: #efc8c8; // also services


### PR DESCRIPTION
Small tweak for a playground area. Currently playground areas are too visible for me (they stand out in the city) and they are also too blue (a bit like pool). 

After the fix they are light green and are still visible on school and park areas (the most usual places they exist):
![exgg1qfd](https://cloud.githubusercontent.com/assets/5439713/17161573/eb19d022-53ae-11e6-99c7-4fc1553df48b.png)

even when the icon is still not there:
![4sqwbf6l](https://cloud.githubusercontent.com/assets/5439713/17161599/18b0d60c-53af-11e6-9795-d3176ffbbcb3.png)

but also work reasonably on other surfaces, like grass or residential area:
![5ks4dbme](https://cloud.githubusercontent.com/assets/5439713/17161615/31bd9afe-53af-11e6-9c79-1894ae1534da.png)

It's a standalone fix, but can be very useful if we change the water color to be lighter than it is currently (see https://github.com/gravitystorm/openstreetmap-carto/issues/1781#issuecomment-235450267).