### PR TITLE
Increase strength of tertiary/residential/unclassified casing [WIP]

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -25,10 +25,10 @@
 @access-marking-living-street: #cccccc;
 
 @default-casing: white;
-@tertiary-casing: #8f8f8f;
-@residential-casing: #bbb;
+@tertiary-casing: #777;
+@residential-casing: #777;
 @road-casing: @residential-casing;
-@service-casing: @residential-casing;
+@service-casing: #aaa;
 @living-street-casing: @residential-casing;
 @pedestrian-casing: #999;
 @path-casing: @default-casing;
@@ -198,16 +198,17 @@
 
 @major-casing-width-z11:          0.3;
 
-@casing-width-z12:                0.1;
+@casing-width-z12:                0.3;
 @secondary-casing-width-z12:      0.3;
 @major-casing-width-z12:          0.5;
 
 @casing-width-z13:                0.5;
-@residential-casing-width-z13:    0.5;
+@residential-casing-width-z13:    0.3;
 @secondary-casing-width-z13:      0.35;
 @major-casing-width-z13:          0.5;
 
 @casing-width-z14:                0.55;
+@residential-casing-width-z14:    0.4;
 @secondary-casing-width-z14:      0.35;
 @major-casing-width-z14:          0.6;
 
@@ -1374,7 +1375,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
       [zoom >= 13] {
         line-width: @residential-width-z13 - 2 * @residential-casing-width-z13;
-        [zoom >= 14] { line-width: @residential-width-z14 - 2 * @casing-width-z14; }
+        [zoom >= 14] { line-width: @residential-width-z14 - 2 * @residential-casing-width-z14; }
         [zoom >= 15] { line-width: @residential-width-z15 - 2 * @casing-width-z15; }
         [zoom >= 16] { line-width: @residential-width-z16 - 2 * @casing-width-z16; }
         [zoom >= 17] { line-width: @residential-width-z17 - 2 * @casing-width-z17; }

--- a/roads.mss
+++ b/roads.mss
@@ -1403,8 +1403,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_living_street'] {
       [zoom >= 13] {
-        line-width: @living-street-width-z13 - 2 * @casing-width-z13;
-        [zoom >= 14] { line-width: @living-street-width-z14 - 2 * @casing-width-z14; }
+        line-width: @living-street-width-z13 - 2 * @residential-casing-width-z13;
+        [zoom >= 14] { line-width: @living-street-width-z14 - 2 * @residential-casing-width-z14; }
         [zoom >= 15] { line-width: @living-street-width-z15 - 2 * @casing-width-z15; }
         [zoom >= 16] { line-width: @living-street-width-z16 - 2 * @casing-width-z16; }
         [zoom >= 17] { line-width: @living-street-width-z17 - 2 * @casing-width-z17; }


### PR DESCRIPTION
White roads (tertiary/residential/unclassified) should contrast sufficiently with features like landcover and buildings, with which they are frequently surrounded. To increase the contrast, this pull request makes the casing of these roads darker.

Resolves #2448 (this is a toned down version of the changes proposed there).

Before/after (note that Github/your browser might scale the images so best to open them individually and/or press ctrl+0):

![12-old](https://cloud.githubusercontent.com/assets/5251909/20467339/b7d7a670-af85-11e6-8d90-040401fd455e.png) ![12-new](https://cloud.githubusercontent.com/assets/5251909/20467415/6a7764a4-af87-11e6-8f8c-134af258130a.png)

![13-old](https://cloud.githubusercontent.com/assets/5251909/20467338/b7d70e54-af85-11e6-8f8d-c537333f2979.png) ![13-new](https://cloud.githubusercontent.com/assets/5251909/20467416/6f22ff7c-af87-11e6-9473-bc88dede55af.png)

![14-old](https://cloud.githubusercontent.com/assets/5251909/20467337/b7d61512-af85-11e6-93c6-6b0bb9e5b449.png) ![14-new](https://cloud.githubusercontent.com/assets/5251909/20467336/b7ca9d90-af85-11e6-97f6-487c8cbaf524.png)

![15-old](https://cloud.githubusercontent.com/assets/5251909/20467334/b7b62dba-af85-11e6-9440-1e04b69246e8.png) ![15-new](https://cloud.githubusercontent.com/assets/5251909/20467335/b7c8beda-af85-11e6-8e3e-f9cd4629fe3e.png)

![16-old](https://cloud.githubusercontent.com/assets/5251909/20467333/b7b51a06-af85-11e6-9623-81f9848332fb.png) ![16-new](https://cloud.githubusercontent.com/assets/5251909/20467340/b7d9c3ba-af85-11e6-9835-54de2f269606.png)