### PR TITLE
Use json.dumps() for yaml2mml.py

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1,2093 +1,2047 @@
 {
-  "interactivity": false,
   "Layer": [
     {
-      "name": "world",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "world",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
-        "type": "shape",
-        "file": "data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp"
+        "file": "data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp",
+        "type": "shape"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "world",
+      "name": "world",
       "properties": {
         "maxzoom": 9
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "coast-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "coast-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
-        "type": "shape",
-        "file": "data/land-polygons-split-3857/land_polygons.shp"
+        "file": "data/land-polygons-split-3857/land_polygons.shp",
+        "type": "shape"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "coast-poly",
+      "name": "coast-poly",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "builtup",
-      "srs-name": "mercator",
-      "geometry": "polygon",
-      "class": "",
-      "id": "builtup",
-      "srs": "+proj=merc +datum=WGS84 +over",
       "Datasource": {
-        "type": "shape",
-        "file": "data/world_boundaries/builtup_area.shp"
+        "file": "data/world_boundaries/builtup_area.shp",
+        "type": "shape"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "builtup",
+      "name": "builtup",
       "properties": {
         "maxzoom": 9,
         "minzoom": 8
       },
-      "advanced": {}
+      "srs": "+proj=merc +datum=WGS84 +over",
+      "srs-name": "mercator"
     },
     {
-      "name": "necountries",
-      "srs-name": "WGS84",
-      "geometry": "linestring",
-      "class": "",
-      "id": "necountries",
-      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
       "Datasource": {
-        "type": "shape",
-        "file": "data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp"
+        "file": "data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp",
+        "type": "shape"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "necountries",
+      "name": "necountries",
       "properties": {
         "maxzoom": 3,
         "minzoom": 1
       },
-      "advanced": {}
+      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
+      "srs-name": "WGS84"
     },
     {
-      "name": "landcover-low-zoom",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "landcover-low-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, name, way_pixels,\n    COALESCE(wetland, landuse, \"natural\") AS feature\n  FROM (SELECT\n      way, COALESCE(name, '') AS name,\n      ('landuse_' || (CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END)) AS landuse,\n      ('natural_' || (CASE WHEN \"natural\" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN \"natural\" ELSE NULL END)) AS \"natural\",\n      ('wetland_' || (CASE WHEN \"natural\" IN ('wetland', 'mud') THEN (CASE WHEN \"natural\" IN ('mud') THEN \"natural\" ELSE wetland END) ELSE NULL END)) AS wetland,\n      way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n    FROM planet_osm_polygon\n    WHERE (landuse IN ('forest', 'military')\n      OR \"natural\" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock'))\n      AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n      AND building IS NULL\n    ORDER BY CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END, way_area DESC\n  ) AS features\n) AS landcover_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, name, way_pixels,\n    COALESCE(wetland, landuse, \"natural\") AS feature\n  FROM (SELECT\n      way, COALESCE(name, '') AS name,\n      ('landuse_' || (CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END)) AS landuse,\n      ('natural_' || (CASE WHEN \"natural\" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN \"natural\" ELSE NULL END)) AS \"natural\",\n      ('wetland_' || (CASE WHEN \"natural\" IN ('wetland', 'mud') THEN (CASE WHEN \"natural\" IN ('mud') THEN \"natural\" ELSE wetland END) ELSE NULL END)) AS wetland,\n      way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n    FROM planet_osm_polygon\n    WHERE (landuse IN ('forest', 'military')\n      OR \"natural\" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock'))\n      AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n      AND building IS NULL\n    ORDER BY CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END, way_area DESC\n  ) AS features\n) AS landcover_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "landcover-low-zoom",
+      "name": "landcover-low-zoom",
       "properties": {
         "maxzoom": 9,
         "minzoom": 7
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "landcover",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "landcover",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, name, religion, way_pixels,\n    COALESCE(aeroway, amenity, wetland, power, landuse, leisure, military, \"natural\", tourism, highway, railway) AS feature\n  FROM (SELECT\n      way, COALESCE(name, '') AS name,\n      ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,\n      ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', \n                                            'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic') \n                                            THEN amenity ELSE NULL END)) AS amenity,\n      ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass', \n                                            'allotments', 'forest', 'farmyard', 'farm', 'farmland', 'greenhouse_horticulture', \n                                            'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial', \n                                            'brownfield', 'landfill', 'construction') THEN landuse ELSE NULL END)) AS landuse,\n      ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'common', 'garden', \n                                            'golf_course', 'miniature_golf', 'picnic_table', 'sports_centre', 'stadium', 'pitch', \n                                            'track', 'dog_park') THEN leisure ELSE NULL END)) AS leisure,\n      ('military_' || (CASE WHEN military IN ('danger_area') THEN military ELSE NULL END)) AS military,\n      ('natural_' || (CASE WHEN \"natural\" IN ('beach', 'shoal', 'heath', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub') THEN \"natural\" ELSE NULL END)) AS \"natural\",\n      ('wetland_' || (CASE WHEN \"natural\" IN ('wetland', 'marsh', 'mud') THEN (CASE WHEN \"natural\" IN ('marsh', 'mud') THEN \"natural\" ELSE wetland END) ELSE NULL END)) AS wetland,\n      ('power_' || (CASE WHEN power IN ('station', 'sub_station', 'substation', 'generator') THEN power ELSE NULL END)) AS power,\n      ('tourism_' || (CASE WHEN tourism IN ('attraction', 'camp_site', 'caravan_site', 'picnic_site') THEN tourism ELSE NULL END)) AS tourism,\n      ('highway_' || (CASE WHEN highway IN ('services', 'rest_area') THEN highway ELSE NULL END)) AS highway,\n      ('railway_' || (CASE WHEN railway = 'station' THEN railway ELSE NULL END)) AS railway,\n      CASE WHEN religion IN ('christian', 'jewish') THEN religion ELSE 'INT-generic'::text END AS religion,\n      way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n    FROM planet_osm_polygon\n    WHERE (landuse IS NOT NULL\n      OR leisure IS NOT NULL\n      OR aeroway IN ('apron', 'aerodrome')\n      OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten', \n                     'grave_yard', 'place_of_worship', 'prison', 'clinic')\n      OR military IN ('danger_area')\n      OR \"natural\" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')\n      OR power IN ('station', 'sub_station', 'substation', 'generator')\n      OR tourism IN ('attraction', 'camp_site', 'caravan_site', 'picnic_site')\n      OR highway IN ('services', 'rest_area')\n      OR railway = 'station')\n      AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n    ORDER BY CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END, way_area DESC\n  ) AS landcover\n) AS features",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, name, religion, way_pixels,\n    COALESCE(aeroway, amenity, wetland, power, landuse, leisure, military, \"natural\", tourism, highway, railway) AS feature\n  FROM (SELECT\n      way, COALESCE(name, '') AS name,\n      ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,\n      ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', \n                                            'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic') \n                                            THEN amenity ELSE NULL END)) AS amenity,\n      ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass', \n                                            'allotments', 'forest', 'farmyard', 'farm', 'farmland', 'greenhouse_horticulture', \n                                            'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial', \n                                            'brownfield', 'landfill', 'construction') THEN landuse ELSE NULL END)) AS landuse,\n      ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'common', 'garden', \n                                            'golf_course', 'miniature_golf', 'picnic_table', 'sports_centre', 'stadium', 'pitch', \n                                            'track', 'dog_park') THEN leisure ELSE NULL END)) AS leisure,\n      ('military_' || (CASE WHEN military IN ('danger_area') THEN military ELSE NULL END)) AS military,\n      ('natural_' || (CASE WHEN \"natural\" IN ('beach', 'shoal', 'heath', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub') THEN \"natural\" ELSE NULL END)) AS \"natural\",\n      ('wetland_' || (CASE WHEN \"natural\" IN ('wetland', 'marsh', 'mud') THEN (CASE WHEN \"natural\" IN ('marsh', 'mud') THEN \"natural\" ELSE wetland END) ELSE NULL END)) AS wetland,\n      ('power_' || (CASE WHEN power IN ('station', 'sub_station', 'substation', 'generator') THEN power ELSE NULL END)) AS power,\n      ('tourism_' || (CASE WHEN tourism IN ('attraction', 'camp_site', 'caravan_site', 'picnic_site') THEN tourism ELSE NULL END)) AS tourism,\n      ('highway_' || (CASE WHEN highway IN ('services', 'rest_area') THEN highway ELSE NULL END)) AS highway,\n      ('railway_' || (CASE WHEN railway = 'station' THEN railway ELSE NULL END)) AS railway,\n      CASE WHEN religion IN ('christian', 'jewish') THEN religion ELSE 'INT-generic'::text END AS religion,\n      way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n    FROM planet_osm_polygon\n    WHERE (landuse IS NOT NULL\n      OR leisure IS NOT NULL\n      OR aeroway IN ('apron', 'aerodrome')\n      OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten', \n                     'grave_yard', 'place_of_worship', 'prison', 'clinic')\n      OR military IN ('danger_area')\n      OR \"natural\" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')\n      OR power IN ('station', 'sub_station', 'substation', 'generator')\n      OR tourism IN ('attraction', 'camp_site', 'caravan_site', 'picnic_site')\n      OR highway IN ('services', 'rest_area')\n      OR railway = 'station')\n      AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n    ORDER BY CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END, way_area DESC\n  ) AS landcover\n) AS features",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "landcover",
+      "name": "landcover",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "landcover-line",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "landcover-line",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE man_made = 'cutline'\n) AS landcover_line",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE man_made = 'cutline'\n) AS landcover_line",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "landcover-line",
+      "name": "landcover-line",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-lines-casing",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "water-lines-casing",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, waterway, intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel\n  FROM planet_osm_line\n  WHERE waterway IN ('stream', 'drain', 'ditch')\n) AS water_lines_casing",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, waterway, intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel\n  FROM planet_osm_line\n  WHERE waterway IN ('stream', 'drain', 'ditch')\n) AS water_lines_casing",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "water-lines-casing",
+      "name": "water-lines-casing",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-lines-low-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "water-lines-low-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    waterway,\n    intermittent\n  FROM planet_osm_line\n  WHERE waterway = 'river'\n) AS water_lines_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    waterway,\n    intermittent\n  FROM planet_osm_line\n  WHERE waterway = 'river'\n) AS water_lines_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "water-lines-low-zoom",
+      "name": "water-lines-low-zoom",
       "properties": {
         "maxzoom": 11,
         "minzoom": 8
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "icesheet-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
+      "Datasource": {
+        "file": "data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp",
+        "type": "shape"
+      },
+      "advanced": {},
       "class": "",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "polygon",
       "id": "icesheet-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "type": "shape",
-        "file": "data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
+      "name": "icesheet-poly",
       "properties": {
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-areas",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "water-areas",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    \"natural\",\n    waterway,\n    landuse,\n    name,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE\n    (waterway IN ('dock', 'riverbank', 'canal')\n      OR landuse IN ('reservoir', 'basin')\n      OR \"natural\" IN ('water', 'glacier'))\n    AND building IS NULL\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC\n) AS water_areas",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "water-areas",
+      "name": "water-areas",
       "properties": {
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "landcover-area-symbols",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "landcover-area-symbols",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, surface, \n    COALESCE(CASE WHEN landuse = 'forest' THEN 'wood' ELSE NULL END, \"natural\") AS \"natural\",\n    CASE WHEN \"natural\" IN ('marsh', 'mud') \n        THEN \"natural\" \n        ELSE CASE WHEN (\"natural\" = 'wetland' AND wetland IS NULL) \n          THEN 'wetland' \n          ELSE CASE WHEN (\"natural\" = 'wetland')\n            THEN wetland\n            ELSE NULL\n            END \n        END\n      END AS int_wetland\n  FROM planet_osm_polygon\n  WHERE (\"natural\" IN ('marsh', 'mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub') OR landuse = 'forest')\n    AND building IS NULL\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC\n) AS landcover_area_symbols",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, surface, \n    COALESCE(CASE WHEN landuse = 'forest' THEN 'wood' ELSE NULL END, \"natural\") AS \"natural\",\n    CASE WHEN \"natural\" IN ('marsh', 'mud') \n        THEN \"natural\" \n        ELSE CASE WHEN (\"natural\" = 'wetland' AND wetland IS NULL) \n          THEN 'wetland' \n          ELSE CASE WHEN (\"natural\" = 'wetland')\n            THEN wetland\n            ELSE NULL\n            END \n        END\n      END AS int_wetland\n  FROM planet_osm_polygon\n  WHERE (\"natural\" IN ('marsh', 'mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub') OR landuse = 'forest')\n    AND building IS NULL\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC\n) AS landcover_area_symbols",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "landcover-area-symbols",
+      "name": "landcover-area-symbols",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "icesheet-outlines",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "icesheet-outlines",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
-        "type": "shape",
-        "file": "data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp"
+        "file": "data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp",
+        "type": "shape"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "icesheet-outlines",
+      "name": "icesheet-outlines",
       "properties": {
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-lines",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "water-lines",
-      "id": "water-lines",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, waterway, name, intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,\n    'no' AS bridge\n  FROM planet_osm_line\n  WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')\n    AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))\n  ORDER BY z_order\n) AS water_lines",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, waterway, name, intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,\n    'no' AS bridge\n  FROM planet_osm_line\n  WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')\n    AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))\n  ORDER BY z_order\n) AS water_lines",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "water-lines",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "water-lines",
+      "name": "water-lines",
       "properties": {
         "minzoom": 12
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-barriers-line",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "water-barriers-line",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    waterway,\n    name\n  FROM planet_osm_line\n  WHERE waterway IN ('dam', 'weir', 'lock_gate')\n) AS water_barriers_line",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "water-barriers-line",
+      "name": "water-barriers-line",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-barriers-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "water-barriers-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    waterway,\n    name\n  FROM planet_osm_polygon\n  WHERE waterway IN ('dam', 'weir', 'lock_gate')\n) AS water_barriers_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "water-barriers-poly",
+      "name": "water-barriers-poly",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "marinas-area",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "marinas-area",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_polygon\n  WHERE leisure = 'marina'\n) AS marinas_area",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_polygon\n  WHERE leisure = 'marina'\n) AS marinas_area",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "marinas-area",
+      "name": "marinas-area",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "piers-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "piers-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way, man_made\n  FROM planet_osm_polygon\n  WHERE man_made IN ('pier', 'breakwater', 'groyne')\n) AS piers_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "piers-poly",
+      "name": "piers-poly",
       "properties": {
         "minzoom": 12
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "piers-line",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "piers-line",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way, man_made\n  FROM planet_osm_line\n  WHERE man_made IN ('pier', 'breakwater', 'groyne')\n) AS piers_line",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "piers-line",
+      "name": "piers-line",
       "properties": {
         "minzoom": 12
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-barriers-point",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "water-barriers-point",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, waterway\n  FROM planet_osm_point\n  WHERE waterway IN ('dam', 'weir', 'lock_gate')\n) AS water_barriers_points",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, waterway\n  FROM planet_osm_point\n  WHERE waterway IN ('dam', 'weir', 'lock_gate')\n) AS water_barriers_points",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "water-barriers-point",
+      "name": "water-barriers-point",
       "properties": {
         "minzoom": 17
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "bridge",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "bridge",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    man_made,\n    name\n  FROM planet_osm_polygon\n  WHERE man_made = 'bridge'\n) AS bridge",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    man_made,\n    name\n  FROM planet_osm_polygon\n  WHERE man_made = 'bridge'\n) AS bridge",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "bridge",
+      "name": "bridge",
       "properties": {
         "minzoom": 12
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "buildings",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "buildings",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    building\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC\n) AS buildings",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 13
-      },
-      "advanced": {}
-    },
-    {
-      "name": "buildings-major",
-      "srs-name": "900913",
-      "geometry": "polygon",
+      "advanced": {},
       "class": "",
-      "id": "buildings-major",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR building = 'train_station')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "buildings",
+      "name": "buildings",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "tunnels",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "tunnels-fill tunnels-casing access",
-      "id": "tunnels",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS tunnels",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    building,\n    amenity,\n    aeroway\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building != 'no'\n    AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR building = 'train_station')\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n  ORDER BY z_order, way_area DESC)\nAS buildings_major",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "buildings-major",
+      "name": "buildings-major",
+      "properties": {
+        "minzoom": 13
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS tunnels",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "tunnels-fill tunnels-casing access",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "linestring",
+      "id": "tunnels",
+      "name": "tunnels",
       "properties": {
         "group-by": "layernotnull",
         "minzoom": 9
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "landuse-overlay",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "landuse-overlay",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    landuse,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE landuse = 'military'\n    AND building IS NULL\n) AS landuse_overlay",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    landuse,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE landuse = 'military'\n    AND building IS NULL\n) AS landuse_overlay",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "landuse-overlay",
+      "name": "landuse-overlay",
       "properties": {
         "minzoom": 7
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "line-barriers",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "barriers",
-      "id": "line-barriers",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, COALESCE(historic, barrier) AS feature\n  FROM (SELECT way,\n    ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',\n          'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,\n    ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic\n    FROM planet_osm_line\n    WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',\n          'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')\n      OR historic = 'citywalls'\n      AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi'))\n  ) AS features\n) AS line_barriers",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, COALESCE(historic, barrier) AS feature\n  FROM (SELECT way,\n    ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',\n          'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,\n    ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic\n    FROM planet_osm_line\n    WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',\n          'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')\n      OR historic = 'citywalls'\n      AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi'))\n  ) AS features\n) AS line_barriers",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "barriers",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "line-barriers",
+      "name": "line-barriers",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "cliffs",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "cliffs",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, \"natural\", man_made\n  FROM planet_osm_line\n  WHERE \"natural\" = 'cliff' OR man_made = 'embankment'\n) AS cliffs",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, \"natural\", man_made\n  FROM planet_osm_line\n  WHERE \"natural\" = 'cliff' OR man_made = 'embankment'\n) AS cliffs",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "cliffs",
+      "name": "cliffs",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "area-barriers",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "barriers",
-      "id": "area-barriers",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, barrier AS feature\n  FROM (SELECT way,\n    ('barrier_' || barrier) AS barrier\n    FROM planet_osm_polygon\n    WHERE barrier IS NOT NULL\n  ) AS features\n) AS area_barriers",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, barrier AS feature\n  FROM (SELECT way,\n    ('barrier_' || barrier) AS barrier\n    FROM planet_osm_polygon\n    WHERE barrier IS NOT NULL\n  ) AS features\n) AS area_barriers",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "barriers",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "area-barriers",
+      "name": "area-barriers",
       "properties": {
         "minzoom": 16
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "ferry-routes",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "ferry-routes",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE route = 'ferry'\n) AS ferry_routes",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE route = 'ferry'\n) AS ferry_routes",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "ferry-routes",
+      "name": "ferry-routes",
       "properties": {
         "minzoom": 7
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "turning-circle-casing",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "turning-circle-casing",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT DISTINCT ON (p.way)\n    p.way AS way, l.highway AS int_tc_type,\n    CASE WHEN l.service IN ('parking_aisle', 'drive-through', 'driveway')\n      THEN 'INT-minor'::text\n      ELSE 'INT-normal'::text\n    END AS int_tc_service\n  FROM planet_osm_point p\n    JOIN planet_osm_line l ON ST_DWithin(p.way, l.way, 0.1) -- Assumes Mercator\n    JOIN (VALUES\n      ('tertiary', 1),\n      ('unclassified', 2),\n      ('residential', 3),\n      ('living_street', 4),\n      ('service', 5)\n      ) AS v (highway, prio)\n      ON v.highway=l.highway\n  WHERE p.highway = 'turning_circle'\n    OR p.highway = 'turning_loop'\n  ORDER BY p.way, v.prio\n) AS turning_circle_casing",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT DISTINCT ON (p.way)\n    p.way AS way, l.highway AS int_tc_type,\n    CASE WHEN l.service IN ('parking_aisle', 'drive-through', 'driveway')\n      THEN 'INT-minor'::text\n      ELSE 'INT-normal'::text\n    END AS int_tc_service\n  FROM planet_osm_point p\n    JOIN planet_osm_line l ON ST_DWithin(p.way, l.way, 0.1) -- Assumes Mercator\n    JOIN (VALUES\n      ('tertiary', 1),\n      ('unclassified', 2),\n      ('residential', 3),\n      ('living_street', 4),\n      ('service', 5)\n      ) AS v (highway, prio)\n      ON v.highway=l.highway\n  WHERE p.highway = 'turning_circle'\n    OR p.highway = 'turning_loop'\n  ORDER BY p.way, v.prio\n) AS turning_circle_casing",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "turning-circle-casing",
+      "name": "turning-circle-casing",
       "properties": {
         "minzoom": 15
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "highway-area-casing",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "highway-area-casing",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE((\n      'highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'track', 'path', 'platform') THEN highway ELSE NULL END)),\n      ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END))\n    ) AS feature\n  FROM planet_osm_polygon\n  WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'track', 'path', 'platform')\n    OR railway IN ('platform')\n  ORDER BY z_order, way_area DESC\n) AS highway_area_casing",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    COALESCE((\n      'highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'track', 'path', 'platform') THEN highway ELSE NULL END)),\n      ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END))\n    ) AS feature\n  FROM planet_osm_polygon\n  WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'track', 'path', 'platform')\n    OR railway IN ('platform')\n  ORDER BY z_order, way_area DESC\n) AS highway_area_casing",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "highway-area-casing",
+      "name": "highway-area-casing",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-casing",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "roads-casing",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS roads_casing",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS roads_casing",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "roads-casing",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
       "id": "roads-casing",
