### PR TITLE
Rendering the name of man_made=bridge inside the polygon

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2448,6 +2448,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-fill: @standard-halo-fill;
       text-min-distance: 2;
       text-wrap-width: 30;
+      text-placement: interior;
       [way_pixels > 250] {
         text-size: 9;
       }


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/2364.

When man_made=bridge shape is not typical, the name label can be placed outside the polygon, which is unexpected and confusing. Simple fix required just adding `text-placement: interior;` option. Thanks for the hint, @HolgerJeromin!

Before
![qyyskatw](https://cloud.githubusercontent.com/assets/5439713/20376844/a612393a-ac8a-11e6-8009-2d7bfb04c728.png)

After
![sxsgjyfk](https://cloud.githubusercontent.com/assets/5439713/20376850/ae1317ee-ac8a-11e6-8666-86bb75efe3bb.png)