### PR TITLE
remove redundant tertiary_link from road names

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2818,8 +2818,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-size: 12;
     }
   }
-  [highway = 'tertiary'],
-  [highway = 'tertiary_link'] {
+  [highway = 'tertiary'] {
     [zoom >= 14] {
       text-name: "[name]";
       text-size: 9;


### PR DESCRIPTION
By looking at https://github.com/gravitystorm/openstreetmap-carto/blob/master/project.mml#L1954 I think that the additional `tertiary_link` filter is redundant and can be removed.