### PR TITLE
Add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ When using the OpenStreetMap Carto spaces you should act in the spirit of the va
 
 The OpenStreetMap Carto maintainers are responsible for handling conduct-related issues. Their goal is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties.
 
-If you encounter a conduct-related issue, you should report it to the maintainers by email.
+If you encounter a conduct-related issue, you should report it to the maintainers by sending them [all an email](mailto:openstreetmap-carto@gravitystorm.co.uk,penorman@mac.com,info@matthijsmelissen.nl,matkoniecz@gmail.com).
 
 **Note that the goal of the Code of Conduct and the maintainers is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bans and other forceful measures are to be employed only as a last resort.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,26 +1,26 @@
-# Go Community Code of Conduct
+# OpenStreetMap Carto Community Code of Conduct
 
 ## Why have a Code of Conduct?
 
-Online communities include people from many different backgrounds. The Go contributors are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+Online communities include people from many different backgrounds. The OpenStreetMap Carto contributors are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
 
-The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about Go effectively, productively, and respectfully.
+The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about OpenStreetMap Carto effectively, productively, and respectfully.
 
 The second goal is to provide a mechanism for resolving conflicts in the community when they arise.
 
-The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical to the project; for Go to be successful, it needs contributors and users from all backgrounds. (See Go, Open Source, Community.)
+The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical to the project; for OpenStreetMap Carto to be successful, it needs contributors and users from all backgrounds.
 
 With that said, a healthy community must allow for disagreement and debate. The Code of Conduct is not a mechanism for people to silence others with whom they disagree.
 
 ## Where does the Code of Conduct apply?
 
-If you participate in or contribute to the Go ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
+If you participate in or contribute to the OpenStreetMap Carto ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
 
 Explicit enforcement of the Code of Conduct applies to the OpenStreetMap Carto GitHub project and code reviews.
 
-## Gopher values
+## Values
 
-These are the values to which people in the Go community (“Gophers”) should aspire.
+These are the values to which people in the OpenStreetMap Carto should aspire.
 
 - Be friendly and welcoming
 - Be patient
@@ -44,7 +44,7 @@ People are complicated. You should expect to be misunderstood and to misundersta
 
 ## Unwelcome behavior
 
-These actions are explicitly forbidden in Go spaces:
+These actions are explicitly forbidden in OpenStreetMap Carto spaces:
 
 - Insulting, demeaning, hateful, or threatening remarks.
 - Discrimination based on age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
@@ -54,9 +54,9 @@ These actions are explicitly forbidden in Go spaces:
 
 ## Moderation
 
-The Go spaces are not free speech venues; they are for discussion about Go. These spaces have moderators. The goal of the moderators is to facilitate civil discussion about Go.
+The OpenStreetMap Carto spaces are not free speech venues; they are for discussion about OpenStreetMap Carto. These spaces have moderators. The goal of the moderators is to facilitate civil discussion about OpenStreetMap Carto.
 
-When using the official Go spaces you should act in the spirit of the “Gopher values”. If you conduct yourself in a way that is explicitly forbidden by the CoC, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the CoC will result in a permanent ban.
+When using the official OpenStreetMap Carto spaces you should act in the spirit of the values. If you conduct yourself in a way that is explicitly forbidden by the CoC, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the CoC will result in a permanent ban.
 
 Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others, and should expect to be removed from their position if they cannot adhere to the CoC.
 
@@ -81,4 +81,4 @@ Changes to the Code of Conduct should be proposed as pull requests.
 
 ## Acknowledgements
 
-Parts of this document were derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
+This document is based on the Go Code of Conduct, which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ These are the values to which people in the OpenStreetMap Carto should aspire.
   - Derailing: stay on topic; if you want to talk about something else, start a new conversation.
   - Unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
   - Snarking (pithy, unproductive, sniping comments)
-  - Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+  - Discussing potentially offensive or sensitive issues unless directly technically relevant; this all too often leads to unnecessary conflict.
   - Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group.
 
 People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of *all parties* to de-escalate conflict when it arises.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -54,13 +54,9 @@ These actions are explicitly forbidden in OpenStreetMap Carto spaces:
 
 ## Moderation
 
-The OpenStreetMap Carto spaces are not free speech venues; they are for discussion about OpenStreetMap Carto. These spaces have moderators. The goal of the moderators is to facilitate civil discussion about OpenStreetMap Carto.
+The OpenStreetMap Carto spaces are not free speech venues; they are for discussion about OpenStreetMap Carto.
 
-When using the official OpenStreetMap Carto spaces you should act in the spirit of the values. If you conduct yourself in a way that is explicitly forbidden by the CoC, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the CoC will result in a permanent ban.
-
-Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others, and should expect to be removed from their position if they cannot adhere to the CoC.
-
-Complaints about moderator actions must be handled using the reporting process below.
+When using the OpenStreetMap Carto spaces you should act in the spirit of the values. If you conduct yourself in a way that is explicitly forbidden by the CoC, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the CoC will result in a permanent ban.
 
 ## Reporting issues
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -16,13 +16,7 @@ With that said, a healthy community must allow for disagreement and debate. The 
 
 If you participate in or contribute to the Go ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
 
