### PR TITLE
Render both housenumber and housename

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -10,31 +10,22 @@
   }
 }
 
-#housenames {
+#addresses {
   [zoom >= 17] {
     text-name: "[addr_housename]";
     ["addr_housenumber" != null] {
-      text-name: [addr_housenumber] + "\n" + [addr_housename] ;
+      text-name: [addr_housenumber];
+      ["addr_housename" != null] {
+        text-name: [addr_housenumber] + "\n" + [addr_housename];
+      }
     }
     text-placement: interior;
+    text-min-distance: 1;
     text-wrap-width: 20;
     text-face-name: @book-fonts;
     text-fill: @address-color;
-    text-size: 10;
-    [zoom >= 20] {
-        text-size: 11;
-    }
-  }
-}
-
-#housenumbers {
-  [zoom >= 17] {
-    text-name: "[addr_housenumber]";
-    text-placement: interior;
-    text-min-distance: 1;
-    text-wrap-width: 0;
-    text-face-name: @book-fonts;
-    text-fill: @address-color;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
     text-size: 10;
     [zoom >= 20] {
         text-size: 11;
@@ -49,12 +40,12 @@ no official postal addresses) */
   [zoom >= 14][way_pixels > 3000],
   [zoom >= 17] {
     text-name: "[name]";
-    text-size: 11;
-    text-fill: #444;
-    text-face-name: @book-fonts;
-    text-halo-radius: @standard-halo-radius;
-    text-wrap-width: 20;
-    text-halo-fill: rgba(255,255,255,0.5);
     text-placement: interior;
+    text-wrap-width: 20;
+    text-face-name: @book-fonts;
+    text-fill: #444;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-size: 11;
   }
 }

--- a/addressing.mss
+++ b/addressing.mss
@@ -1,16 +1,35 @@
+/* Features related to (postal) adresses: */
+
 @address-color: #666;
 
 #interpolation {
   [zoom >= 17] {
-    line-color: #888;
+    line-color: @address-color;
     line-width: 1;
     line-dasharray: 2,4;
   }
 }
 
+#housenames {
+  [zoom >= 17] {
+    text-name: "[addr_housename]";
+    ["addr_housenumber" != null] {
+      text-name: [addr_housenumber] + "\n" + [addr_housename] ;
+    }
+    text-placement: interior;
+    text-wrap-width: 20;
+    text-face-name: @book-fonts;
+    text-fill: @address-color;
+    text-size: 10;
+    [zoom >= 20] {
+        text-size: 11;
+    }
+  }
+}
+
 #housenumbers {
   [zoom >= 17] {
-    text-name: "[addr:housenumber]";
+    text-name: "[addr_housenumber]";
     text-placement: interior;
     text-min-distance: 1;
     text-wrap-width: 0;
@@ -23,19 +42,8 @@
   }
 }
 
-#housenames {
-  [zoom >= 17] {
-    text-name: "[addr:housename]";
-    text-placement: interior;
-    text-wrap-width: 20;
-    text-face-name: @book-fonts;
-    text-fill: @address-color;
-    text-size: 10;
-    [zoom >= 20] {
-        text-size: 11;
-    }
-  }
-}
+/* Building names (rendered differently from addresses because they are
+no official postal addresses) */
 
 #building-text {
   [zoom >= 14][way_pixels > 3000],

