### PR TITLE
Revised min. zoom for tourism=alpine_hut

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1705,7 +1705,7 @@
     text-face-name: @standard-font;
   }
 
-  [feature = 'tourism_alpine_hut'][zoom >= 15],
+  [feature = 'tourism_alpine_hut'][zoom >= 14],
   [feature = 'amenity_shelter'][zoom >= 17],
   [feature = 'tourism_hotel'][zoom >= 17],
   [feature = 'tourism_motel'][zoom >= 17],


### PR DESCRIPTION
Revised min. zoom for tourism=alpine_hut

This PR supersedes #2139 and #2294 specifically for the functionality to reduce the min. zoom to show the text name of alpine huts (tourism=alpine_hut).
