### PR TITLE
Change font size and minimum zoom level for house numbers

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -7,27 +7,30 @@
 }
 
 #housenumbers {
-  [zoom >= 17] {
+  [zoom >= 18] {
     text-name: "[addr:housenumber]";
     text-placement: interior;
     text-min-distance: 1;
     text-wrap-width: 0;
     text-face-name: @book-fonts;
     text-fill: #666;
-    text-size: 9;
+    text-size: 10;
+    [zoom >= 20] {
+        text-size: 11;
+    }
   }
 }
 
 #housenames {
-  [zoom >= 17] {
+  [zoom >= 18] {
     text-name: "[addr:housename]";
     text-placement: interior;
     text-wrap-width: 20;
     text-face-name: @book-fonts;
-    text-size: 8;
     text-fill: #666;
-    [zoom >= 18] {
-      text-size: 9;
+    text-size: 10;
+    [zoom >= 20] {
+        text-size: 11;
     }
   }
 }

--- a/addressing.mss
+++ b/addressing.mss
@@ -1,3 +1,5 @@
+@address-color: #666;
+
 #interpolation {
   [zoom >= 17] {
     line-color: #888;
@@ -7,13 +9,13 @@
 }
 
 #housenumbers {
-  [zoom >= 18] {
+  [zoom >= 17] {
     text-name: "[addr:housenumber]";
     text-placement: interior;
     text-min-distance: 1;
     text-wrap-width: 0;
     text-face-name: @book-fonts;
-    text-fill: #666;
+    text-fill: @address-color;
     text-size: 10;
     [zoom >= 20] {
         text-size: 11;
@@ -22,12 +24,12 @@
 }
 
 #housenames {
-  [zoom >= 18] {
+  [zoom >= 17] {
     text-name: "[addr:housename]";
     text-placement: interior;
     text-wrap-width: 20;
     text-face-name: @book-fonts;
-    text-fill: #666;
+    text-fill: @address-color;
     text-size: 10;
     [zoom >= 20] {
         text-size: 11;


### PR DESCRIPTION
minimal font size for adresses: 10

Unify rendering of addr:housename and addr:housenumber and have now always the same size at the same zoom level. Drop rendering at z17 (yet currently there are collisions, often no way_pixels available for making a better choise). Minimal font size of 10.

Contains a filter for z20. Now osm.org does not provide z20. Is it useful anyway or not?