### PR TITLE
Adding ref for railway=subway_entrance

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1654,6 +1654,7 @@ Layer:
         (SELECT
             way,
             name,
+            ref,
             railway,
             aerialway,
             CASE railway 
@@ -1681,6 +1682,7 @@ Layer:
         (SELECT
             way,
             name,
+            ref,
             railway,
             aerialway
         FROM planet_osm_polygon

--- a/stations.mss
+++ b/stations.mss
@@ -7,6 +7,17 @@
     marker-placement: interior;
     marker-fill: @transportation-icon;
     marker-clip: false;
+    [zoom >= 19] {
+      text-name: [ref];
+      text-face-name: @book-fonts;
+      text-size: 10;
+      text-fill: @transportation-icon;
+      text-dy: 10;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      text-halo-fill: @standard-halo-fill;
+      text-wrap-width: 0;
+      text-placement: interior;
+    }
   }
 
   [railway = 'station'][zoom >= 12] {


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/645.

I guess we need to wait for a database reload to show also refs, but it's possible to render the name of subway entrances right now ([15k+ uses](http://taginfo.openstreetmap.org/tags/railway=subway_entrance#combinations)):
![a8ne_h8q](https://cloud.githubusercontent.com/assets/5439713/18811924/151ebc42-82c2-11e6-9486-8cb3a9fc11d7.png)

UPDATE: probably ref should be available, but is not in .stations - could somebody help me with it?