+      "name": "roads-casing",
       "properties": {
         "minzoom": 9
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "highway-area-fill",
-      "srs-name": "900913",
-      "class": "",
-      "id": "highway-area-fill",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      ('highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', \n                                            'track', 'path', 'platform', 'services') THEN highway ELSE NULL END)),\n      ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END)),\n      (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))\n    ) AS feature\n  FROM planet_osm_polygon\n  WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'living_street', 'track', 'path', 'platform', 'services')\n    OR railway IN ('platform')\n    OR aeroway IN ('runway', 'taxiway', 'helipad')\n  ORDER BY z_order, way_area desc\n) AS highway_area_fill",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    COALESCE(\n      ('highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', \n                                            'track', 'path', 'platform', 'services') THEN highway ELSE NULL END)),\n      ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END)),\n      (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))\n    ) AS feature\n  FROM planet_osm_polygon\n  WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'living_street', 'track', 'path', 'platform', 'services')\n    OR railway IN ('platform')\n    OR aeroway IN ('runway', 'taxiway', 'helipad')\n  ORDER BY z_order, way_area desc\n) AS highway_area_fill",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "id": "highway-area-fill",
+      "name": "highway-area-fill",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-fill",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "roads-fill access",
-      "id": "roads-fill",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- begin \"features\" subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, -- only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null' AS surface, -- Should be a SQL NULL?\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS roads_fill",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- begin \"features\" subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, -- only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'  \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null' AS surface, -- Should be a SQL NULL?\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))\n        AND (covered IS NULL OR NOT covered = 'yes')\n        AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS roads_fill",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "roads-fill access",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "roads-fill",
+      "name": "roads-fill",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "turning-circle-fill",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "turning-circle-fill",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    DISTINCT on (p.way)\n    p.way AS way, l.highway AS int_tc_type,\n    CASE WHEN l.service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n      ELSE 'INT-normal'::text END AS int_tc_service\n  FROM planet_osm_point p\n    JOIN planet_osm_line l\n      ON ST_DWithin(p.way, l.way, 0.1)\n    JOIN (VALUES\n      ('tertiary', 1),\n      ('unclassified', 2),\n      ('residential', 3),\n      ('living_street', 4),\n      ('service', 5),\n      ('track', 6)\n    ) AS v (highway, prio)\n      ON v.highway=l.highway\n  WHERE p.highway = 'turning_circle' OR p.highway = 'turning_loop'\n  ORDER BY p.way, v.prio\n) AS turning_circle_fill",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    DISTINCT on (p.way)\n    p.way AS way, l.highway AS int_tc_type,\n    CASE WHEN l.service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n      ELSE 'INT-normal'::text END AS int_tc_service\n  FROM planet_osm_point p\n    JOIN planet_osm_line l\n      ON ST_DWithin(p.way, l.way, 0.1)\n    JOIN (VALUES\n      ('tertiary', 1),\n      ('unclassified', 2),\n      ('residential', 3),\n      ('living_street', 4),\n      ('service', 5),\n      ('track', 6)\n    ) AS v (highway, prio)\n      ON v.highway=l.highway\n  WHERE p.highway = 'turning_circle' OR p.highway = 'turning_loop'\n  ORDER BY p.way, v.prio\n) AS turning_circle_fill",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "turning-circle-fill",
+      "name": "turning-circle-fill",
       "properties": {
         "minzoom": 15
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "aerialways",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "aerialways",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    aerialway\n  FROM planet_osm_line\n  WHERE aerialway IS NOT NULL\n) AS aerialways",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    aerialway\n  FROM planet_osm_line\n  WHERE aerialway IS NOT NULL\n) AS aerialways",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "aerialways",
+      "name": "aerialways",
       "properties": {
         "minzoom": 12
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-low-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "roads-low-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      ('highway_' || (CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN substr(highway, 0, length(highway)-4) ELSE highway end)),\n      ('railway_' || (CASE WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard' \n                           WHEN railway IN ('rail', 'tram', 'light_rail', 'funicular', 'narrow_gauge') THEN railway ELSE NULL END))\n    ) AS feature,\n    CASE WHEN tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes' THEN 'yes' ELSE 'no' END AS int_tunnel,\n    CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes' ELSE 'no' END AS link,\n    CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                          'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n      WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                          'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n      ELSE NULL\n    END AS int_surface\n  FROM planet_osm_roads\n  WHERE highway IS NOT NULL\n    OR (railway IS NOT NULL AND railway != 'preserved'\n      AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))\n  ORDER BY z_order\n) AS roads_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    COALESCE(\n      ('highway_' || (CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN substr(highway, 0, length(highway)-4) ELSE highway end)),\n      ('railway_' || (CASE WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard' \n                           WHEN railway IN ('rail', 'tram', 'light_rail', 'funicular', 'narrow_gauge') THEN railway ELSE NULL END))\n    ) AS feature,\n    CASE WHEN tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes' THEN 'yes' ELSE 'no' END AS int_tunnel,\n    CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes' ELSE 'no' END AS link,\n    CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                          'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n      WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                          'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n      ELSE NULL\n    END AS int_surface\n  FROM planet_osm_roads\n  WHERE highway IS NOT NULL\n    OR (railway IS NOT NULL AND railway != 'preserved'\n      AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))\n  ORDER BY z_order\n) AS roads_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "roads-low-zoom",
+      "name": "roads-low-zoom",
       "properties": {
         "maxzoom": 9,
         "minzoom": 5
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "waterway-bridges",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "water-lines",
-      "id": "waterway-bridges",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    waterway,\n    name,\n    intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,\n    'yes' AS bridge\n  FROM planet_osm_line\n  WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')\n    AND bridge IN ('yes', 'aqueduct')\n  ORDER BY z_order\n) AS waterway_bridges",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    waterway,\n    name,\n    intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,\n    'yes' AS bridge\n  FROM planet_osm_line\n  WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')\n    AND bridge IN ('yes', 'aqueduct')\n  ORDER BY z_order\n) AS waterway_bridges",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "water-lines",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "waterway-bridges",
+      "name": "waterway-bridges",
       "properties": {
         "minzoom": 15
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "bridges",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "bridges-fill bridges-casing access",
-      "id": "bridges",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard' \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS bridges",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    (CASE WHEN substr(feature, length(feature)-3, 4) = 'link' THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,\n    horse,\n    foot,\n    bicycle,\n    tracktype,\n    int_surface,\n    access,\n    construction,\n    service,\n    link,\n    layernotnull\n  FROM ( -- subselect that contains both roads and rail/aero\n    SELECT\n        way,\n        ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',\n                              'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay') THEN 'unpaved'\n          WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',\n                              'concrete:plates', 'paving_stones', 'metal', 'wood') THEN 'paved'\n          ELSE NULL\n        END AS int_surface,\n        CASE WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE\n          WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text\n          ELSE 'INT-normal'::text\n        END AS service,\n        CASE\n          WHEN substr(highway, length(highway)-3, 4) = 'link' THEN 'yes'\n          ELSE 'no'\n        END AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')\n        AND highway IS NOT NULL -- end of road select\n    UNION ALL\n    SELECT\n        way,\n        COALESCE(\n          ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text \n                               WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard' \n                               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),\n          ('aeroway_' || aeroway)\n        ) AS feature,\n        horse,\n        foot,\n        bicycle,\n        tracktype,\n        'null',\n        CASE\n          WHEN access IN ('destination') THEN 'destination'::text\n          WHEN access IN ('no', 'private') THEN 'no'::text\n          ELSE NULL\n        END AS access,\n        construction,\n        CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,\n        'no' AS link,\n        CASE WHEN layer~E'^-?\\\\d+$' AND length(layer)<10 THEN layer::integer ELSE 0 END AS layernotnull\n      FROM planet_osm_line\n      WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')\n        AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select\n    ) AS features\n  JOIN (VALUES -- this join is also putting a condition on what is selected. features not matching it do not make it into the results.\n      ('railway_rail', 440),\n      ('railway_INT-preserved-ssy', 430),\n      ('railway_INT-spur-siding-yard', 430),\n      ('railway_subway', 420),\n      ('railway_narrow_gauge', 420),\n      ('railway_light_rail', 420),\n      ('railway_preserved', 420),\n      ('railway_funicular', 420),\n      ('railway_monorail', 420),\n      ('railway_miniature', 420),\n      ('railway_turntable', 420),\n      ('railway_tram', 410),\n      ('railway_tram-service', 405),\n      ('railway_disused', 400),\n      ('railway_construction', 400),\n      ('highway_motorway', 380),\n      ('highway_trunk', 370),\n      ('highway_primary', 360),\n      ('highway_secondary', 350),\n      ('highway_tertiary', 340),\n      ('highway_residential', 330),\n      ('highway_unclassified', 330),\n      ('highway_road', 330),\n      ('highway_living_street', 320),\n      ('highway_pedestrian', 310),\n      ('highway_raceway', 300),\n      ('highway_motorway_link', 240),\n      ('highway_trunk_link', 230),\n      ('highway_primary_link', 220),\n      ('highway_secondary_link', 210),\n      ('highway_tertiary_link', 200),\n      ('highway_service', 150),\n      ('highway_track', 110),\n      ('highway_path', 100),\n      ('highway_footway', 100),\n      ('highway_bridleway', 100),\n      ('highway_cycleway', 100),\n      ('highway_steps', 100),\n      ('highway_platform', 90),\n      ('railway_platform', 90),\n      ('aeroway_runway', 60),\n      ('aeroway_taxiway', 50),\n      ('highway_construction', 10)\n    ) AS ordertable (feature, prio)\n    USING (feature)\n  ORDER BY\n    layernotnull,\n    prio,\n    CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,\n    CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END\n) AS bridges",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "bridges-fill bridges-casing access",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "bridges",
+      "name": "bridges",
       "properties": {
         "group-by": "layernotnull",
         "minzoom": 9
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "guideways",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "guideways",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE highway = 'bus_guideway'\n) AS guideways",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE highway = 'bus_guideway'\n) AS guideways",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "guideways",
+      "name": "guideways",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "admin-low-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
       "id": "admin-low-zoom",
