### PR TITLE
Do not label waterway inside tunnel

### DIFF
--- a/water.mss
+++ b/water.mss
@@ -201,7 +201,7 @@
 }
 
 #water-lines-text {
-  [lock != 'yes'] {
+  [lock != 'yes'][int_tunnel != 'yes'] {
     [waterway = 'river'][zoom >= 13] {
       text-name: "[name]";
       text-face-name: @oblique-fonts;


### PR DESCRIPTION
Rendering labels of rivers flowing through canalizations is currently somewhat ugly.
Here is an example:
http://www.openstreetmap.org/#map=18/49.05799/8.52062

Thus I made this trivial change to German style. Probably also of interest to upstream.