### PR TITLE
Add Map Icon Guidelines to Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,13 +142,7 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 
 * All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any proprietary tags. In Inkscape software, you will need to "Save As..." and choose the format Optimized SVG (preferable) or Plain SVG.
 * Icons must use SVG fills only, not SVG strokes or any feature Mapnik does not support.
-* Use no color for the icon's fill.  MSS (Map Style Sheets) gives the icon the appropriate thematic color.  As an example the [parking symbol in parking.svg](https://github.com/gravitystorm/openstreetmap-carto/blob/master/symbols/parking.svg) has no color defined (XML code):
-```XML
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 9 12">
-<path fill-rule="evenodd" d="M 0,0 L 0,12 1.75,12 1.75,7 6,7 A 3.0,3.5 0 0,0 6,0 Z M 1.75,1.75 L 1.75,5.25 5.5,5.25 A 1.58,1.75 0 0,0 5.5,1.75 Z"/>
-</svg>
-```
+* Use no color for the icon's fill if the icon is monochromatic. This allows the color to be set in the MSS.
 * Use a common canvas size, which is usually 14x14 px.
 * Draw a simple siloutte of the subject with an "on the shelf" perspective.
 * Align vectors to the pixel grid.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,19 +140,16 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 
 ## Map Icon Guidelines
 
-Icons for the submitted to the standard tile layer will be:
+Design Guidelines
 * SVG only
-* flat (single colour [usually black], no gradients, no outlines)
-* clean (reduced complexity where possible)
-* sharp (aligned to pixel grid)
-* single point of view (avoid use of perspective where possible)
-* common canvas size (usually 14x14px)
+* flat meaning a single colour, no gradients, no outlines
+* common canvas size, which is usually 14x14 px
+* single point of view and avoid use of perspective where possible
 
-Read the [https://wiki.openstreetmap.org/wiki/Map_Icons/Map_Icons_Standards](Map Icon Standards)
-on how to approach designing clear icons.
+Best Practices
+* align to pixel grid
+* clean design, so reduced complexity where possible
 
-More information at [https://wiki.openstreetmap.org/wiki/Map_Icons](OSM wiki Map Icons)
-and information concerning icon color.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,15 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 
 ## Map Icon Guidelines
 
-* All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any prioprietery tags.  In Inksapce software, you will need to Save As... Plain SVG format.
-* Icons must be use fills and not outlines.
-* Use a single color, typically black, for the fill portion of the icon.  MSS (Map Style Sheets) replaces the single color with the appropriate thematic color.
+* All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any proprietary tags.  In Inksapce software, you will need to "Save As..." and choose the format Optimized SVG (preferable) or Plain SVG.
+* Icons must use SVG fills only, not SVG strokes or any feature Mapnik does not support.
+* Use no color for the icon's fill.  MSS (Map Style Sheets) gives the icon the appropriate thematic color.  As an example the [parking symbol in parking.svg](https://github.com/gravitystorm/openstreetmap-carto/blob/master/symbols/parking.svg) has no color defined (XML code):
+```XML
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 9 12">
+<path fill-rule="evenodd" d="M 0,0 L 0,12 1.75,12 1.75,7 6,7 A 3.0,3.5 0 0,0 6,0 Z M 1.75,1.75 L 1.75,5.25 5.5,5.25 A 1.58,1.75 0 0,0 5.5,1.75 Z"/>
+</svg>
+```
 * Use a common canvas size, which is usually 14x14 px.
 * Draw a simple siloutte of the subject with an "on the shelf" perspective.
 * Align vectors to the pixel grid.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 
 ## Map Icon Guidelines
 
-* All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any proprietary tags.  In Inksapce software, you will need to "Save As..." and choose the format Optimized SVG (preferable) or Plain SVG.
+* All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any proprietary tags. In Inkscape software, you will need to "Save As..." and choose the format Optimized SVG (preferable) or Plain SVG.
 * Icons must use SVG fills only, not SVG strokes or any feature Mapnik does not support.
 * Use no color for the icon's fill.  MSS (Map Style Sheets) gives the icon the appropriate thematic color.  As an example the [parking symbol in parking.svg](https://github.com/gravitystorm/openstreetmap-carto/blob/master/symbols/parking.svg) has no color defined (XML code):
 ```XML

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,16 +140,18 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 
 ## Map Icon Guidelines
 
-Design Guidelines
-* SVG only
-* flat meaning a single colour, no gradients, no outlines
-* common canvas size, which is usually 14x14 px
-* single point of view and avoid use of perspective where possible
+* All new icons must be SVG format only.  The SVG must be saved as standards compliant SVG without any prioprietery tags.  In Inksapce software, you will need to Save As... Plain SVG format.
+* Icons must be use fills and not outlines.
+* Use a single color, typically black, for the fill portion of the icon.  MSS (Map Style Sheets) replaces the single color with the appropriate thematic color.
+* Use a common canvas size, which is usually 14x14 px.
+* Draw a simple siloutte of the subject with an "on the shelf" perspective.
+* Align vectors to the pixel grid.
+* Make a clean design, so reduced complexity where possible.
 
-Best Practices
-* align to pixel grid
-* clean design, so reduced complexity where possible
-
+### External Icon Design Resources
+These are resources with some helpful information about icon design.  These resources may have a different goal or philosophy and should not be held as authoritative sources for this project's icon design.
+* [Maki Icons Design Guidelines](https://www.mapbox.com/maki-icons/guidelines/) has some great illustrations of a well designed icon.
+* [GNOME Icon Design Guildelines](https://developer.gnome.org/hig/stable/icons-and-artwork.html.en) has some great concepts about general icon design, but color ideas do not apply to this project.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,22 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 * One space before and after = etc
 * Name SQL subqueries after the layer name (but use underscores)
 
+## Map Icon Guidelines
+
+Icons for the submitted to the standard tile layer will be:
+* SVG only
+* flat (single colour [usually black], no gradients, no outlines)
+* clean (reduced complexity where possible)
+* sharp (aligned to pixel grid)
+* single point of view (avoid use of perspective where possible)
+* common canvas size (usually 14x14px)
+
+Read the [https://wiki.openstreetmap.org/wiki/Map_Icons/Map_Icons_Standards](Map Icon Standards)
+on how to approach designing clear icons.
+
+More information at [https://wiki.openstreetmap.org/wiki/Map_Icons](OSM wiki Map Icons)
+and information concerning icon color.
+
 ## Pull requests
 
 Pull requests that change the cartography should contain a few images selected

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,10 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 * Make a clean design, so reduced complexity where possible.
 
 ### External Icon Design Resources
-These are resources with some helpful information about icon design.  These resources may have a different goal or philosophy and should not be held as authoritative sources for this project's icon design.
-* [Maki Icons Design Guidelines](https://www.mapbox.com/maki-icons/guidelines/) has some great illustrations of a well designed icon.
-* [GNOME Icon Design Guildelines](https://developer.gnome.org/hig/stable/icons-and-artwork.html.en) has some great concepts about general icon design, but color ideas do not apply to this project.
+The project's goals and design philsophy are different from other projects, but some external resources with general information about icon design are:
+
+* [Maki Icons Design Guidelines](https://www.mapbox.com/maki-icons/guidelines/)
+* [GNOME Icon Design Guildelines](https://developer.gnome.org/hig/stable/icons-and-artwork.html.en)
 
 ## Pull requests
 


### PR DESCRIPTION
Give brief guidelines for map icon submission.  Mainly points contributors to back to OSM wiki for more extensive information.

In my opinion, the repository is currently a little sparse in regard to this kind of information.