-Explicit enforcement of the Code of Conduct applies to the official forums operated by the Go project (“Go spaces”):
-
-The official GitHub projects and code reviews.
-The golang-nuts and golang-dev mailing lists.
-The #go-nuts IRC channel on Freenode.
-The /r/golang subreddit.
-Other Go groups (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Those groups must provide their own moderators and/or working group (see below).
+Explicit enforcement of the Code of Conduct applies to the OpenStreetMap Carto GitHub project and code reviews.
 
 ## Gopher values
 
@@ -70,48 +64,20 @@ Complaints about moderator actions must be handled using the reporting process b
 
 ## Reporting issues
 
-The Code of Conduct Working Group is a group of people that represent the Go community. They are responsible for handling conduct-related issues. Their purpose is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties. They are:
+The OpenStreetMap Carto maintainers are responsible for handling conduct-related issues. Their goal is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties.
 
-- Aditya Mukerjee <dev@chimeracoder.net>
-- Andrew Gerrand <adg@golang.org>
-- Dave Cheney <dave@cheney.net>
-- Jason Buberel <jbuberel@google.com>
-- Peggy Li <peggyli.224@gmail.com>
-- Sarah Adams <sadams.codes@gmail.com>
-- Steve Francia <steve.francia@gmail.com>
-- Verónica López <gveronicalg@gmail.com>
+If you encounter a conduct-related issue, you should report it to the maintainers by email.
 
-If you encounter a conduct-related issue, you should report it to the Working Group using the process described below. Do not post about the issue publicly or try to rally sentiment against a particular individual or group.
+**Note that the goal of the Code of Conduct and the maintainers is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bans and other forceful measures are to be employed only as a last resort.
 
-- Mail conduct@golang.org or submit an anonymous report.
-  - Your message will reach the Working Group.
-  - Reports are confidential within the Working Group.
-  - Should you choose to remain anonymous then the Working Group cannot notify you of the outcome of your report.
-  - You may contact a member of the group directly if you do not feel comfortable contacting the group as a whole. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
-  - If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
-  - The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
-- You should receive a response within 48 hours (likely sooner). (Should you choose to contact a single Working Group member, it may take longer to receive a response.)
-- The Working Group will meet to review the incident and determine what happened.
-  - With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
-- The Working Group will reach a decision as to how to act. These may include:
-  - Nothing.
-  - A request for a private or public apology.
-  - A private or public warning.
-  - An imposed vacation (for instance, asking someone to abstain for a week from a mailing list or IRC).
-  - A permanent or temporary ban from some or all Go spaces.
-- The Working Group will reach out to the original reporter to let them know the decision.
-- Appeals to the decision may be made to the Working Group, or to any of its members directly.
-
-**Note that the goal of the Code of Conduct and the Working Group is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort.
-
-Changes to the Code of Conduct (including to the members of the Working Group) should be proposed using the change proposal process.
+Changes to the Code of Conduct should be proposed as pull requests.
 
 ## Summary
 
 - Treat everyone with respect and kindness.
 - Be thoughtful in how you communicate.
 - Don’t be destructive or inflammatory.
-- If you encounter an issue, please mail conduct@golang.org.
+- If you encounter an issue, please mail the maintainers.
 
 ## Acknowledgements
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -82,3 +82,5 @@ Changes to the Code of Conduct should be proposed as pull requests.
 ## Acknowledgements
 
 This document is based on the Go Code of Conduct, which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
+
+This documented is licensed under the Creative Commons Attribution 3.0 License.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# Go Community Code of Conduct
+
+## Why have a Code of Conduct?
+
+Online communities include people from many different backgrounds. The Go contributors are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+
+The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about Go effectively, productively, and respectfully.
+
+The second goal is to provide a mechanism for resolving conflicts in the community when they arise.
+
+The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical to the project; for Go to be successful, it needs contributors and users from all backgrounds. (See Go, Open Source, Community.)
+
+With that said, a healthy community must allow for disagreement and debate. The Code of Conduct is not a mechanism for people to silence others with whom they disagree.
+
+## Where does the Code of Conduct apply?
+
+If you participate in or contribute to the Go ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
+
+Explicit enforcement of the Code of Conduct applies to the official forums operated by the Go project (“Go spaces”):
+
+The official GitHub projects and code reviews.
+The golang-nuts and golang-dev mailing lists.
+The #go-nuts IRC channel on Freenode.
+The /r/golang subreddit.
+Other Go groups (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Those groups must provide their own moderators and/or working group (see below).
+
+## Gopher values
+
+These are the values to which people in the Go community (“Gophers”) should aspire.
+
+- Be friendly and welcoming
+- Be patient
+  - Remember that people have varying communication styles and that not everyone is using their native language. (Meaning and tone can be lost in translation.)
+- Be thoughtful
+  - Productive communication requires effort. Think about how your words will be interpreted.
+  - Remember that sometimes it is best to refrain entirely from commenting.
+- Be respectful
+  - In particular, respect differences of opinion.
+- Be charitable
+  - Interpret the arguments of others in good faith, do not seek to disagree.
+  - When we do disagree, try to understand why.
+- Avoid destructive behavior:
+  - Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+  - Unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+  - Snarking (pithy, unproductive, sniping comments)
+  - Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+  - Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group.
+
+People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of *all parties* to de-escalate conflict when it arises.
+
+## Unwelcome behavior
+
+These actions are explicitly forbidden in Go spaces:
+
+- Insulting, demeaning, hateful, or threatening remarks.
+- Discrimination based on age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+- Bullying or systematic harassment.
+- Unwelcome sexual advances.
+- Incitement to any of these.
+
+## Moderation
+
+The Go spaces are not free speech venues; they are for discussion about Go. These spaces have moderators. The goal of the moderators is to facilitate civil discussion about Go.
+
+When using the official Go spaces you should act in the spirit of the “Gopher values”. If you conduct yourself in a way that is explicitly forbidden by the CoC, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the CoC will result in a permanent ban.
+
+Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others, and should expect to be removed from their position if they cannot adhere to the CoC.
+
+Complaints about moderator actions must be handled using the reporting process below.
+
+## Reporting issues
+
+The Code of Conduct Working Group is a group of people that represent the Go community. They are responsible for handling conduct-related issues. Their purpose is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties. They are:
+
+- Aditya Mukerjee <dev@chimeracoder.net>
+- Andrew Gerrand <adg@golang.org>
+- Dave Cheney <dave@cheney.net>
+- Jason Buberel <jbuberel@google.com>
+- Peggy Li <peggyli.224@gmail.com>
+- Sarah Adams <sadams.codes@gmail.com>
+- Steve Francia <steve.francia@gmail.com>
+- Verónica López <gveronicalg@gmail.com>
+
+If you encounter a conduct-related issue, you should report it to the Working Group using the process described below. Do not post about the issue publicly or try to rally sentiment against a particular individual or group.
+
+- Mail conduct@golang.org or submit an anonymous report.
+  - Your message will reach the Working Group.
+  - Reports are confidential within the Working Group.
+  - Should you choose to remain anonymous then the Working Group cannot notify you of the outcome of your report.
+  - You may contact a member of the group directly if you do not feel comfortable contacting the group as a whole. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
+  - If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
+  - The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
+- You should receive a response within 48 hours (likely sooner). (Should you choose to contact a single Working Group member, it may take longer to receive a response.)
+- The Working Group will meet to review the incident and determine what happened.
+  - With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
+- The Working Group will reach a decision as to how to act. These may include:
+  - Nothing.
+  - A request for a private or public apology.
+  - A private or public warning.
+  - An imposed vacation (for instance, asking someone to abstain for a week from a mailing list or IRC).
+  - A permanent or temporary ban from some or all Go spaces.
+- The Working Group will reach out to the original reporter to let them know the decision.
+- Appeals to the decision may be made to the Working Group, or to any of its members directly.
+
+**Note that the goal of the Code of Conduct and the Working Group is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort.
+
+Changes to the Code of Conduct (including to the members of the Working Group) should be proposed using the change proposal process.
+
+## Summary
+
+- Treat everyone with respect and kindness.
+- Be thoughtful in how you communicate.
+- Don’t be destructive or inflammatory.
+- If you encounter an issue, please mail conduct@golang.org.
+
+## Acknowledgements
+
+Parts of this document were derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,6 +77,6 @@ Changes to the Code of Conduct should be proposed as pull requests.
 
 ## Acknowledgements
 
-This document is based on the Go Code of Conduct, which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
+This document is based on the [Go Code of Conduct](https://golang.org/conduct), which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
 
 This documented is licensed under the Creative Commons Attribution 3.0 License.


### PR DESCRIPTION
This adds a code of conduct, based on the Go code of conduct. The goal of a code of conduct is to make explicit inappropriate behavior and mechanisms for dealing with it.

In selecting the Go code of conduct as a starting point, I looked at about 25 options, looking for those which covered the problems we have had and would work with a small scale project, or could be made to work by eliminating content instead of substantial rewrites.[1]

I was initially expecting to do something based on the [Debian code of conduct](https://www.debian.org/code_of_conduct) but I found it less useful than the Values section of the Go document. It is much easier to remove unnecessary sections than expand a document.

## Modifications
Most of the modifications are because the Go process does not [scale down to small projects](https://github.com/golang/proposal/blob/master/design/13073-code-of-conduct.md#open-issues). We have four maintainers and one discussion venue - Github. Go has orders of magnitude more people involved and has IRC channels, mailing lists, mutiple GitHub projects, a subreddit, and in-person events.

## To Do
* [ ] Add links to the document
* [ ] Link to it from CONTRIBUTING.md

## References

[Go CoC proposal rationale](https://github.com/golang/proposal/blob/master/design/13073-code-of-conduct.md#rationale)
[Go CoC blog post/talk](https://blog.golang.org/open-source#TOC_7.)

[1]: Debian, FreeBSD, Go, Joomla, and Puppet met the initial filtering.