### PR TITLE
Make landfill color different than construction and brownfield

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -33,7 +33,7 @@
 @bare_ground: #eee5dc;
 @campsite: #def6c0; // also caravan_site, picnic_site
 @cemetery: #aacbaf; // also grave_yard
-@construction: #c7c7b4;
+@construction: #c7c7b4; // also brownfield
 @danger_area: pink;
 @garages: #dfddce;
 @heath: #d6d99f;
@@ -373,10 +373,17 @@
   }
 
   [feature = 'landuse_brownfield'],
-  [feature = 'landuse_landfill'],
   [feature = 'landuse_construction'] {
     [zoom >= 10] {
       polygon-fill: @construction;
+      [way_pixels >= 4]  { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.3;  }
+    }
+  }
+
+  [feature = 'landuse_landfill'] {
+    [zoom >= 10] {
+      polygon-fill: #b6b592;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }


### PR DESCRIPTION
In https://github.com/gravitystorm/openstreetmap-carto/pull/2292 I didn't check that construction color is used also for brownfield and landfill. While I think construction (76k uses) and brownfield (64k uses) are somewhat similar and more popular, landfll (21k uses) is much different, since it has nothing to do with development cycle. So I think it would be good to restore stronger color only for this tag. 

Example of construction and landfill areas near each other:
![pxajjpu3](https://cloud.githubusercontent.com/assets/5439713/18421220/cd216d28-7884-11e6-88bf-b73973b08b6e.png)
