### PR TITLE
Add area rendering for amenity=clinic

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -463,6 +463,7 @@
   }
 
   [feature = 'amenity_hospital'],
+  [feature = 'amenity_clinic'],
   [feature = 'amenity_university'],
   [feature = 'amenity_college'],
   [feature = 'amenity_school'],


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/2449.

Split from https://github.com/gravitystorm/openstreetmap-carto/pull/2519. 

Renders clinic area the same as for the hospital (part of the code is already here since https://github.com/gravitystorm/openstreetmap-carto/pull/1565):

![ozdwh4c4](https://cloud.githubusercontent.com/assets/5439713/21592813/1cfbb792-d111-11e6-909b-05241f0718fd.png)
