### PR TITLE
Render addr:unit

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -18,6 +18,12 @@
       ["addr_housename" != null] {
         text-name: [addr_housenumber] + "\n" + [addr_housename];
       }
+      ["addr_unit" != null] {
+        text-name: [addr_housenumber] + " " + [addr_unit];
+        ["addr_housename" != null] {
+          text-name: [addr_housenumber] + " " + [addr_unit] + "\n" + [addr_housename];
+        }
+      }
     }
     text-placement: interior;
     text-min-distance: 1;
@@ -26,8 +32,11 @@
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-size: 10;
-    text-wrap-width: 20; // 2.0 em
+    text-wrap-width: 30; // 3.0 em
     text-line-spacing: -1.5; // -0.15 em
+    [zoom >= 18]["addr_unit" != null]["addr_housenumber" = null] {
+      text-name: [addr_unit];
+    }
     [zoom >= 20] {
         text-size: 11;
         text-wrap-width: 22; // 2.0 em

--- a/project.mml
+++ b/project.mml
@@ -2138,18 +2138,20 @@ Layer:
             way,
             "addr:housenumber" AS addr_housenumber,
             "addr:housename" AS addr_housename,
+            tags->'addr:unit' AS addr_unit,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL))
+          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR (tags->'addr:unit' IS NOT NULL))
             AND building IS NOT NULL
         UNION ALL
         SELECT
             way,
             "addr:housenumber" AS addr_housenumber,
             "addr:housename" AS addr_housename,
+            tags->'addr:unit' AS addr_unit,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL)
+          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR (tags->'addr:unit' IS NOT NULL)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:


### PR DESCRIPTION
This branch implements rendering of addr:unit tags on ways (buildings) and nodes (entrances etc.), as discussed in issue #2488 

The image below, rendered from http://www.openstreetmap.org/#map=18/60.16315/24.87713 shows rendering of addr:unit with addr:housenumber on buildings and without addr:housenumber on entrances.

![addrunit](https://cloud.githubusercontent.com/assets/3215/20926854/3ff154f0-bbc7-11e6-81ff-f9d23d3a5ec2.png)
