### PR TITLE
Cosmetic fix for uniform layers code

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -781,8 +781,8 @@ Layer:
     properties:
       minzoom: 14
     advanced: {}
-  - name: "roads-casing"
-    id: "roads-casing"
+  - id: "roads-casing"
+    name: "roads-casing"
     class: "roads-casing"
     geometry: "linestring"
     <<: *extents
@@ -1342,8 +1342,8 @@ Layer:
     properties:
       minzoom: 13
     advanced: {}
-  - name: "admin-low-zoom"
-    id: "admin-low-zoom"
+  - id: "admin-low-zoom"
+    name: "admin-low-zoom"
     class: ""
     geometry: "linestring"
     <<: *extents


### PR DESCRIPTION
Small fix to make layers code more uniform, as discussed in https://github.com/gravitystorm/openstreetmap-carto/issues/2429.