### PR TITLE
Drop sport from polygon_keys

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -27,7 +27,6 @@ local polygon_keys = {
     'power',
     'public_transport',
     'shop',
-    'sport',
     'tourism',
     'water',
     'waterway',


### PR DESCRIPTION
This is a PR against the lua branch.

Sport is a non-physical key, so it should always be combined with
another, physical key. That physical key should define whether the
object is a polygon or line. Since an object with a polygon key
and a line key will be treated as polygon, treating sport as line
by default is the sane default.

For example:
* sport=running, highway=footway should be treated as line. The
  current PR accomplishes this, before it would be a polygon.
* sport=soccer, leisure=pitch should be treated as polygon. Nothing
  changes here.

This resolves ... #854 but only after it gets merged into master.