--- a/project.mml
+++ b/project.mml
@@ -1809,41 +1809,15 @@
       "advanced": {}
     },
     {
-      "name": "housenames",
+      "name": "addresses",
       "srs-name": "900913",
       "geometry": "point",
       "class": "",
-      "id": "housenames",
+      "id": "addresses",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    \"addr:housename\" AS addr_housename,\n    \"addr:housenumber\" AS addr_housenumber,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housename\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housename\" AS addr_housename,\n    \"addr:housenumber\" AS addr_housenumber,\n    NULL AS way_pixels\n  FROM planet_osm_point WHERE \"addr:housename\" IS NOT NULL\nORDER BY way_pixels DESC NULLS LAST\n) AS housenames",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 17
-      },
-      "advanced": {}
-    },
-    {
-      "name": "housenumbers",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "housenumbers",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housenumber\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE \"addr:housenumber\" IS NOT NULL\n  ORDER BY way_pixels DESC NULLS LAST\n) AS housenumbers",
+        "table": "(SELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    \"addr:housename\" AS addr_housename,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE ((\"addr:housenumber\" IS NOT NULL) OR (\"addr:housename\" IS NOT NULL))\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    \"addr:housename\" AS addr_housename,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE (\"addr:housenumber\" IS NOT NULL) OR (\"addr:housename\" IS NOT NULL)\n  ORDER BY way_pixels DESC NULLS LAST\n) AS addresses",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.mml
+++ b/project.mml
@@ -1809,15 +1809,15 @@
       "advanced": {}
     },
     {
-      "name": "housenumbers",
+      "name": "housenames",
       "srs-name": "900913",
       "geometry": "point",
       "class": "",
-      "id": "housenumbers",
+      "id": "housenames",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    \"addr:housenumber\",\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housenumber\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housenumber\",\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE \"addr:housenumber\" IS NOT NULL\n  ORDER BY way_pixels DESC NULLS LAST\n) AS housenumbers",
+        "table": "(SELECT\n    way,\n    \"addr:housename\" AS addr_housename,\n    \"addr:housenumber\" AS addr_housenumber,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housename\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housename\" AS addr_housename,\n    \"addr:housenumber\" AS addr_housenumber,\n    NULL AS way_pixels\n  FROM planet_osm_point WHERE \"addr:housename\" IS NOT NULL\nORDER BY way_pixels DESC NULLS LAST\n) AS housenames",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1835,15 +1835,15 @@
       "advanced": {}
     },
     {
-      "name": "housenames",
+      "name": "housenumbers",
       "srs-name": "900913",
       "geometry": "point",
       "class": "",
-      "id": "housenames",
+      "id": "housenumbers",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    \"addr:housename\",\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housename\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housename\",\n    NULL AS way_pixels\n  FROM planet_osm_point WHERE \"addr:housename\" IS NOT NULL\nORDER BY way_pixels DESC NULLS LAST\n) AS housenames",
+        "table": "(SELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE \"addr:housenumber\" IS NOT NULL\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE \"addr:housenumber\" IS NOT NULL\n  ORDER BY way_pixels DESC NULLS LAST\n) AS housenumbers",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -2352,36 +2352,8 @@ Layer:
     properties:
       minzoom: 17
     advanced: {}
-  - id: "housenames"
-    name: "housenames"
-    class: ""
-    geometry: "point"
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            "addr:housename" AS addr_housename,
-            "addr:housenumber" AS addr_housenumber,
-            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
-          FROM planet_osm_polygon
-          WHERE "addr:housename" IS NOT NULL
-            AND building IS NOT NULL
-        UNION ALL
-        SELECT
-            way,
-            "addr:housename" AS addr_housename,
-            "addr:housenumber" AS addr_housenumber,
-            NULL AS way_pixels
-          FROM planet_osm_point WHERE "addr:housename" IS NOT NULL
-        ORDER BY way_pixels DESC NULLS LAST
-        ) AS housenames
-    properties:
-      minzoom: 17
-    advanced: {}
-  - id: "housenumbers"
-    name: "housenumbers"
+  - id: "addresses"
+    name: "addresses"
     class: ""
     geometry: "point"
     <<: *extents
@@ -2391,19 +2363,21 @@ Layer:
         (SELECT
             way,
             "addr:housenumber" AS addr_housenumber,
+            "addr:housename" AS addr_housename,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE "addr:housenumber" IS NOT NULL
+          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL))
             AND building IS NOT NULL
         UNION ALL
         SELECT
             way,
             "addr:housenumber" AS addr_housenumber,
+            "addr:housename" AS addr_housename,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE "addr:housenumber" IS NOT NULL
+          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL)
           ORDER BY way_pixels DESC NULLS LAST
-        ) AS housenumbers
+        ) AS addresses
     properties:
       minzoom: 17
     advanced: {}

--- a/project.yaml
+++ b/project.yaml
@@ -2352,33 +2352,6 @@ Layer:
     properties:
       minzoom: 17
     advanced: {}
-  - id: "housenumbers"
-    name: "housenumbers"
-    class: ""
-    geometry: "point"
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            "addr:housenumber",
-            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
-          FROM planet_osm_polygon
-          WHERE "addr:housenumber" IS NOT NULL
-            AND building IS NOT NULL
-        UNION ALL
-        SELECT
-            way,
-            "addr:housenumber",
-            NULL AS way_pixels
-          FROM planet_osm_point
-          WHERE "addr:housenumber" IS NOT NULL
-          ORDER BY way_pixels DESC NULLS LAST
-        ) AS housenumbers
-    properties:
-      minzoom: 17
-    advanced: {}
   - id: "housenames"
     name: "housenames"
     class: ""
@@ -2389,7 +2362,8 @@ Layer:
       table: |-
         (SELECT
             way,
-            "addr:housename",
+            "addr:housename" AS addr_housename,
+            "addr:housenumber" AS addr_housenumber,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
           WHERE "addr:housename" IS NOT NULL
@@ -2397,11 +2371,39 @@ Layer:
         UNION ALL
         SELECT
             way,
-            "addr:housename",
+            "addr:housename" AS addr_housename,
+            "addr:housenumber" AS addr_housenumber,
             NULL AS way_pixels
           FROM planet_osm_point WHERE "addr:housename" IS NOT NULL
         ORDER BY way_pixels DESC NULLS LAST
         ) AS housenames
+    properties:
+      minzoom: 17
+    advanced: {}
+  - id: "housenumbers"
+    name: "housenumbers"
+    class: ""
+    geometry: "point"
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            "addr:housenumber" AS addr_housenumber,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
+          FROM planet_osm_polygon
+          WHERE "addr:housenumber" IS NOT NULL
+            AND building IS NOT NULL
+        UNION ALL
+        SELECT
+            way,
+            "addr:housenumber" AS addr_housenumber,
+            NULL AS way_pixels
+          FROM planet_osm_point
+          WHERE "addr:housenumber" IS NOT NULL
+          ORDER BY way_pixels DESC NULLS LAST
+        ) AS housenumbers
     properties:
       minzoom: 17
     advanced: {}


### PR DESCRIPTION
Render both housenumber and housename if both are present. Same colour for all address-related features. A little bit of documentation.

Fixes #2328 
Fixes #735 