### PR TITLE
Add village and hamlet to capital SQL query.

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1535,7 +1535,7 @@ Layer:
             END as population,
             round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
           FROM planet_osm_point
-          WHERE place IN ('city', 'town')
+          WHERE place IN ('city', 'town', 'village', 'hamlet')
             AND name IS NOT NULL
             AND capital = 'yes'
           ORDER BY population DESC
@@ -1627,8 +1627,11 @@ Layer:
             place,
             name
           FROM planet_osm_point
-          WHERE place IN ('suburb', 'village', 'hamlet', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
-            AND name IS NOT NULL
+          WHERE place IN ('village', 'hamlet')
+             AND name IS NOT NULL
+             AND (capital IS NULL OR capital != 'yes')
+             OR place IN ('suburb', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
+             AND name IS NOT NULL
           ORDER BY CASE
               WHEN place = 'suburb' THEN 3
               WHEN place = 'village' THEN 4


### PR DESCRIPTION
Add village and hamlet to capital-names and exclude these capitals from placenames-small. This currently affects Vaduz and Ngerulmud [as documented in Wiki](http://wiki.openstreetmap.org/wiki/Key:capital) (see also Talk page). This respects the index for places from #2408.

I originally did a Github commit comment with tests but this comment vanished when I rebased, which is a known gotcha. Better use PR or review comments.