+      "name": "admin-low-zoom",
       "properties": {
         "maxzoom": 10,
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "admin-mid-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "admin-mid-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n) AS admin_mid_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "admin-mid-zoom",
+      "name": "admin-mid-zoom",
       "properties": {
         "maxzoom": 12,
         "minzoom": 11
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "admin-high-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "admin-high-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND osm_id < 0\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND osm_id < 0\n  ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering\n) AS admin_high_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "admin-high-zoom",
+      "name": "admin-high-zoom",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "power-minorline",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "power-minorline",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE power = 'minor_line'\n) AS power_minorline",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE power = 'minor_line'\n) AS power_minorline",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "power-minorline",
+      "name": "power-minorline",
       "properties": {
         "minzoom": 16
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "power-line",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "power-line",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE power = 'line'\n) AS power_line",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE power = 'line'\n) AS power_line",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "power-line",
+      "name": "power-line",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "nature-reserve-boundaries",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "nature-reserve-boundaries",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    boundary,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND building IS NULL\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n) AS national_park_boundaries",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    name,\n    boundary,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND building IS NULL\n    AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real\n) AS national_park_boundaries",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "nature-reserve-boundaries",
+      "name": "nature-reserve-boundaries",
       "properties": {
         "minzoom": 7
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "tourism-boundary",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "tourism-boundary",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    tourism\n  FROM planet_osm_polygon\n  WHERE tourism = 'theme_park'\n    OR tourism = 'zoo'\n) AS tourism_boundary",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    tourism\n  FROM planet_osm_polygon\n  WHERE tourism = 'theme_park'\n    OR tourism = 'zoo'\n) AS tourism_boundary",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "tourism-boundary",
+      "name": "tourism-boundary",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "trees",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "trees",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way, \"natural\"\n  FROM planet_osm_point\n  WHERE \"natural\" = 'tree'\nUNION ALL\nSELECT\n    way, \"natural\"\n  FROM planet_osm_line\n  WHERE \"natural\" = 'tree_row'\n) AS trees",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way, \"natural\"\n  FROM planet_osm_point\n  WHERE \"natural\" = 'tree'\nUNION ALL\nSELECT\n    way, \"natural\"\n  FROM planet_osm_line\n  WHERE \"natural\" = 'tree_row'\n) AS trees",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "trees",
+      "name": "trees",
       "properties": {
         "minzoom": 16
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "country-names",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "country",
-      "id": "country-names",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '2'\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real\n  ORDER BY way_area DESC\n) AS country_names",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '2'\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real\n  ORDER BY way_area DESC\n) AS country_names",
+        "type": "postgis"
       },
