### PR TITLE
Add area rendering for amenity=doctors

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -463,6 +463,7 @@
   }
 
   [feature = 'amenity_hospital'],
+  [feature = 'amenity_doctors'],
   [feature = 'amenity_university'],
   [feature = 'amenity_college'],
   [feature = 'amenity_school'],

--- a/project.mml
+++ b/project.mml
@@ -145,7 +145,7 @@ Layer:
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 
-                                                    'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic') 
+                                                    'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'doctors') 
                                                     THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass', 
                                                     'allotments', 'forest', 'farmyard', 'farm', 'farmland', 'greenhouse_horticulture', 
@@ -168,7 +168,7 @@ Layer:
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten', 
-                             'grave_yard', 'place_of_worship', 'prison', 'clinic')
+                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'doctors')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')
               OR power IN ('station', 'sub_station', 'substation', 'generator')


### PR DESCRIPTION
[UPDATE: now only for amenity=doctors]

Both amenity=clinic and amenity=doctors can be tagged as an area and it would be good to show it the same as with hospitals:

![1pnjiy6r](https://cloud.githubusercontent.com/assets/5439713/21356547/4e06affc-c6d2-11e6-9cb9-ef16011602cd.png)

amenity=clinic area rendering is half baked, because I had not enough experience when trying to [add the icon](https://github.com/gravitystorm/openstreetmap-carto/pull/1565).