### PR TITLE
base placename direction parameter on geometry

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1267,7 +1267,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    CASE\n      WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0\n    END as population,\n    round(random()) AS dir\n  FROM planet_osm_point\n  WHERE capital = 'yes'\n    AND admin_level = '2'\n  ORDER BY population DESC\n) AS capital_names",
+        "table": "(SELECT\n    way,\n    name,\n    CASE\n      WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0\n    END as population,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM planet_osm_point\n  WHERE capital = 'yes'\n    AND admin_level = '2'\n  ORDER BY population DESC\n) AS capital_names",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1320,7 +1320,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    score,\n    CASE\n      WHEN (place = 'city') THEN 1\n      ELSE 2\n    END as category,\n    round(random()) AS dir\n  FROM \n    (SELECT\n        way,\n        place,\n        name,\n        (\n          (CASE\n            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER\n            WHEN (place = 'city') THEN 100000\n            WHEN (place = 'town') THEN 1000\n            ELSE 1\n          END)\n          *\n          (CASE\n            WHEN (capital = '4' OR (capital = 'yes' AND admin_level = '4')) THEN 2\n            ELSE 1\n          END)\n        ) AS score\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND name IS NOT NULL\n        AND (capital IS NULL OR capital != 'yes' OR (capital = 'yes' AND (admin_level IS NULL OR admin_level != '2')))\n    ) as p\n  ORDER BY score DESC, length(name) DESC, name\n) AS placenames_medium",
+        "table": "(SELECT\n    way,\n    name,\n    score,\n    CASE\n      WHEN (place = 'city') THEN 1\n      ELSE 2\n    END as category,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM \n    (SELECT\n        osm_id,\n        way,\n        place,\n        name,\n        (\n          (CASE\n            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER\n            WHEN (place = 'city') THEN 100000\n            WHEN (place = 'town') THEN 1000\n            ELSE 1\n          END)\n          *\n          (CASE\n            WHEN (capital = '4' OR (capital = 'yes' AND admin_level = '4')) THEN 2\n            ELSE 1\n          END)\n        ) AS score\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND name IS NOT NULL\n        AND (capital IS NULL OR capital != 'yes' OR (capital = 'yes' AND (admin_level IS NULL OR admin_level != '2')))\n    ) as p\n  ORDER BY score DESC, length(name) DESC, name\n) AS placenames_medium",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1533,7 +1533,7 @@ Layer:
             CASE
               WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0
             END as population,
-            round(random()) AS dir
+            round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
           FROM planet_osm_point
           WHERE capital = 'yes'
             AND admin_level = '2'
@@ -1582,9 +1582,10 @@ Layer:
               WHEN (place = 'city') THEN 1
               ELSE 2
             END as category,
-            round(random()) AS dir
+            round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
           FROM 
             (SELECT
+                osm_id,
                 way,
                 place,
                 name,


### PR DESCRIPTION
Which makes it consistent across metatiles. Idea by @imagico. Ref #2378.

I have not seen any visual changes but at least we now can rule out this factor as source for misplaced labels at metatile boundaries.