### PR TITLE
More accurate change log entry for subway entrance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Noto Naskh is now used for Arabic
 - Visual impact of campsites and quarries reduced below z13
 - Wilderness huts rendered
-- Subway entrances rendered
+- "ref" (reference) text of subway entrances rendered
 
 ## [v2.45.1](https://github.com/gravitystorm/openstreetmap-carto/compare/v2.45.0...v2.45.1) - 2016-12-03
 ### Changes


### PR DESCRIPTION
Version 3 adds rendering of the "ref" tag for subway entrances. In earlier versions, these entrances were rendered with an icon only.