### PR TITLE
replace text-dy logic with combined name and ref rendering for motorway junctions

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2394,29 +2394,26 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #junctions {
   [highway = 'motorway_junction'] {
     [zoom >= 11] {
-      ref/text-name: "[ref]";
-      ref/text-size: 10;
-      ref/text-fill: @junction-text-color;
-      ref/text-min-distance: 2;
-      ref/text-face-name: @oblique-fonts;
-      ref/text-halo-radius: @standard-halo-radius * 1.5;
+      text-name: "[ref]";
+      text-size: 10;
+      text-fill: @junction-text-color;
+      text-min-distance: 2;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-wrap-character: ";";
+      text-wrap-width: 2; // effectively break after every wrap character
+      text-line-spacing: -1.5; // -0.15 em
       [zoom >= 12] {
-        name/text-name: "[name]";
-        name/text-size: 10;
-        name/text-fill: @junction-text-color;
-        name/text-dy: -10;
-        name/text-face-name: @oblique-fonts;
-        name/text-halo-radius: @standard-halo-radius;
-        name/text-wrap-character: ";";
-        name/text-wrap-width: 2; // effectively break after every wrap character
-        name/text-line-spacing: -1.5; // -0.15 em
-        name/text-min-distance: 2;
+        ["name" != null]["ref" = null] {
+          text-name: "[name]";
+        }
+        ["name" != null]["ref" != null] {
+          text-name: [name] + "\n" + [ref];
+        }
       }
       [zoom >= 15] {
-        ref/text-size: 11;
-        name/text-size: 11;
-        name/text-dy: -11;
-        name/text-line-spacing: -1.65; // -0.15 em
+        text-size: 11;
+        text-line-spacing: -1.65; // -0.15 em
       }
     }
   }


### PR DESCRIPTION
before
![before](https://cloud.githubusercontent.com/assets/3531092/24265916/6709f096-1005-11e7-892a-61a709c783c7.png)

after
![after](https://cloud.githubusercontent.com/assets/3531092/24265919/68e3fa2e-1005-11e7-855f-7b105deb50d3.png)

This also avoids situations where one part of the label can be placed and the other cannot due to some conflict with another object. Leads to simplified code too.