### PR TITLE
use land-color as background for waterway tunnels

### DIFF
--- a/water.mss
+++ b/water.mss
@@ -96,6 +96,18 @@
   [waterway = 'canal'][zoom >= 12],
   [waterway = 'river'][zoom >= 12],
   [waterway = 'wadi'][zoom >= 13] {
+    // the additional line of land color is used to provide a background for dashed casings
+    [int_tunnel = 'yes'] {
+      background/line-color: @land-color;
+      background/line-width: 2;
+      background/line-cap: round;
+      background/line-join: round;
+    }
+    water/line-color: @water-color;
+    water/line-width: 2;
+    water/line-cap: round;
+    water/line-join: round;
+
     [bridge = 'yes'] {
       [zoom >= 14] {
         bridgecasing/line-color: black;
@@ -106,6 +118,7 @@
         [zoom >= 18] { bridgecasing/line-width: 13; }
       }
     }
+
     [intermittent = 'yes'],
     [waterway = 'wadi'] {
       [bridge = 'yes'][zoom >= 14] {
@@ -116,30 +129,36 @@
         [zoom >= 17] { bridgefill/line-width: 9; }
         [zoom >= 18] { bridgefill/line-width: 11; }
       }
-      line-dasharray: 4,3;
-      line-cap: butt;
-      line-join: round;
-      line-clip: false;
+      water/line-dasharray: 4,3;
+      water/line-cap: butt;
+      water/line-join: round;
+      water/line-clip: false;
     }
-    line-color: @water-color;
-    line-width: 2;
-    [zoom >= 13] { line-width: 3; }
-    [zoom >= 14] { line-width: 5; }
-    [zoom >= 15] { line-width: 6; }
-    [zoom >= 17] { line-width: 10; }
-    [zoom >= 18] { line-width: 12; }
-    line-cap: round;
-    line-join: round;
+
+    [zoom >= 13] { water/line-width: 3; }
+    [zoom >= 14] { water/line-width: 5; }
+    [zoom >= 15] { water/line-width: 6; }
+    [zoom >= 17] { water/line-width: 10; }
+    [zoom >= 18] { water/line-width: 12; }
+
     [int_tunnel = 'yes'] {
-      line-dasharray: 4,2;
-      line-cap: butt;
-      line-join: miter;
-      a/line-color: #f3f7f7;
-      a/line-width: 1;
-      [zoom >= 14] { a/line-width: 2; }
-      [zoom >= 15] { a/line-width: 3; }
-      [zoom >= 17] { a/line-width: 7; }
-      [zoom >= 18] { a/line-width: 8; }
+      [zoom >= 13] { background/line-width: 3; }
+      [zoom >= 14] { background/line-width: 5; }
+      [zoom >= 15] { background/line-width: 6; }
+      [zoom >= 17] { background/line-width: 10; }
+      [zoom >= 18] { background/line-width: 12; }
+
+      water/line-dasharray: 4,2;
+      background/line-cap: butt;
+      background/line-join: miter;
+      water/line-cap: butt;
+      water/line-join: miter;
+      tunnelfill/line-color: #f3f7f7;
+      tunnelfill/line-width: 1;
+      [zoom >= 14] { tunnelfill/line-width: 2; }
+      [zoom >= 15] { tunnelfill/line-width: 3; }
+      [zoom >= 17] { tunnelfill/line-width: 7; }
+      [zoom >= 18] { tunnelfill/line-width: 8; }
     }
   }
 
@@ -147,6 +166,14 @@
   [waterway = 'ditch'],
   [waterway = 'drain'] {
     [zoom >= 13] {
+      // the additional line of land color is used to provide a background for dashed casings
+      [int_tunnel = 'yes'] {
+        background/line-width: 2;
+        background/line-color: @land-color;
+      }
+      water/line-width: 2;
+      water/line-color: @water-color;
+
       [bridge = 'yes'] {
         [zoom >= 14] {
           bridgecasing/line-color: black;
@@ -159,24 +186,35 @@
           [waterway = 'stream'][zoom >= 15] { bridgeglow/line-width: 3; }
         }
       }
+
       [intermittent = 'yes'] {
-        line-dasharray: 4,3;
-        line-cap: butt;
-        line-join: round;
-        line-clip: false;
+        water/line-dasharray: 4,3;
+        water/line-cap: butt;
+        water/line-join: round;
+        water/line-clip: false;
+        background/line-cap: butt;
+        background/line-join: round;
+        background/line-clip: false;
       }
-      line-width: 2;
-      line-color: @water-color;
+
       [waterway = 'stream'][zoom >= 15] {
-        line-width: 3;
+        water/line-width: 3;
+
+        [int_tunnel = 'yes'] {
+          background/line-width: 3;
+        }
       }
       [int_tunnel = 'yes'][zoom >= 15] {
-        line-width: 3.5;
-        [waterway = 'stream'] { line-width: 4.5; }
-        line-dasharray: 4,2;
-        a/line-width: 1;
-        [waterway = 'stream'] { a/line-width: 2; }
-        a/line-color: #f3f7f7;
+        background/line-width: 3.5;
+        water/line-width: 3.5;
+        [waterway = 'stream'] {
+          background/line-width: 4.5;
+          water/line-width: 4.5;
+        }
+        water/line-dasharray: 4,2;
+        tunnelfill/line-width: 1;
+        [waterway = 'stream'] { tunnelfill/line-width: 2; }
+        tunnelfill/line-color: #f3f7f7;
       }
     }
   }


### PR DESCRIPTION
Ref #488.

Waterway tunnel dashes might disappear depending on background. By using an additional line with land-color as base this does not happen anymore.

Original location of #488:
before
![pool_before](https://cloud.githubusercontent.com/assets/3531092/24295641/0dbcb41e-109c-11e7-8081-0ebf625ec31b.png)

after
![pool_after](https://cloud.githubusercontent.com/assets/3531092/24295643/1156b552-109c-11e7-9c81-71fed361ecb6.png)

This would also apply to intermittent waterways:
before
![before_intermittent_river](https://cloud.githubusercontent.com/assets/3531092/24295661/28296216-109c-11e7-8f42-8e04d2bd7ca8.png)

after
![after_intermittent_river](https://cloud.githubusercontent.com/assets/3531092/24295673/342fdc3e-109c-11e7-8949-2a438b590232.png)

This can have side-effects when a intermittent river is tagged with a riverbank. Depends if we view that as valid tagging combination.
before
![before_intermittent_with_riverbank](https://cloud.githubusercontent.com/assets/3531092/24295697/51a35188-109c-11e7-8f91-946a514637ac.png)

after
![after_intermittent_riverbank](https://cloud.githubusercontent.com/assets/3531092/24295702/57bc5f06-109c-11e7-87b0-6f52ea6710b1.png)

Also stream tunnels over forests look a bit strange but there is likely some fine-tuning possible:
![stream_forest_strange](https://cloud.githubusercontent.com/assets/3531092/24295714/6746dc9e-109c-11e7-8c62-1b69d7d45754.png)
