### PR TITLE
Making pitch and track color less dominant

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -55,7 +55,7 @@
 
 // --- sports ---
 
-@pitch: #80d7b5;
+@pitch: #aae0cb;
 @track: @pitch;
 @stadium: @societal_amenities; // also sports_centre
 @golf_course: #b5e3b5;


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1190.

The color definition is not absolute for now to make it easier to test modifications. When it'll be ready to merge, I will remove the "[WIP]" (work in progress) from the title.

After some testing I feel this color (lighten 8%, desaturate 5%) is the best on typical backgrounds:

z14 - it's still visible on the sport center and on the ground, but less than a forest, and small spots on residential area are not a problem now:

Before
![jdk619dg](https://cloud.githubusercontent.com/assets/5439713/18746146/0fe33756-80c6-11e6-823d-4a4154b299de.png)
After
![4ylsau2h](https://cloud.githubusercontent.com/assets/5439713/18746101/c6b277d6-80c5-11e6-8abf-74d47e9348f2.png)

z15 - pitches are less intense than a special building and secondary roads, now they are more or less like a regular buildings, which is good:

Before
![vouzm97o](https://cloud.githubusercontent.com/assets/5439713/18746199/594af7f8-80c6-11e6-9f3f-7a5ba5e360fe.png)
After
![9 xab68c](https://cloud.githubusercontent.com/assets/5439713/18746229/8628efe6-80c6-11e6-97c5-a21bd9bdd574.png)

z16 - when school areas are bigger, it's the same as with sport centres, and we have a special case, pitch on the residential area, which also looks OK on this zoom level:

Before
![f9vbphts](https://cloud.githubusercontent.com/assets/5439713/18746437/aaf192fa-80c7-11e6-8470-35421c1a0bd6.png)
After
![zypwbbvq](https://cloud.githubusercontent.com/assets/5439713/18746429/998e18b2-80c7-11e6-83c9-5608d7bca75b.png)

z17 - another typical background, pitch on a grass, you can also see that it's still much different than cemetery green:

Before
![wpbsfxf](https://cloud.githubusercontent.com/assets/5439713/18746501/1c5cedd6-80c8-11e6-8337-3c9b35327f5f.png)
After
![_vw2ny6z](https://cloud.githubusercontent.com/assets/5439713/18746533/3f901544-80c8-11e6-926e-3e9505b2dadb.png)
