### PR TITLE
add rendering for aerialway=mixed_lift (same as gondola)

### DIFF
--- a/aerialways.mss
+++ b/aerialways.mss
@@ -1,6 +1,7 @@
 #aerialways {
   [aerialway = 'cable_car'],
-  [aerialway = 'gondola'] {
+  [aerialway = 'gondola'],
+  [aerialway = 'mixed_lift'] {
     [zoom >= 12] {
       line/line-width: 1;
       line/line-join: round;


### PR DESCRIPTION
Fixes #347 

This is a special case so it needs some explaining. This feature request was rejected first due to low usage. In this case usage is not really significant as it is a rare feature. There is at least one of those not far from where I live. Since we render other types of aerialways already it makes also sense to render this one, especially as leaving it out can lead to the weird situation that other aerialways are seemingly not reachable as in my example below.

Also there is tagging for the renderer going on as https://www.openstreetmap.org/way/31766480 illustrates. Under this circumstances I wanted to add this. Also it is mentioned on the aerialway Wiki page and it also has its own Wiki page. Given the rare occurrence of this feature I view this tag as established.

I chose the same rendering as for gondola as this type of aerialway usually consists of gondolas and chairs and so it deserves to be rendered as the higher category.

https://www.openstreetmap.org/way/2304032
before (note how Seekareckbahn, Panoramabahn, Hochalmbahn are seemingly unreachable)
![before](https://cloud.githubusercontent.com/assets/3531092/24219828/776b84e4-0f48-11e7-9ed7-c24252f83a83.png)

after
![after](https://cloud.githubusercontent.com/assets/3531092/24219837/7d405bc4-0f48-11e7-98e2-07963eed82b5.png)