### PR TITLE
Make permissive equivalent to access=yes and drop access=public

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -344,7 +344,7 @@
     marker-placement: interior;
     marker-clip: false;
     marker-fill: @transportation-icon;
-    [access != ''][access != 'public'][access != 'yes'] {
+    [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
   }
@@ -460,7 +460,7 @@
     marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
-    [access != ''][access != 'yes'] {
+    [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
   }
@@ -974,7 +974,7 @@
     marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
-    [access != ''][access != 'yes'] {
+    [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
   }
@@ -1111,7 +1111,7 @@
     marker-placement: interior;
     marker-clip: false;
     marker-fill: @transportation-icon;
-    [access != ''][access != 'public'][access != 'yes'] {
+    [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
   }
@@ -1275,7 +1275,7 @@
     text-halo-fill: @standard-halo-fill;
     text-wrap-width: @standard-wrap-width;
     text-placement: interior;
-    [access != ''][access != 'public'][access != 'yes'] {
+    [access != ''][access != 'permissive'][access != 'yes'] {
       text-fill: #66ccaf;
     }
     [feature = 'amenity_bicycle_parking'],
@@ -1444,7 +1444,7 @@
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: @standard-wrap-width;
       text-placement: interior;
-      [access != ''][access != 'yes'] {
+      [access != ''][access != 'permissive'][access != 'yes'] {
         text-fill: darken(@park, 50%);
       }
     }


### PR DESCRIPTION
IMO access=permissive is a valid tagging but should not be equivalent to private.

Example:
https://www.openstreetmap.org/way/4646264#map=18/51.91005/8.84213

Done this for all parkings, recycling, playground, dog_park

We dropped permissive rendering for roads with #682.

resolves #1634
superseeds #2512