### PR TITLE
removing waterway=canal area rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -241,7 +241,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
           WHERE
-            (waterway IN ('dock', 'riverbank', 'canal')
+            (waterway IN ('dock', 'riverbank')
               OR landuse IN ('reservoir', 'basin')
               OR "natural" IN ('water', 'glacier'))
             AND building IS NULL

--- a/water.mss
+++ b/water.mss
@@ -25,8 +25,7 @@
     }
   }
 
-  [waterway = 'dock'],
-  [waterway = 'canal'] {
+  [waterway = 'dock'] {
     [zoom >= 9]::waterway {
       polygon-fill: @water-color;
       [way_pixels >= 4] {


### PR DESCRIPTION
fixes #2424.

Note this only removes the area rendering, correctly treating closed ways with waterway=canal as line features will depend on the database reload.  Current lua branch already has this covered:

https://github.com/gravitystorm/openstreetmap-carto/blob/lua/openstreetmap-carto.lua#L40
