### PR TITLE
better outline color for societal amenities (hospitals, schools), adding missing outline for stadium/sports_centre

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -474,7 +474,7 @@
         polygon-fill: @societal_amenities;
         [zoom >= 13] {
           line-width: 0.3;
-          line-color: brown;
+          line-color: darken(@societal_amenities, 35%);
         }
       }
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
@@ -534,6 +534,10 @@
       polygon-fill: @stadium;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
+      [zoom >= 13] {
+        line-width: 0.3;
+        line-color: darken(@stadium, 35%);
+      }
     }
   }
 


### PR DESCRIPTION
fixes #2498, #2388.

![school outline](http://www.imagico.de/files/carto-hospital_outline.png)

This is also significantly weaker than previously to make sure the outline is not so prone to be confused with barriers, like for example here:

http://www.openstreetmap.org/#map=18/47.98378/7.82667