### PR TITLE
Fixing rendering major buildings twice

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -424,6 +424,9 @@ Layer:
           FROM planet_osm_polygon
           WHERE building IS NOT NULL
             AND building != 'no'
+            AND (aeroway IS NULL OR aeroway != 'terminal')
+            AND (amenity IS NULL OR amenity != 'place_of_worship')
+            AND building != 'train_station'
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY z_order, way_area DESC
         ) AS buildings


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1997.

SQL fix that prevents from rendering major buildings twice (as normal building and as a major building on top of that).