### PR TITLE
Update INSTALL.md for fonts not included

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 On Ubuntu 16.04 or Debian Testing you can install all required fonts with
 
 ```
-sudo apt-get install fonts-noto ttf-unifont
+sudo apt-get install fonts-noto fonts-noto-cjk ttf-unifont
 ```
 
 DejaVu is packaged as `fonts-dejavu-core`.


### PR DESCRIPTION
The Noto CJK JP font seems to be missing in the Standard layer, it took me some time to figure out that it could be the problem in the installation guide.

Noto CJK fonts are provided in another `fonts-noto-cjk` package in Debian / Ubuntu instead of `fonts-noto`. The guide should be updated.

Note: `fonts-noto-cjk` is not available in Debian Jessie. :'(