+      "class": "country",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "country-names",
+      "name": "country-names",
       "properties": {
         "minzoom": 2
-      }
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "capital-names",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "capital-names",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    CASE\n      WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0\n    END as population,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND name IS NOT NULL\n    AND capital = 'yes'\n    AND admin_level = '2'\n  ORDER BY population DESC\n) AS capital_names",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    name,\n    CASE\n      WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0\n    END as population,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM planet_osm_point\n  WHERE place IN ('city', 'town')\n    AND name IS NOT NULL\n    AND capital = 'yes'\n    AND admin_level = '2'\n  ORDER BY population DESC\n) AS capital_names",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "capital-names",
+      "name": "capital-names",
       "properties": {
         "maxzoom": 15,
         "minzoom": 3
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "state-names",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "state",
-      "id": "state-names",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '4'\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real\n  ORDER BY way_area DESC\n) AS state_names",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '4'\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real\n  ORDER BY way_area DESC\n) AS state_names",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "state",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "state-names",
+      "name": "state-names",
       "properties": {
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "placenames-medium",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "placenames-medium",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    score,\n    CASE\n      WHEN (place = 'city') THEN 1\n      ELSE 2\n    END as category,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM \n    (SELECT\n        osm_id,\n        way,\n        place,\n        name,\n        (\n          (CASE\n            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER\n            WHEN (place = 'city') THEN 100000\n            WHEN (place = 'town') THEN 1000\n            ELSE 1\n          END)\n          *\n          (CASE\n            WHEN (capital = '4' OR (capital = 'yes' AND admin_level = '4')) THEN 2\n            ELSE 1\n          END)\n        ) AS score\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND name IS NOT NULL\n        AND (capital IS NULL OR capital != 'yes' OR (capital = 'yes' AND (admin_level IS NULL OR admin_level != '2')))\n    ) as p\n  ORDER BY score DESC, length(name) DESC, name\n) AS placenames_medium",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    name,\n    score,\n    CASE\n      WHEN (place = 'city') THEN 1\n      ELSE 2\n    END as category,\n    round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles\n  FROM \n    (SELECT\n        osm_id,\n        way,\n        place,\n        name,\n        (\n          (CASE\n            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER\n            WHEN (place = 'city') THEN 100000\n            WHEN (place = 'town') THEN 1000\n            ELSE 1\n          END)\n          *\n          (CASE\n            WHEN (capital = '4' OR (capital = 'yes' AND admin_level = '4')) THEN 2\n            ELSE 1\n          END)\n        ) AS score\n      FROM planet_osm_point\n      WHERE place IN ('city', 'town')\n        AND name IS NOT NULL\n        AND (capital IS NULL OR capital != 'yes' OR (capital = 'yes' AND (admin_level IS NULL OR admin_level != '2')))\n    ) as p\n  ORDER BY score DESC, length(name) DESC, name\n) AS placenames_medium",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "placenames-medium",
+      "name": "placenames-medium",
       "properties": {
         "maxzoom": 15,
         "minzoom": 4
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "placenames-small",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "placenames-small",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    place,\n    name\n  FROM planet_osm_point\n  WHERE place IN ('suburb', 'village', 'hamlet', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')\n    AND name IS NOT NULL\n  ORDER BY CASE\n      WHEN place = 'suburb' THEN 3\n      WHEN place = 'village' THEN 4\n      WHEN place = 'hamlet' THEN 5\n      WHEN place = 'neighbourhood' THEN 6\n      WHEN place = 'locality' THEN 7\n      WHEN place = 'isolated_dwelling' THEN 8\n      WHEN place = 'farm' THEN 9\n    END ASC, length(name) DESC, name\n) AS placenames_small",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 12
-      },
-      "advanced": {}
-    },
-    {
-      "name": "stations",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "stations",
-      "id": "stations",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    railway,\n    aerialway,\n    CASE railway \n      WHEN 'station' THEN 1 \n      WHEN 'subway_entrance' THEN 3\n      ELSE 2\n    END\n      AS prio\n  FROM planet_osm_point\n  WHERE railway IN ('station', 'halt', 'tram_stop', 'subway_entrance')\n    OR aerialway = 'station'\n  ORDER BY prio\n) AS stations",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 12
-      },
-      "advanced": {}
-    },
-    {
-      "name": "stations-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "stations",
-      "id": "stations-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    railway,\n    aerialway\nFROM planet_osm_polygon\nWHERE railway IN ('station', 'halt', 'tram_stop')\n  OR aerialway = 'station'\n) AS stations_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 12
-      },
-      "advanced": {}
-    },
-    {
-      "name": "amenity-points-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "points",
-      "id": "amenity-points-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', \n                                          'hostel', 'hotel', 'motel', 'information', 'museum', 'picnic_site') THEN tourism ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                                          'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre', 'fire_station', 'fountain',\n                                          'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', 'townhall', 'parking', \n                                          'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', 'dentist', 'place_of_worship', \n                                          'police', 'post_box', 'post_office', 'pub', 'biergarten', 'recycling', 'restaurant', 'food_court', \n                                          'fast_food', 'telephone', 'emergency_phone', 'taxi', 'theatre', 'toilets', 'drinking_water', \n                                          'prison', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                          'charging_station') THEN amenity ELSE NULL END,\n      'shop_' || CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', \n                                    'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', \n                                    'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', \n                                    'photo', 'photo_studio', 'photography', 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', \n                                    'mobile_phone', 'motorcycle', 'musical_instrument', 'newsagent', 'optician', 'jewelry', 'jewellery', \n                                    'electronics', 'chemist', 'toys', 'travel_agency', 'car_parts', 'greengrocer', 'farm', 'stationery', \n                                    'laundry', 'dry_cleaning', 'beverages', 'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', \n                                    'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                      WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n      'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table') THEN leisure ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('spring') THEN \"natural\" ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n      'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,\n      'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END\n    ) AS feature,\n    access,\n    religion,\n    denomination,\n    \"generator:source\",\n    power_source,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n  WHERE aeroway IN ('helipad', 'aerodrome')\n    OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                   'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site')\n    OR amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                   'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre',\n                   'fire_station', 'fountain', 'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', \n                   'townhall', 'parking', 'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', \n                   'dentist', 'place_of_worship', 'police', 'post_box', 'post_office', 'pub', 'biergarten', \n                   'recycling', 'restaurant', 'food_court', 'fast_food', 'telephone', 'emergency_phone', 'taxi', \n                   'theatre', 'toilets', 'drinking_water', 'prison', 'hunting_stand', 'nightclub', 'veterinary',\n                   'social_facility', 'charging_station')\n    OR shop IS NOT NULL -- skip checking a huge list and use a null check\n    OR leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table')\n    OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk')\n    OR \"natural\" IN ('spring')\n    OR historic IN ('memorial', 'monument', 'archaeological_site')\n    OR highway IN ('bus_stop', 'elevator', 'traffic_signals')\n    OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n  ORDER BY way_area desc\n) AS amenity_points_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
-      },
-      "advanced": {}
-    },
-    {
-      "name": "amenity-points",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "points",
-      "id": "amenity-points",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                                          'hotel', 'motel', 'information', 'museum', 'picnic_site') THEN tourism ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                                          'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre', 'fire_station', 'fountain',\n                                          'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', 'townhall', 'parking', \n                                          'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', 'dentist', 'place_of_worship', \n                                          'police', 'post_box', 'post_office', 'pub', 'biergarten', 'recycling', 'restaurant', 'food_court', \n                                          'fast_food', 'telephone', 'emergency_phone', 'taxi', 'theatre', 'toilets', 'drinking_water', \n                                          'prison', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                          'charging_station') THEN amenity ELSE NULL END,\n      'shop_' || CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 'confectionery', \n                                    'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 'garden_centre', \n                                    'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 'photo', 'photo_studio', \n                                    'photography', 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', \n                                    'musical_instrument', 'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', \n                                    'travel_agency', 'car_parts', 'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', \n                                    'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                      WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n      'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',\n                                          'dog_park') THEN leisure ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN \"natural\" ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n      'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford') THEN highway ELSE NULL END,\n      'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END\n    ) AS feature,\n    access,\n    CASE\n      WHEN \"natural\" IN ('peak', 'volcano', 'saddle') THEN\n        CASE\n          WHEN ele ~ '^-?\\d{1,4}(\\.\\d+)?$' THEN ele::NUMERIC\n          ELSE NULL\n        END\n      ELSE NULL\n    END AS score,\n    religion,\n    denomination,\n    \"generator:source\",\n    power_source,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n  WHERE aeroway IN ('helipad', 'aerodrome')\n    OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                   'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site')\n    OR amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                   'car_rental',  'car_wash', 'cinema', 'clinic', 'community_centre',\n                   'fire_station', 'fountain', 'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', \n                   'townhall', 'parking', 'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', \n                   'dentist', 'place_of_worship', 'police', 'post_box', 'post_office', 'pub', 'biergarten', \n                   'recycling', 'restaurant', 'food_court', 'fast_food', 'telephone', 'emergency_phone', \n                   'taxi', 'theatre', 'toilets', 'drinking_water', 'prison', 'hunting_stand', 'nightclub', \n                   'veterinary', 'social_facility', 'charging_station')\n    OR shop IS NOT NULL -- skip checking a huge list and use a null check\n    OR leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',\n                   'dog_park')\n    OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')\n    OR \"natural\" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')\n    OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')\n    OR highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford')\n    OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n  ORDER BY score DESC NULLS LAST\n  ) AS amenity_points",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
-      },
-      "advanced": {}
-    },
-    {
-      "name": "power-towers",
-      "srs-name": "900913",
-      "geometry": "point",
+      "advanced": {},
       "class": "",
-      "id": "power-towers",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_point\n  WHERE power = 'tower'\n) AS power_towers",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "placenames-small",
+      "name": "placenames-small",
+      "properties": {
+        "minzoom": 12
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    name,\n    railway,\n    aerialway,\n    CASE railway \n      WHEN 'station' THEN 1 \n      WHEN 'subway_entrance' THEN 3\n      ELSE 2\n    END\n      AS prio\n  FROM planet_osm_point\n  WHERE railway IN ('station', 'halt', 'tram_stop', 'subway_entrance')\n    OR aerialway = 'station'\n  ORDER BY prio\n) AS stations",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "stations",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "point",
+      "id": "stations",
+      "name": "stations",
+      "properties": {
+        "minzoom": 12
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    name,\n    railway,\n    aerialway\nFROM planet_osm_polygon\nWHERE railway IN ('station', 'halt', 'tram_stop')\n  OR aerialway = 'station'\n) AS stations_poly",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "stations",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "polygon",
+      "id": "stations-poly",
+      "name": "stations-poly",
+      "properties": {
+        "minzoom": 12
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    COALESCE(\n      'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', \n                                          'hostel', 'hotel', 'motel', 'information', 'museum', 'picnic_site') THEN tourism ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                                          'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre', 'fire_station', 'fountain',\n                                          'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', 'townhall', 'parking', \n                                          'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', 'dentist', 'place_of_worship', \n                                          'police', 'post_box', 'post_office', 'pub', 'biergarten', 'recycling', 'restaurant', 'food_court', \n                                          'fast_food', 'telephone', 'emergency_phone', 'taxi', 'theatre', 'toilets', 'drinking_water', \n                                          'prison', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                          'charging_station') THEN amenity ELSE NULL END,\n      'shop_' || CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', \n                                    'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', \n                                    'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', \n                                    'photo', 'photo_studio', 'photography', 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', \n                                    'mobile_phone', 'motorcycle', 'musical_instrument', 'newsagent', 'optician', 'jewelry', 'jewellery', \n                                    'electronics', 'chemist', 'toys', 'travel_agency', 'car_parts', 'greengrocer', 'farm', 'stationery', \n                                    'laundry', 'dry_cleaning', 'beverages', 'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', \n                                    'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                      WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n      'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table') THEN leisure ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('spring') THEN \"natural\" ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n      'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,\n      'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END\n    ) AS feature,\n    access,\n    religion,\n    denomination,\n    \"generator:source\",\n    power_source,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n  WHERE aeroway IN ('helipad', 'aerodrome')\n    OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                   'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site')\n    OR amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                   'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre',\n                   'fire_station', 'fountain', 'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', \n                   'townhall', 'parking', 'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', \n                   'dentist', 'place_of_worship', 'police', 'post_box', 'post_office', 'pub', 'biergarten', \n                   'recycling', 'restaurant', 'food_court', 'fast_food', 'telephone', 'emergency_phone', 'taxi', \n                   'theatre', 'toilets', 'drinking_water', 'prison', 'hunting_stand', 'nightclub', 'veterinary',\n                   'social_facility', 'charging_station')\n    OR shop IS NOT NULL -- skip checking a huge list and use a null check\n    OR leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table')\n    OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk')\n    OR \"natural\" IN ('spring')\n    OR historic IN ('memorial', 'monument', 'archaeological_site')\n    OR highway IN ('bus_stop', 'elevator', 'traffic_signals')\n    OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n  ORDER BY way_area desc\n) AS amenity_points_poly",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "points",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "polygon",
+      "id": "amenity-points-poly",
+      "name": "amenity-points-poly",
+      "properties": {
+        "minzoom": 10
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    COALESCE(\n      'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                                          'hotel', 'motel', 'information', 'museum', 'picnic_site') THEN tourism ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                                          'car_rental', 'car_wash', 'cinema', 'clinic', 'community_centre', 'fire_station', 'fountain',\n                                          'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', 'townhall', 'parking', \n                                          'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', 'dentist', 'place_of_worship', \n                                          'police', 'post_box', 'post_office', 'pub', 'biergarten', 'recycling', 'restaurant', 'food_court', \n                                          'fast_food', 'telephone', 'emergency_phone', 'taxi', 'theatre', 'toilets', 'drinking_water', \n                                          'prison', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                          'charging_station') THEN amenity ELSE NULL END,\n      'shop_' || CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 'confectionery', \n                                    'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 'garden_centre', \n                                    'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 'photo', 'photo_studio', \n                                    'photography', 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', \n                                    'musical_instrument', 'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', \n                                    'travel_agency', 'car_parts', 'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', \n                                    'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                      WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n      'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',\n                                          'dog_park') THEN leisure ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN \"natural\" ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n      'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford') THEN highway ELSE NULL END,\n      'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END\n    ) AS feature,\n    access,\n    CASE\n      WHEN \"natural\" IN ('peak', 'volcano', 'saddle') THEN\n        CASE\n          WHEN ele ~ '^-?\\d{1,4}(\\.\\d+)?$' THEN ele::NUMERIC\n          ELSE NULL\n        END\n      ELSE NULL\n    END AS score,\n    religion,\n    denomination,\n    \"generator:source\",\n    power_source,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n  WHERE aeroway IN ('helipad', 'aerodrome')\n    OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'guest_house', 'hostel', \n                   'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site')\n    OR amenity IN ('shelter', 'atm', 'bank', 'bar', 'bicycle_rental', 'bus_station', 'cafe', \n                   'car_rental',  'car_wash', 'cinema', 'clinic', 'community_centre',\n                   'fire_station', 'fountain', 'fuel', 'hospital', 'ice_cream', 'embassy', 'library', 'courthouse', \n                   'townhall', 'parking', 'bicycle_parking', 'motorcycle_parking', 'pharmacy', 'doctors', \n                   'dentist', 'place_of_worship', 'police', 'post_box', 'post_office', 'pub', 'biergarten', \n                   'recycling', 'restaurant', 'food_court', 'fast_food', 'telephone', 'emergency_phone', \n                   'taxi', 'theatre', 'toilets', 'drinking_water', 'prison', 'hunting_stand', 'nightclub', \n                   'veterinary', 'social_facility', 'charging_station')\n    OR shop IS NOT NULL -- skip checking a huge list and use a null check\n    OR leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',\n                   'dog_park')\n    OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')\n    OR \"natural\" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')\n    OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')\n    OR highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford')\n    OR (power = 'generator' AND (\"generator:source\" = 'wind' OR power_source = 'wind'))\n  ORDER BY score DESC NULLS LAST\n  ) AS amenity_points",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "points",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "point",
+      "id": "amenity-points",
+      "name": "amenity-points",
+      "properties": {
+        "minzoom": 10
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way\n  FROM planet_osm_point\n  WHERE power = 'tower'\n) AS power_towers",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "point",
+      "id": "power-towers",
+      "name": "power-towers",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "power-poles",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "power-poles",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way\n  FROM planet_osm_point\n  WHERE power = 'pole'\n) AS power_poles",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way\n  FROM planet_osm_point\n  WHERE power = 'pole'\n) AS power_poles",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "power-poles",
+      "name": "power-poles",
       "properties": {
         "minzoom": 16
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-text-ref-low-zoom",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "roads-text-ref-low-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    highway,\n    height,\n    width,\n    refs\n  FROM (\n    SELECT\n        way, highway,\n        array_length(refs,1) AS height,\n        (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,\n        array_to_string(refs, E'\\n') AS refs\n      FROM (\n        SELECT\n            way,\n            highway,\n            string_to_array(ref, ';') AS refs\n        FROM planet_osm_roads\n          WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary')\n          AND ref IS NOT NULL\n      ) AS p) AS q\n  WHERE height <= 4 AND width <= 11) AS roads_text_ref_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    highway,\n    height,\n    width,\n    refs\n  FROM (\n    SELECT\n        way, highway,\n        array_length(refs,1) AS height,\n        (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,\n        array_to_string(refs, E'\\n') AS refs\n      FROM (\n        SELECT\n            way,\n            highway,\n            string_to_array(ref, ';') AS refs\n        FROM planet_osm_roads\n          WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary')\n          AND ref IS NOT NULL\n      ) AS p) AS q\n  WHERE height <= 4 AND width <= 11) AS roads_text_ref_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "roads-text-ref-low-zoom",
+      "name": "roads-text-ref-low-zoom",
       "properties": {
         "maxzoom": 12,
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "junctions",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "junctions",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    highway,\n    junction,\n    ref,\n    name\n  FROM planet_osm_point\n  WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'\n) AS junctions",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "junctions",
+      "name": "junctions",
       "properties": {
         "minzoom": 11
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "bridge-text",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "bridge-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    man_made,\n    name\n  FROM planet_osm_polygon\n  WHERE man_made = 'bridge'\n) AS bridge_text",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "bridge-text",
+      "name": "bridge-text",
       "properties": {
         "minzoom": 11
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-text-ref",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "roads-text-ref",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    highway,\n    height,\n    width,\n    refs\n  FROM (\n    SELECT\n        way, highway,\n        array_length(refs,1) AS height,\n        (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,\n        array_to_string(refs, E'\\n') AS refs\n      FROM (\n        SELECT\n            way,\n            COALESCE(\n              CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential') THEN highway ELSE NULL END,\n              CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END\n            ) AS highway,\n            string_to_array(ref, ';') AS refs\n          FROM planet_osm_line\n            WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential') OR aeroway IN ('runway', 'taxiway'))\n              AND ref IS NOT NULL\n      ) AS p) AS q\n  WHERE height <= 4 AND width <= 11) AS roads_text_ref",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "roads-text-ref",
+      "name": "roads-text-ref",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-area-text-name",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "roads-area-text-name",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    highway,\n    name\n  FROM planet_osm_polygon\n  WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')\n    OR railway IN ('platform')\n    AND name IS NOT NULL\n) AS roads_area_text_name",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "roads-area-text-name",
+      "name": "roads-area-text-name",
       "properties": {
         "minzoom": 15
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "roads-text-name",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "directions",
-      "id": "roads-text-name",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,\n    CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,\n    CASE WHEN construction IN ('service', 'footway', 'cycleway', 'bridleway', 'path', 'track') THEN 'yes' ELSE 'no' END AS int_construction_minor,\n    name,\n    CASE\n      WHEN oneway IN ('yes', '-1') THEN oneway\n      WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'\n      ELSE NULL\n    END AS oneway,\n    horse, bicycle\n  FROM planet_osm_line\n  WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', \n                    'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction')\n    AND (name IS NOT NULL\n      OR oneway IN ('yes', '-1')\n      OR junction IN ('roundabout'))\n) AS roads_text_name",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,\n    CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,\n    CASE WHEN construction IN ('service', 'footway', 'cycleway', 'bridleway', 'path', 'track') THEN 'yes' ELSE 'no' END AS int_construction_minor,\n    name,\n    CASE\n      WHEN oneway IN ('yes', '-1') THEN oneway\n      WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'\n      ELSE NULL\n    END AS oneway,\n    horse, bicycle\n  FROM planet_osm_line\n  WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', \n                    'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction')\n    AND (name IS NOT NULL\n      OR oneway IN ('yes', '-1')\n      OR junction IN ('roundabout'))\n) AS roads_text_name",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "directions",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "roads-text-name",
+      "name": "roads-text-name",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "paths-text-name",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "paths-text-name",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    highway,\n    name\n  FROM planet_osm_line\n  WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')\n    AND name IS NOT NULL\n) AS paths_text_name",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    highway,\n    name\n  FROM planet_osm_line\n  WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')\n    AND name IS NOT NULL\n) AS paths_text_name",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "paths-text-name",
+      "name": "paths-text-name",
       "properties": {
         "minzoom": 15
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "text-poly-low-zoom",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "text-low-zoom",
-      "id": "text-poly-low-zoom",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    COALESCE(\n      'landuse_' || CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN \"natural\" ELSE NULL END,\n      'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,\n      'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,\n      'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END\n    ) AS feature,\n    name,\n    CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions\n  FROM planet_osm_polygon\n  WHERE (landuse IN ('forest', 'military')\n      OR \"natural\" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')\n      OR \"place\" IN ('island')\n      OR boundary IN ('national_park')\n      OR leisure IN ('nature_reserve'))\n    AND building IS NULL\n    AND name IS NOT NULL\n  ORDER BY way_area DESC\n) AS text_poly_low_zoom",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    COALESCE(\n      'landuse_' || CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN \"natural\" ELSE NULL END,\n      'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,\n      'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,\n      'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END\n    ) AS feature,\n    name,\n    CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions\n  FROM planet_osm_polygon\n  WHERE (landuse IN ('forest', 'military')\n      OR \"natural\" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')\n      OR \"place\" IN ('island')\n      OR boundary IN ('national_park')\n      OR leisure IN ('nature_reserve'))\n    AND building IS NULL\n    AND name IS NOT NULL\n  ORDER BY way_area DESC\n) AS text_poly_low_zoom",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "text-low-zoom",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "text-poly-low-zoom",
+      "name": "text-poly-low-zoom",
       "properties": {
         "maxzoom": 9,
         "minzoom": 7
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "text-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "text",
-      "id": "text-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    COALESCE(\n      'aeroway_' || CASE WHEN aeroway IN ('gate', 'apron', 'helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', \n                                          'theme_park', 'museum', 'zoo', 'information', 'picnic_site') THEN tourism ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('pub', 'restaurant', 'food_court', 'cafe', 'fast_food', 'biergarten', 'bar', 'library', \n                                          'theatre', 'courthouse', 'townhall', 'cinema', 'clinic', 'community_centre', 'parking', \n                                          'bicycle_parking', 'motorcycle_parking', 'police', 'fire_station', 'fountain', 'place_of_worship', \n                                          'grave_yard', 'shelter', 'bank', 'embassy', 'fuel', 'bus_station', 'prison', 'university', \n                                          'school', 'college', 'kindergarten', 'hospital', 'ice_cream', 'pharmacy', 'doctors', 'dentist', \n                                          'atm', 'bicycle_rental', 'car_rental', 'car_wash', 'post_box', 'post_office',\n                                          'recycling', 'telephone', 'emergency_phone', 'toilets', 'taxi', 'drinking_water', 'hunting_stand', \n                                          'nightclub', 'veterinary', 'social_facility', 'charging_station') THEN amenity ELSE NULL END,\n      'shop_' || CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 'confectionery', \n                                    'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 'garden_centre', \n                                    'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 'photo', 'photo_studio', \n                                    'photography', 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', \n                                    'musical_instrument', 'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', \n                                    'travel_agency', 'car_parts', 'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', \n                                    'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                      WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n      'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'sports_centre', 'stadium', 'track', \n                                          'pitch', 'playground', 'park', 'recreation_ground', 'common', 'garden', 'nature_reserve', 'marina', \n                                          'picnic_table', 'dog_park') THEN leisure ELSE NULL END,\n      'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power ELSE NULL END,\n      'landuse_' || CASE WHEN landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery', \n                                          'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farm', 'farmland', \n                                          'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill', \n                                          'construction', 'military') THEN landuse ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk') THEN man_made ELSE NULL END,\n      'natural_' || CASE WHEN \"natural\" IN ('wood', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath', \n                                            'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier') THEN \"natural\" ELSE NULL END,\n      'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,\n      'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n      'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford') THEN highway ELSE NULL END,\n      'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,\n      'waterway_' || CASE WHEN waterway IN ('dam') THEN waterway ELSE NULL END,\n      'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END\n    ) AS feature,\n    access,\n    name,\n    operator,\n    ref,\n    way_area,\n    CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n  FROM planet_osm_polygon\n  -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n  WHERE (aeroway IN ('gate', 'apron', 'helipad', 'aerodrome')\n      OR tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', 'theme_park', \n                     'museum', 'viewpoint', 'attraction', 'zoo', 'information', 'picnic_site')\n      OR amenity IS NOT NULL -- skip checking a huge list and use a null check\n      OR shop IS NOT NULL\n      OR leisure IS NOT NULL\n      OR landuse IS NOT NULL\n      OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk')\n      OR \"natural\" IS NOT NULL\n      OR place IN ('island', 'islet')\n      OR military IN ('danger_area')\n      OR historic IN ('memorial', 'monument', 'archaeological_site')\n      OR highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford')\n      OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')\n      OR boundary IN ('national_park')\n      OR waterway = 'dam')\n    AND (name IS NOT NULL\n         OR (ref IS NOT NULL AND aeroway IN ('gate'))\n        )\n  ORDER BY way_area DESC\n) AS text_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
-      },
-      "advanced": {}
-    },
-    {
-      "name": "text-line",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "text-line",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n  way,\n    NULL as way_pixels,\n    COALESCE('man_made_' || man_made, 'waterway_' || waterway, 'natural_' || \"natural\") AS feature,\n    access,\n    name,\n    operator,\n    ref,\n    NULL AS way_area,\n    CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n  FROM planet_osm_line\n  WHERE (man_made IN ('pier', 'breakwater', 'groyne', 'embankment')\n      OR waterway IN ('dam', 'weir')\n      OR \"natural\" IN ('cliff'))\n    AND name IS NOT NULL\n) AS text_line",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 10
-      },
-      "advanced": {}
-    },
-    {
-      "name": "text-point",
-      "srs-name": "900913",
-      "geometry": "point",
+      "advanced": {},
       "class": "text",
-      "id": "text-point",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_pixels,\n    feature,\n    access,\n    CONCAT(\n        name,\n        CASE WHEN name IS NOT NULL AND elevation IS NOT NULL THEN E'\\n' ELSE NULL END,\n        CASE WHEN elevation IS NOT NULL THEN CONCAT(REPLACE(ROUND(elevation)::TEXT, '-', U&'\\2212'), U&'\\00A0', 'm') ELSE NULL END\n    ) AS name,\n    CASE\n      WHEN \"natural\" IN ('peak', 'volcano', 'saddle') THEN elevation\n      ELSE NULL\n    END AS score,\n    operator,\n    ref,\n    way_area,\n    is_building\n  FROM\n    (SELECT\n        way,\n        NULL AS way_pixels,\n        COALESCE(\n          'aeroway_' || CASE WHEN aeroway IN ('gate', 'apron', 'helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n          'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', \n                                              'theme_park', 'museum', 'zoo', 'information', 'picnic_site') THEN tourism ELSE NULL END,\n          'amenity_' || CASE WHEN amenity IN ('pub', 'restaurant', 'food_court', 'cafe', 'fast_food', 'biergarten', 'bar', 'library', 'theatre', \n                                              'courthouse', 'townhall', 'cinema', 'clinic', 'community_centre', 'parking', 'bicycle_parking', \n                                              'motorcycle_parking', 'police', 'fire_station', 'fountain', 'place_of_worship', 'grave_yard', 'shelter', 'bank', \n                                              'embassy', 'fuel', 'bus_station', 'prison', 'university', 'school', 'college', 'kindergarten', 'hospital', \n                                              'ice_cream', 'pharmacy', 'doctors', 'dentist', 'atm', 'bicycle_rental', 'car_rental',\n                                              'car_wash', 'post_box', 'post_office', 'recycling', 'telephone', 'emergency_phone', 'toilets', 'taxi', \n                                              'drinking_water', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                              'charging_station') THEN amenity ELSE NULL END,\n          'shop_' || CASE WHEN shop IN ('supermarket', 'bag','bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 'confectionery', 'fashion', \n                                        'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 'garden_centre', 'hairdresser', \n                                        'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 'photo', 'photo_studio', 'photography', \n                                        'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', 'musical_instrument', \n                                        'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', 'travel_agency', 'car_parts', \n                                        'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', 'perfumery', 'cosmetics', \n                                        'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                          WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n          'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'sports_centre', 'stadium', 'track',  \n                                              'pitch','playground', 'park', 'recreation_ground', 'common', 'garden', 'nature_reserve', 'marina',  \n                                              'slipway', 'picnic_table', 'dog_park') THEN leisure ELSE NULL END,\n          'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power ELSE NULL END,\n          'landuse_' || CASE WHEN landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery', \n                                              'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farm', 'farmland', \n                                              'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill', \n                                              'construction', 'military') THEN landuse ELSE NULL END,\n          'man_made_' || CASE WHEN man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'obelisk') THEN man_made ELSE NULL END,\n          'natural_' || CASE WHEN \"natural\" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', \n                                                'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree') \n                                                THEN \"natural\" ELSE NULL END,\n          'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,\n          'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,\n          'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n          'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford') THEN highway ELSE NULL END,\n          'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,\n          'waterway_' || CASE WHEN waterway IN ('dam', 'weir') THEN waterway ELSE NULL END,\n          'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,\n          'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n          'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END\n        ) AS feature,\n        access,\n        name,\n        CASE\n          WHEN \"natural\" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter' THEN\n            CASE\n              WHEN ele ~ '^-?\\d{1,4}(\\.\\d+)?$' THEN ele::NUMERIC\n              ELSE NULL\n            END\n          ELSE NULL\n        END AS elevation,\n        \"natural\",\n        operator,\n        ref,\n        NULL AS way_area,\n        CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n      FROM planet_osm_point\n      -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n      WHERE (aeroway IN ('gate', 'apron', 'helipad', 'aerodrome')\n          OR tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', 'theme_park', \n                         'museum', 'viewpoint', 'attraction', 'zoo', 'information', 'picnic_site')\n          OR amenity IS NOT NULL -- skip checking a huge list and use a null check\n          OR shop IS NOT NULL\n          OR leisure IS NOT NULL\n          OR landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery', 'residential', \n                         'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farm', 'farmland', 'greenhouse_horticulture', \n                         'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill', 'construction', 'military')\n          OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'cross', 'obelisk')\n          OR \"natural\" IS NOT NULL\n          OR place IN ('island', 'islet')\n          OR military IN ('danger_area')\n          OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')\n          OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator', 'ford')\n          OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')\n          OR boundary IN ('national_park')\n          OR waterway IN ('dam', 'weir'))\n        AND (name IS NOT NULL\n             OR (ele IS NOT NULL AND (\"natural\" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter'))\n             OR (ref IS NOT NULL AND aeroway IN ('gate'))\n            )\n      ) AS p\n  ORDER BY score DESC NULLS LAST\n  ) AS text",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "polygon",
+      "id": "text-poly",
+      "name": "text-poly",
       "properties": {
         "minzoom": 10
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "building-text",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "",
-      "id": "building-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    name,\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building NOT IN ('no')\n    AND name IS NOT NULL\n  ORDER BY way_area DESC\n) AS building_text",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n  way,\n    NULL as way_pixels,\n    COALESCE('man_made_' || man_made, 'waterway_' || waterway, 'natural_' || \"natural\") AS feature,\n    access,\n    name,\n    operator,\n    ref,\n    NULL AS way_area,\n    CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n  FROM planet_osm_line\n  WHERE (man_made IN ('pier', 'breakwater', 'groyne', 'embankment')\n      OR waterway IN ('dam', 'weir')\n      OR \"natural\" IN ('cliff'))\n    AND name IS NOT NULL\n) AS text_line",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "text-line",
+      "name": "text-line",
+      "properties": {
+        "minzoom": 10
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    way_pixels,\n    feature,\n    access,\n    CONCAT(\n        name,\n        CASE WHEN name IS NOT NULL AND elevation IS NOT NULL THEN E'\\n' ELSE NULL END,\n        CASE WHEN elevation IS NOT NULL THEN CONCAT(REPLACE(ROUND(elevation)::TEXT, '-', U&'\\2212'), U&'\\00A0', 'm') ELSE NULL END\n    ) AS name,\n    CASE\n      WHEN \"natural\" IN ('peak', 'volcano', 'saddle') THEN elevation\n      ELSE NULL\n    END AS score,\n    operator,\n    ref,\n    way_area,\n    is_building\n  FROM\n    (SELECT\n        way,\n        NULL AS way_pixels,\n        COALESCE(\n          'aeroway_' || CASE WHEN aeroway IN ('gate', 'apron', 'helipad', 'aerodrome') THEN aeroway ELSE NULL END,\n          'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', \n                                              'theme_park', 'museum', 'zoo', 'information', 'picnic_site') THEN tourism ELSE NULL END,\n          'amenity_' || CASE WHEN amenity IN ('pub', 'restaurant', 'food_court', 'cafe', 'fast_food', 'biergarten', 'bar', 'library', 'theatre', \n                                              'courthouse', 'townhall', 'cinema', 'clinic', 'community_centre', 'parking', 'bicycle_parking', \n                                              'motorcycle_parking', 'police', 'fire_station', 'fountain', 'place_of_worship', 'grave_yard', 'shelter', 'bank', \n                                              'embassy', 'fuel', 'bus_station', 'prison', 'university', 'school', 'college', 'kindergarten', 'hospital', \n                                              'ice_cream', 'pharmacy', 'doctors', 'dentist', 'atm', 'bicycle_rental', 'car_rental',\n                                              'car_wash', 'post_box', 'post_office', 'recycling', 'telephone', 'emergency_phone', 'toilets', 'taxi', \n                                              'drinking_water', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',\n                                              'charging_station') THEN amenity ELSE NULL END,\n          'shop_' || CASE WHEN shop IN ('supermarket', 'bag','bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 'confectionery', 'fashion', \n                                        'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 'garden_centre', 'hairdresser', \n                                        'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 'photo', 'photo_studio', 'photography', \n                                        'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', 'musical_instrument', \n                                        'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', 'travel_agency', 'car_parts', \n                                        'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', 'perfumery', 'cosmetics', \n                                        'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea') THEN shop \n                          WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,\n          'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'sports_centre', 'stadium', 'track',  \n                                              'pitch','playground', 'park', 'recreation_ground', 'common', 'garden', 'nature_reserve', 'marina',  \n                                              'slipway', 'picnic_table', 'dog_park') THEN leisure ELSE NULL END,\n          'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power ELSE NULL END,\n          'landuse_' || CASE WHEN landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery', \n                                              'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farm', 'farmland', \n                                              'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill', \n                                              'construction', 'military') THEN landuse ELSE NULL END,\n          'man_made_' || CASE WHEN man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'obelisk') THEN man_made ELSE NULL END,\n          'natural_' || CASE WHEN \"natural\" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', \n                                                'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree') \n                                                THEN \"natural\" ELSE NULL END,\n          'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,\n          'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,\n          'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,\n          'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford') THEN highway ELSE NULL END,\n          'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,\n          'waterway_' || CASE WHEN waterway IN ('dam', 'weir') THEN waterway ELSE NULL END,\n          'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,\n          'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n          'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END\n        ) AS feature,\n        access,\n        name,\n        CASE\n          WHEN \"natural\" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter' THEN\n            CASE\n              WHEN ele ~ '^-?\\d{1,4}(\\.\\d+)?$' THEN ele::NUMERIC\n              ELSE NULL\n            END\n          ELSE NULL\n        END AS elevation,\n        \"natural\",\n        operator,\n        ref,\n        NULL AS way_area,\n        CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building\n      FROM planet_osm_point\n      -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering\n      WHERE (aeroway IN ('gate', 'apron', 'helipad', 'aerodrome')\n          OR tourism IN ('artwork', 'alpine_hut', 'hotel', 'motel', 'hostel', 'chalet', 'guest_house', 'camp_site', 'caravan_site', 'theme_park', \n                         'museum', 'viewpoint', 'attraction', 'zoo', 'information', 'picnic_site')\n          OR amenity IS NOT NULL -- skip checking a huge list and use a null check\n          OR shop IS NOT NULL\n          OR leisure IS NOT NULL\n          OR landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery', 'residential', \n                         'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farm', 'farmland', 'greenhouse_horticulture', \n                         'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill', 'construction', 'military')\n          OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'cross', 'obelisk')\n          OR \"natural\" IS NOT NULL\n          OR place IN ('island', 'islet')\n          OR military IN ('danger_area')\n          OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')\n          OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator', 'ford')\n          OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')\n          OR boundary IN ('national_park')\n          OR waterway IN ('dam', 'weir'))\n        AND (name IS NOT NULL\n             OR (ele IS NOT NULL AND (\"natural\" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter'))\n             OR (ref IS NOT NULL AND aeroway IN ('gate'))\n            )\n      ) AS p\n  ORDER BY score DESC NULLS LAST\n  ) AS text",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "text",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "point",
+      "id": "text-point",
+      "name": "text-point",
+      "properties": {
+        "minzoom": 10
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    name,\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE building IS NOT NULL\n    AND building NOT IN ('no')\n    AND name IS NOT NULL\n  ORDER BY way_area DESC\n) AS building_text",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "polygon",
+      "id": "building-text",
+      "name": "building-text",
       "properties": {
         "minzoom": 14
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "interpolation",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "interpolation",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way\n  FROM planet_osm_line\n  WHERE \"addr:interpolation\" IS NOT NULL\n) AS interpolation",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "interpolation",
+      "name": "interpolation",
       "properties": {
         "minzoom": 17
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "addresses",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "",
-      "id": "addresses",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    \"addr:housename\" AS addr_housename,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE ((\"addr:housenumber\" IS NOT NULL) OR (\"addr:housename\" IS NOT NULL))\n    AND building IS NOT NULL\nUNION ALL\nSELECT\n    way,\n    \"addr:housenumber\" AS addr_housenumber,\n    \"addr:housename\" AS addr_housename,\n    NULL AS way_pixels\n  FROM planet_osm_point\n  WHERE (\"addr:housenumber\" IS NOT NULL) OR (\"addr:housename\" IS NOT NULL)\n  ORDER BY way_pixels DESC NULLS LAST\n) AS addresses",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "point",
+      "id": "addresses",
+      "name": "addresses",
       "properties": {
         "minzoom": 17
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "water-lines-text",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "water-lines-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    waterway,\n    lock,\n    name,\n    intermittent,\n    CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel\n  FROM planet_osm_line\n  WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')\n    AND (tunnel IS NULL or tunnel != 'culvert')\n    AND name IS NOT NULL\n  ORDER BY z_order\n) AS water_lines_text",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "water-lines-text",
+      "name": "water-lines-text",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "ferry-routes-text",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "ferry-routes-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
         "table": "(SELECT\n    way,\n    name\n  FROM planet_osm_line\n  WHERE route = 'ferry'\n    AND name IS NOT NULL\n) AS ferry_routes_text",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "ferry-routes-text",
+      "name": "ferry-routes-text",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "admin-text",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "admin-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    name,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')\n    AND name IS NOT NULL\n  ORDER BY admin_level::integer ASC, way_area DESC\n) AS admin_text",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "admin-text",
+      "name": "admin-text",
       "properties": {
         "minzoom": 16
       },
-      "advanced": {}
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     },
     {
-      "name": "nature-reserve-text",
-      "srs-name": "900913",
-      "geometry": "linestring",
-      "class": "",
-      "id": "nature-reserve-text",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
+        "dbname": "gis",
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    name,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND name IS NOT NULL\n) AS nature_reserve_text",
         "geometry_field": "way",
-        "type": "postgis",
         "key_field": "",
-        "dbname": "gis"
+        "table": "(SELECT\n    way,\n    name,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels\n  FROM planet_osm_polygon\n  WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')\n    AND name IS NOT NULL\n) AS nature_reserve_text",
+        "type": "postgis"
       },
+      "advanced": {},
+      "class": "",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
+      "geometry": "linestring",
+      "id": "nature-reserve-text",
+      "name": "nature-reserve-text",
       "properties": {
         "minzoom": 13
       },
-      "advanced": {}
-    },
-    {
-      "name": "amenity-low-priority",
-      "srs-name": "900913",
-      "geometry": "point",
-      "class": "amenity-low-priority",
-      "id": "amenity-low-priority",
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      'highway_' || CASE WHEN highway IN ('mini_roundabout') THEN highway ELSE NULL END,\n      'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') THEN railway ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket') THEN amenity ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n      'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END\n    )  AS feature,\n    access,\n    CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio\n  FROM planet_osm_point p\n  WHERE highway IN ('mini_roundabout')\n     OR railway IN ('level_crossing', 'crossing')\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')\n     OR historic IN ('wayside_cross')\n     OR man_made IN ('cross')\n     OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n  ORDER BY prio\n  ) AS amenity_low_priority",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 14
-      },
-      "advanced": {}
-    },
-    {
-      "name": "amenity-low-priority-poly",
-      "srs-name": "900913",
-      "geometry": "polygon",
-      "class": "amenity-low-priority",
-      "id": "amenity-low-priority-poly",
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "Datasource": {
-        "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    COALESCE(\n      'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,\n      'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END\n    )  AS feature,\n    access\n  FROM planet_osm_polygon p\n  WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n     OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n  ) AS amenity_low_priority_poly",
-        "geometry_field": "way",
-        "type": "postgis",
-        "key_field": "",
-        "dbname": "gis"
-      },
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
-      "properties": {
-        "minzoom": 14
-      },
-      "advanced": {}
-    }
-  ],
-  "scale": 1,
-  "center": [
-    0,
-    0,
-    4
-  ],
-  "format": "png",
-  "_parts": {
-    "extents": {
-      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
-      "extent": [
-        -180,
-        -85.05112877980659,
-        180,
-        85.05112877980659
-      ],
       "srs-name": "900913"
     },
-    "osm2pgsql": {
-      "geometry_field": "way",
-      "type": "postgis",
-      "dbname": "gis",
-      "extent": "-20037508,-20037508,20037508,20037508",
-      "key_field": ""
-    },
-    "extents84": {
-      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    COALESCE(\n      'highway_' || CASE WHEN highway IN ('mini_roundabout') THEN highway ELSE NULL END,\n      'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') THEN railway ELSE NULL END,\n      'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket') THEN amenity ELSE NULL END,\n      'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,\n      'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,\n      'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END\n    )  AS feature,\n    access,\n    CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio\n  FROM planet_osm_point p\n  WHERE highway IN ('mini_roundabout')\n     OR railway IN ('level_crossing', 'crossing')\n     OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')\n     OR historic IN ('wayside_cross')\n     OR man_made IN ('cross')\n     OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n  ORDER BY prio\n  ) AS amenity_low_priority",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "amenity-low-priority",
       "extent": [
         -180,
         -85.05112877980659,
         180,
         85.05112877980659
       ],
-      "srs-name": "WGS84"
+      "geometry": "point",
+      "id": "amenity-low-priority",
+      "name": "amenity-low-priority",
+      "properties": {
+        "minzoom": 14
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    {
+      "Datasource": {
+        "dbname": "gis",
+        "extent": "-20037508,-20037508,20037508,20037508",
+        "geometry_field": "way",
+        "key_field": "",
+        "table": "(SELECT\n    way,\n    COALESCE(\n      'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,\n      'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END\n    )  AS feature,\n    access\n  FROM planet_osm_polygon p\n  WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')\n     OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')\n  ) AS amenity_low_priority_poly",
+        "type": "postgis"
+      },
+      "advanced": {},
+      "class": "amenity-low-priority",
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "geometry": "polygon",
+      "id": "amenity-low-priority-poly",
+      "name": "amenity-low-priority-poly",
+      "properties": {
+        "minzoom": 14
+      },
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
     }
-  },
-  "metatile": 2,
-  "bounds": [
-    -180,
-    -85.05112877980659,
-    180,
-    85.05112877980659
   ],
-  "name": "OpenStreetMap Carto",
-  "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
   "Stylesheet": [
     "style.mss",
     "shapefiles.mss",
@@ -2106,7 +2060,53 @@
     "admin.mss",
     "addressing.mss"
   ],
-  "minzoom": 0,
+  "_parts": {
+    "extents": {
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "srs-name": "900913"
+    },
+    "extents84": {
+      "extent": [
+        -180,
+        -85.05112877980659,
+        180,
+        85.05112877980659
+      ],
+      "srs": "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
+      "srs-name": "WGS84"
+    },
+    "osm2pgsql": {
+      "dbname": "gis",
+      "extent": "-20037508,-20037508,20037508,20037508",
+      "geometry_field": "way",
+      "key_field": "",
+      "type": "postgis"
+    }
+  },
+  "bounds": [
+    -180,
+    -85.05112877980659,
+    180,
+    85.05112877980659
+  ],
+  "center": [
+    0,
+    0,
+    4
+  ],
+  "description": "A general-purpose OpenStreetMap mapnik style, in CartoCSS",
+  "format": "png",
+  "interactivity": false,
   "maxzoom": 22,
-  "description": "A general-purpose OpenStreetMap mapnik style, in CartoCSS"
+  "metatile": 2,
+  "minzoom": 0,
+  "name": "OpenStreetMap Carto",
+  "scale": 1,
+  "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
 }

