### PR TITLE
use parameters of road type for text rendering of roads under construction

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1953,7 +1953,7 @@ Layer:
             way,
             CASE WHEN substr(highway, length(highway)-3, 4) = 'link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
             CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
-            CASE WHEN construction IN ('service', 'footway', 'cycleway', 'bridleway', 'path', 'track') THEN 'yes' ELSE 'no' END AS int_construction_minor,
+            construction,
             name,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway

--- a/roads.mss
+++ b/roads.mss
@@ -2761,7 +2761,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #roads-text-name {
   [highway = 'motorway'],
   [highway = 'trunk'],
-  [highway = 'primary'] {
+  [highway = 'primary'],
+  [highway = 'construction'][construction = 'motorway'],
+  [highway = 'construction'][construction = 'trunk'],
+  [highway = 'construction'][construction = 'primary'] {
     [zoom >= 13] {
       text-name: "[name]";
       text-size: 8;
@@ -2790,7 +2793,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-size: 12;
     }
   }
-  [highway = 'secondary'] {
+  [highway = 'secondary'],
+  [highway = 'construction'][construction = 'secondary'] {
     [zoom >= 13] {
       text-name: "[name]";
       text-size: 8;
@@ -2815,7 +2819,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-size: 12;
     }
   }
-  [highway = 'tertiary'] {
+  [highway = 'tertiary'],
+  [highway = 'construction'][construction = 'tertiary'] {
     [zoom >= 14] {
       text-name: "[name]";
       text-size: 9;
@@ -2834,29 +2839,32 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-size: 12;
     }
   }
-  [highway = 'construction'] {
-    [int_construction_minor = 'no'][zoom >= 13],
-    [int_construction_minor = 'yes'][zoom >= 14] {
-      text-name: "[name]";
-      text-size: 9;
-      text-fill: black;
-      text-spacing: 300;
-      text-clip: false;
-      text-placement: line;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-face-name: @book-fonts;
-      [zoom >= 17] {
-        text-size: 11;
-      }
-      [zoom >= 19] {
-        text-size: 12;
-      }
+  [highway = 'construction'][construction = null][zoom >= 16] {
+    text-name: "[name]";
+    text-size: 9;
+    text-fill: black;
+    text-spacing: 300;
+    text-clip: false;
+    text-placement: line;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-face-name: @book-fonts;
+
+    [zoom >= 17] {
+      text-size: 11;
+      text-spacing: 400;
+    }
+    [zoom >= 19] {
+      text-size: 12;
+      text-spacing: 400;
     }
   }
   [highway = 'residential'],
   [highway = 'unclassified'],
-  [highway = 'road'] {
+  [highway = 'road'],
+  [highway = 'construction'][construction = 'residential'],
+  [highway = 'construction'][construction = 'unclassified'],
+  [highway = 'construction'][construction = 'road'] {
     [zoom >= 15] {
       text-name: "[name]";
       text-size: 8;
@@ -2882,7 +2890,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 
   [highway = 'raceway'],
-  [highway = 'service'] {
+  [highway = 'service'],
+  [highway = 'construction'][construction = 'raceway'],
+  [highway = 'construction'][construction = 'service'] {
     [zoom >= 16] {
       text-name: "[name]";
       text-size: 9;
@@ -2901,7 +2911,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 
   [highway = 'living_street'],
-  [highway = 'pedestrian'] {
+  [highway = 'pedestrian'],
+  [highway = 'construction'][construction = 'living_street'],
+  [highway = 'construction'][construction = 'pedestrian'] {
     [zoom >= 15] {
       text-name: "[name]";
       text-size: 8;


### PR DESCRIPTION
Fixes #2477

Uses zoom level, size etc. of the respective road types. Also restricts the construction values we render names for to the types where we render highways and empty values of construction.

before
z14
![before_z14](https://cloud.githubusercontent.com/assets/3531092/24272813/484449ee-101f-11e7-9257-9ef06519878a.png)

z15
![before](https://cloud.githubusercontent.com/assets/3531092/24272819/50034d42-101f-11e7-84e7-6372f1d4624c.png)

after
z14
![after_z14](https://cloud.githubusercontent.com/assets/3531092/24272825/53cee7d8-101f-11e7-81c7-0eb4ff48c553.png)

z15
![after](https://cloud.githubusercontent.com/assets/3531092/24272829/57abf08a-101f-11e7-9b27-1fda55fc5dad.png)