### PR TITLE
Less dominant construction color

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -33,7 +33,7 @@
 @bare_ground: #eee5dc;
 @campsite: #def6c0; // also caravan_site, picnic_site
 @cemetery: #aacbaf; // also grave_yard
-@construction: #b6b592;
+@construction: #c7c7b4;
 @danger_area: pink;
 @garages: #dfddce;
 @heath: #d6d99f;


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1197.

As originally proposed by @daganzdaanda, made 10% lighter with 5% desaturation. Lightening stops hinting that construction areas are more important than buildings and desaturation takes away the golden tint, which is currently overused in osm-carto, making also construction area more distinct than lightened-only version.

1) City landscape, comparison with bigger buildings
Before
![ldlg22vf](https://cloud.githubusercontent.com/assets/5439713/17808804/8ca2d7fc-6612-11e6-9e5a-a95fc7075b42.png)

After
![4ejz73xi](https://cloud.githubusercontent.com/assets/5439713/17808820/9810450c-6612-11e6-88bc-aa78b965eaf0.png)

2) City detail, comparison with buildings, trees and special buildings (tagged as place of worship)
Before
![dp7zxvik](https://cloud.githubusercontent.com/assets/5439713/17796679/ccd560c4-65c2-11e6-9d83-4e32cf954fec.png)

After
![fdegunzf](https://cloud.githubusercontent.com/assets/5439713/17808022/e71d117a-660d-11e6-90ac-3ae2c829fb7e.png)

3) City detail, comparison with buildings and landuse=garages
![cvh2xwnv](https://cloud.githubusercontent.com/assets/5439713/17808904/1b100186-6613-11e6-80e6-2b2da5ffe977.png)

4) City detail, buildings on construction area
![u2erjogr](https://cloud.githubusercontent.com/assets/5439713/17808905/1b1157a2-6613-11e6-8323-aca71d5c8882.png)