### PR TITLE
Render greenhouse buildings as light brown

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -19,6 +19,14 @@
       line-width: .75;
       line-clip: false;
     }
+    [building = 'greenhouse'] {
+      polygon-fill: lighten(@building-fill, 3%);
+      [zoom >= 15] {
+        line-color: lighten(@building-line, 3%);
+        line-width: .75;
+        line-clip: false;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/738.

Near Hague, z13:
Before
![df7xf2tx](https://cloud.githubusercontent.com/assets/5439713/21740497/cd007a1c-d4bb-11e6-82d2-9f0b8643f64a.png)
After
![xkhooue4](https://cloud.githubusercontent.com/assets/5439713/21740499/d7a66698-d4bb-11e6-85e6-705dccb6a44f.png)

Warsaw, z17
Before
![ijdt0pa2](https://cloud.githubusercontent.com/assets/5439713/21740565/340555ba-d4bd-11e6-9c45-4d88e09bda04.png)
After
![b5uk5e2d](https://cloud.githubusercontent.com/assets/5439713/21740566/366d9826-d4bd-11e6-9dd5-a443a58caab4.png)