### PR TITLE
Label oceans and large seas from a static file

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -74,7 +74,7 @@
       "geometry": "linestring",
       "class": "",
       "id": "necountries",
-      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
+      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +over",
       "Datasource": {
         "type": "shape",
         "file": "data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp"
@@ -87,6 +87,29 @@
       ],
       "properties": {
         "maxzoom": 3,
+        "minzoom": 1
+      },
+      "advanced": {}
+    },
+    {
+      "name": "ocean-text",
+      "srs-name": "WGS84",
+      "geometry": "linestring",
+      "class": "",
+      "id": "ocean-text",
+      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +over",
+      "Datasource": {
+        "type": "geojson",
+        "file": "static/ocean.geojson"
+      },
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "properties": {
+        "maxzoom": 8,
         "minzoom": 1
       },
       "advanced": {}
@@ -2043,7 +2066,7 @@
       "key_field": ""
     },
     "extents84": {
-      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
+      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +over",
       "extent": [
         -180,
         -85.05112877980659,

--- a/project.yaml
+++ b/project.yaml
@@ -27,7 +27,7 @@ _parts:
   extents84: &extents84
     extent: *world
     srs-name: "WGS84"
-    srs: "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+    srs: "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs +over"
   osm2pgsql: &osm2pgsql
     type: "postgis"
     dbname: "gis"
@@ -100,6 +100,18 @@ Layer:
     properties:
       minzoom: 1
       maxzoom: 3
+    advanced: {}
+  - id: "ocean-text"
+    name: "ocean-text"
+    class: ""
+    geometry: "linestring"
+    <<: *extents84
+    Datasource:
+      file: "static/ocean.geojson"
+      type: "geojson"
+    properties:
+      minzoom: 1
+      maxzoom: 8
     advanced: {}
   - id: "landcover-low-zoom"
     name: "landcover-low-zoom"

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,11 @@
+# Static data
+
+This directory is for static data that is part of OpenStreetMap Carto
+
+## sea.geojson
+
+Hand-placed labels for oceans and major seas. Some data is derived from OpenStreetMap `place=sea` data and other is hand-placed.
+
+Features crossing 180 degrees need to be repeated for each the west and east side of the map.
+
+Data is licensed under the [ODbL](http://opendatacommons.org/licenses/odbl/). Copyright Paul Norman and [OpenStreetMap contributors](http://www.openstreetmap.org/copyright).

--- a/static/ocean.geojson
+++ b/static/ocean.geojson
@@ -1,0 +1,151 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [-150, 0],
+        "type": "Point"
+      },
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 1,
+        "name": "Pacific\nOcean",
+        "size": "bigger"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [-40, 25],
+        "type": "Point"
+      },
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 1,
+        "name": "Atlantic\nOcean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [75, -20],
+        "type": "Point"
+      },
+      "properties": {
+        "minzoom": 1,
+        "maxzoom": 4,
+        "name": "Indian\nOcean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [-180, 80],
+        "type": "Point"
+      },
+      "properties": {
+        "minzoom": 1,
+        "maxzoom": 2,
+        "name": "Arctic Ocean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [180, 80],
+        "type": "Point"
+      },
+      "properties": {
+        "minzoom": 1,
+        "maxzoom": 2,
+        "name": "Arctic Ocean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [160, 77],
+          [190, 75],
+          [220, 77]
+        ],
+        "type": "LineString"
+      },
+      "properties": {
+        "minzoom": 2,
+        "maxzoom": 3,
+        "name": "Arctic Ocean",
+        "size": "big"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [-200, 77],
+          [-170, 75],
+          [-140, 77]
+        ],
+        "type": "LineString"
+      },
+      "properties": {
+        "minzoom": 2,
+        "maxzoom": 3,
+        "name": "Arctic Ocean",
+        "size": "big"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          [5, 81],
+          [65, 83]
+        ],
+        "type": "LineString"
+      },
+      "properties": {
+        "minzoom": 2,
+        "maxzoom": 3,
+        "name": "Arctic Ocean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [-5, -60],
+        "type": "Point"
+      },
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 1,
+        "name": "Southern Ocean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [-160, -65],
+        "type": "Point"
+      },
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 2,
+        "name": "Southern Ocean"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [200, -65],
+        "type": "Point"
+      },
+      "properties": {
+        "maxzoom": 3,
+        "minzoom": 2,
+        "name": "Southern Ocean"
+      },
+      "type": "Feature"
+    }
+  ]
+}

--- a/water.mss
+++ b/water.mss
@@ -295,3 +295,51 @@
     }
   }
 }
+
+#ocean-text {
+  [zoom >= 1][minzoom = 1],
+  [zoom >= 2][minzoom = 2],
+  [zoom >= 3][minzoom = 3],
+  [zoom >= 4][minzoom = 4],
+  [minzoom=null] {
+    [zoom < 1][maxzoom = 1],
+    [zoom < 2][maxzoom = 2],
+    [zoom < 3][maxzoom = 3],
+    [zoom < 4][maxzoom = 4],
+    [maxzoom=null] {
+      text-name: "[name]";
+      // These are all large areas, so they get labeled with larger than normal labels
+      text-size: 15;
+      [size = 'big'] {
+        text-size: 18;
+      }
+      [size = 'bigger'] {
+        text-size: 24;
+      }
+      [zoom >= 2]{
+        text-size: 18;
+        [size = 'big'] {
+          text-size: 24;
+        }
+        [size = 'bigger'] {
+          text-size: 28;
+        }
+      }
+      text-fill: @water-text;
+      text-face-name: @landcover-face-name;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+      ['mapnik::geometry_type'=2] {
+        text-placement: line;
+        text-smooth: 1;
+        // Debugging code
+        /*
+        line-color: red;
+        line-width: 1;
+        line-smooth: 1;
+        */
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a proof of concept of using a static file to label seas and large oceans with hand-placed labels.
- The placements are designed for a webmap which wraps around +/- 180. This allows placement of a single North Pacific label, while many printed maps use two, one on each edge. Other webmaps use a single label but place it so it doesn't cross 180. I believe what I am doing is unique among webmaps. Not worrying about the +/- 180 allows for more flexibility in positions
- Positions and sea selections are designed for Mercator. osm-carto will never make a good map for viewing the entire world at once with its projection, but it's what we use.

There are a number of outstanding issues
- [ ] Even with the increased size, the smallest labels seem faint. We might need to adjust the water colour. Many maps use white.
- [ ] With the syntax used it seems necessary to specify the same point multiple times even when it's at the same location in order to increase its size on higher zooms.
- [ ] Labels on z4+ haven't been given huge consideration
- [x] I'm not sure what to do with the southern ocean. It's geometry is unlike other oceans because the on-globe centroid is on land, and in Mercator it is a very large ocean.
- [ ] ~~Some of the seas should probably be in the local language~~
- [x] Right now line breaks are done through wrapping. Since these are manual labels it might make more sense to turn off wrapping and use manual newlines

I drew technical ideas from [osm2vectortiles seas.geojson](https://github.com/osm2vectortiles/osm2vectortiles/pull/394#issuecomment-238073484) and cartographic/labeling ideas from Natural Earth and [Tim Patterson's Physical Map of the World](http://shadedrelief.com/world/). I specifically avoided looking at MapBox Streets as they have falsely [claimed ownership over similar files to what I was making](https://github.com/osm2vectortiles/osm2vectortiles/issues/387#issuecomment-238060253).
