### PR TITLE
Unification of major buildings

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -5,9 +5,6 @@
 @building-major-fill: darken(@building-fill, 20%);
 @building-major-line: darken(@building-major-fill, 25%);
 
-@building-aeroway-fill: #cc99ff;
-@building-aeroway-line: darken(@building-aeroway-fill,15%);
-
 
 #buildings {
   [zoom >= 13] {
@@ -24,15 +21,7 @@
 
 #buildings-major {
   [zoom >= 13] {
-    [aeroway = 'terminal'] {
-      polygon-fill: @building-aeroway-fill;
-      polygon-clip: false;
-      [zoom >= 15] {
-        line-width: .75;
-        line-clip: false;
-        line-color: @building-aeroway-line;
-      }
-    }
+    [aeroway = 'terminal'],
     [amenity = 'place_of_worship'],
     [building = 'train_station'] {
       polygon-fill: @building-major-fill;


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/issues/2094.

I see no reason to render airport terminals different than other major buildings:
1. It should be clear what are they from the context.
2. We use strong violet for industrial features (especially power stations, IIRC).
3. I'd like to unify the general look of all the transportation "stations".

Also sharing rule that all the buildings are rendered from z13.

Warsaw, z14:
Before
![ufjaaage](https://cloud.githubusercontent.com/assets/5439713/21315834/46087b98-c5fe-11e6-8cdd-8a416de9d583.png)

After
![h4fkvu5y](https://cloud.githubusercontent.com/assets/5439713/21315839/4b75308a-c5fe-11e6-91d8-bc9e83432135.png)