### PR TITLE
Adding localconfig.js to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/
 *.xml
 node_modules/
 localconfig.json
+localconfig.js
 
 # Generated at runtime by Python.
 *.pyc


### PR DESCRIPTION
Technical follow up to https://github.com/gravitystorm/openstreetmap-carto/pull/1578.

Causes git to ignore also `localconfig.js` file (not only `localconfig.json`).