### PR TITLE
Junction names for areas

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1821,7 +1821,17 @@ Layer:
             name
           FROM planet_osm_point
           WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
-        ) AS junctions
+          UNION ALL(
+            SELECT
+              ST_BuildArea(way) AS way,
+              highway,
+              junction,
+              ref,
+              name
+            FROM planet_osm_line
+            WHERE junction = 'yes'
+          )
+         ) AS junctions
     properties:
       minzoom: 11
   - id: bridge-text


### PR DESCRIPTION
Simplified version. Only against planet_osm_line (not the polygone table).

Will not work after lua merge, so this requieres another PR against the lua branch to make sure that this feature continues working after lua merge.

UNION ALL instead of UNION

way_pixels not used (the traditional approach will only work with lua, and for the current approach I didn’t figure out how to do this).

Differently from the example code from @pnorman I didn’t figure out how to omit the last SELECT