### PR TITLE
Clean up bus_stop SVG

### DIFF
--- a/symbols/bus_stop.12.svg
+++ b/symbols/bus_stop.12.svg
@@ -1,14 +1,4 @@
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.1" width="12" height="12" viewBox="0 0 12 12" id="svg2">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs7"/>
-  <rect width="12" height="12" x="0" y="0" id="canvas" style="fill:none;stroke:none;visibility:hidden"/>
-  <path d="M 2,0 1,1 1,9 1.65625,9 c 0,0 0.1011489,1 0.81275,1 C 3.1581295,10 3.25,9 3.25,9 l 3.5,0 c 0,0 0.1143421,1 0.781,1 0.8164686,0 0.81275,-1 0.81275,-1 L 9,9 9,1 8,0 z M 3,1 7,1 7,2 3,2 z M 2,3 8,3 8,6 2,6 z M 2,7 3,7 3,8 2,8 z M 7,7 8,7 8,8 7,8 z" id="bus-stop" style="fill:#000000;fill-opacity:1;stroke:none" transform="translate(1,1)"/>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12" height="12" viewBox="0 0 12 12">
+  <rect width="12" height="12" x="0" y="0" style="fill:none;stroke:none;visibility:hidden"/>
+  <path d="M 2,0 1,1 1,9 1.65625,9 c 0,0 0.1011489,1 0.81275,1 C 3.1581295,10 3.25,9 3.25,9 l 3.5,0 c 0,0 0.1143421,1 0.781,1 0.8164686,0 0.81275,-1 0.81275,-1 L 9,9 9,1 8,0 z M 3,1 7,1 7,2 3,2 z M 2,3 8,3 8,6 2,6 z M 2,7 3,7 3,8 2,8 z M 7,7 8,7 8,8 7,8 z"/>
 </svg>

--- a/symbols/bus_stop.12.svg
+++ b/symbols/bus_stop.12.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12" height="12" viewBox="0 0 12 12">
-  <rect width="12" height="12" x="0" y="0" style="fill:none;stroke:none;visibility:hidden"/>
-  <path d="M 2,0 1,1 1,9 1.65625,9 c 0,0 0.1011489,1 0.81275,1 C 3.1581295,10 3.25,9 3.25,9 l 3.5,0 c 0,0 0.1143421,1 0.781,1 0.8164686,0 0.81275,-1 0.81275,-1 L 9,9 9,1 8,0 z M 3,1 7,1 7,2 3,2 z M 2,3 8,3 8,6 2,6 z M 2,7 3,7 3,8 2,8 z M 7,7 8,7 8,8 7,8 z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" height="12" width="12" version="1.1">
+  <rect style="fill:none;stroke:none;visibility:hidden" y="0" x="0" height="12" width="12" />
+  <path d="m 3,1 -1,1 0,8 0.65625,0 c 0,0 0.1011489,1 0.81275,1 0.6891295,0 0.781,-1 0.781,-1 l 3.5,0 c 0,0 0.1143421,1 0.781,1 0.8164686,0 0.81275,-1 0.81275,-1 L 10,10 10,2 9,1 Z M 4,2 8,2 8,3 4,3 Z M 3,4 9,4 9,7 3,7 Z M 3,8 4,8 4,9 3,9 Z M 8,8 9,8 9,9 8,9 Z" />
 </svg>


### PR DESCRIPTION
Not yet ready to merge. The `<rect/>` element shouldn't be there, but without the icon changes size on the map.

I'm wondering if the rect is forcing the size and the bus part is smaller, so even though marker-width is 12px, the visible part is smaller. This strikes me as the wrong way to achieve that.

cc @nebulon42 