### PR TITLE
Ferry route names font size 10 at z13

### DIFF
--- a/ferry-routes.mss
+++ b/ferry-routes.mss
@@ -24,8 +24,7 @@
     text-placement: line;
     text-fill: @ferry-route-text;
     text-spacing: 1000;
-    text-size: 8;
-    [zoom >= 14] { text-size: 10; }
+    text-size: 10;
     text-halo-radius: 1;
     text-halo-fill: rgba(255,255,255,0.6);
     text-dy: -8;


### PR DESCRIPTION
Switch to font size font size 10 for ferry routes at z13. Implements part of #2209 

Before:
![screenshot 1](https://cloud.githubusercontent.com/assets/6830724/17174458/39ca973c-53f1-11e6-9b73-3ce458bce565.png)

After:
![screenshot 2](https://cloud.githubusercontent.com/assets/6830724/17174464/3eb03d92-53f1-11e6-8d3b-c84dbcae5a45.png)
