### PR TITLE
Directly install individual Noto packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ Mapnik 3 is required for acceptable rendering of most non-Latin scripts, particu
 On Ubuntu 16.04 or Debian Testing you can install all required fonts with
 
 ```
-sudo apt-get install fonts-noto ttf-unifont
+sudo apt-get install fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted ttf-unifont
 ```
 
 DejaVu is packaged as `fonts-dejavu-core`.


### PR DESCRIPTION
The metapackage relies on recommends on 16.04, so the individual
packages need to be specified.

Fixes #2391 
Fixes #2397 