### PR TITLE
Making railway stations appear as major buildings

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -33,7 +33,8 @@
         line-color: @building-aeroway-line;
       }
     }
-    [amenity = 'place_of_worship'] {
+    [amenity = 'place_of_worship'],
+    [building = 'train_station'] {
       polygon-fill: @building-major-fill;
       polygon-clip: false;
       [zoom >= 15] {

--- a/project.mml
+++ b/project.mml
@@ -562,7 +562,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
+        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR building = 'train_station')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -488,7 +488,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE building IS NOT NULL
             AND building != 'no'
-            AND (aeroway = 'terminal' OR amenity = 'place_of_worship')
+            AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR building = 'train_station')
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY z_order, way_area DESC)
         AS buildings_major


### PR DESCRIPTION
Technical follow up to https://github.com/gravitystorm/openstreetmap-carto/pull/2371 (can't reopen after pushing the code). Also related to #327.

This PR makes any building=train_station to be rendered as a major building and does not touch the railway=station tag (this one just has both tags):

z18
![eqwwzyjz](https://cloud.githubusercontent.com/assets/5439713/18812423/614c9604-82d4-11e6-902e-802bf8fc402b.png)