### PR TITLE
Move shop labels to z18

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1938,6 +1938,7 @@
   [feature = 'shop_variety_store'],
   [feature = 'shop_wine'],
   [feature = 'shop_other']{
+    [way_pixels > 3000][zoom >= 17],
     [zoom >= 18] {
       text-name: "[name]";
       text-size: @standard-text-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1938,7 +1938,7 @@
   [feature = 'shop_variety_store'],
   [feature = 'shop_wine'],
   [feature = 'shop_other']{
-    [zoom >= 17] {
+    [zoom >= 18] {
       text-name: "[name]";
       text-size: @standard-text-size;
       text-dy: 12;


### PR DESCRIPTION
Nearly all shops are located in shopping streets or shopping malls,
close to other shops. Therefore, only a very small part of shops
is currently displayed with label on z17. In addition, these areas
are very crowded.

By only displaying shop labels on z18, z17 will appear less overcrowded.

The shop icons will still be displayed on z17.