### PR TITLE
Making railway stations appear as major buildings [WIP]

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -33,7 +33,8 @@
         line-color: @building-aeroway-line;
       }
     }
-    [amenity = 'place_of_worship'] {
+    [amenity = 'place_of_worship'],
+    [railway = 'station'] {
       polygon-fill: @building-major-fill;
       polygon-clip: false;
       [zoom >= 15] {

--- a/project.mml
+++ b/project.mml
@@ -562,7 +562,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
+        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway,\n    railway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR railway = 'station')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -484,11 +484,12 @@ Layer:
             way,
             building,
             amenity,
-            aeroway
+            aeroway,
+            railway
           FROM planet_osm_polygon
           WHERE building IS NOT NULL
             AND building != 'no'
-            AND (aeroway = 'terminal' OR amenity = 'place_of_worship')
+            AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR railway = 'station')
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY z_order, way_area DESC)
         AS buildings_major


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/issues/327.

This code is not production ready, because it highlights all the buildings tagged with railway=station, but I want to do it only for building=train_station, to leave all the other buildings alone. Could anybody help me with it?

z18
![eqwwzyjz](https://cloud.githubusercontent.com/assets/5439713/18812423/614c9604-82d4-11e6-902e-802bf8fc402b.png)