--- a/scripts/yaml2mml.py
+++ b/scripts/yaml2mml.py
@@ -28,7 +28,7 @@ try:
             mml_file.write(json_bytes)
             mml_file.close()
         else:
-            json.dump(yaml, sys.stdout, indent=2, separators=(',', ': '))
+            json.dump(yaml, sys.stdout, sort_keys=True, indent=2, separators=(',', ': '))
     except IOError:
         print('Could not save MML file. Aborting.')
         sys.exit(1)

--- a/scripts/yaml2mml.py
+++ b/scripts/yaml2mml.py
@@ -24,7 +24,8 @@ try:
     try:
         if not args.check:
             mml_file = open(mml_path, 'wb')
-            json.dump(yaml, mml_file, indent=2, separators=(',', ': '))
+            json_bytes = (json.dumps(yaml, sort_keys=True, indent=2, separators=(',', ': '))).encode(encoding="ascii")
+            mml_file.write(json_bytes)
             mml_file.close()
         else:
             json.dump(yaml, sys.stdout, indent=2, separators=(',', ': '))


### PR DESCRIPTION
Fixes #2447. Direct binary mode file output using json.dump() does not work with python 3. Other tricks like _newline_ parameter for _open()_ or using _io.open()_ where not successful. Best solution is to use json.dumps() and convert to bytes afterwards for python 2 & 3 compatibility.

Yields the same sha256sum for python2 and python3. The parameter _sort_keys=True_ has been introduced because python3 output had different sorting after every execution.

Not yet tested on Windows.

