### PR TITLE
Better font fallback beyond BMP

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ The stylesheet uses Noto, an openly licensed font family from Google with suppor
 
 DejaVu Sans is used as an optional fallback font for systems without Noto Sans. If all the Noto fonts are installed, it should never be used.
 
-Hanazono is used a fallback for seldom CJK characters that are not covered by Noto.
+Hanazono is used a fallback for seldom used CJK characters that are not covered by Noto.
 
 Unifont is used as a last resort fallback, with it's excellent coverage, common presence on machines, and ugly look.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ The stylesheet uses Noto, an openly licensed font family from Google with suppor
 
 DejaVu Sans is used as an optional fallback font for systems without Noto Sans. If all the Noto fonts are installed, it should never be used.
 
+Hanazono is used a fallback for seldom CJK characters that are not covered by Noto.
+
 Unifont is used as a last resort fallback, with it's excellent coverage, common presence on machines, and ugly look.
 
 ### Installation on Ubuntu/Debian
@@ -54,7 +56,7 @@ Unifont is used as a last resort fallback, with it's excellent coverage, common 
 On Ubuntu 16.04 or Debian Testing you can download and install the required fonts except Noto Emoji Regular with
 
 ```
-sudo apt-get install fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted ttf-unifont
+sudo apt-get install fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted fonts-hanazono ttf-unifont
 ```
 
 Noto Emoji Regular can be downloaded [from the Noto Emoji repository](https://github.com/googlei18n/noto-emoji).
@@ -69,6 +71,7 @@ The fonts can be downloaded here:
 
 * [Noto homepage](http://www.google.com/get/noto/) and [Noto github repositories](http://github.com/googlei18n?utf8=%E2%9C%93&q=noto)
 * [DejaVu homepage](http://dejavu-fonts.org/)
+* [Hanazono homepage](http://fonts.jp/hanazono/)
 * [Unifont homepage](http://unifoundry.com/)
 
 After the download, you have to install the font files in the usual way of your operation system.

--- a/fonts.mss
+++ b/fonts.mss
@@ -114,6 +114,7 @@ A regular style.
 
                 "DejaVu Sans Book",
 
+                "HanaMinA Regular", "HanaMinB Regular",
                 "Unifont Medium", "unifont Medium", "Unifont Upper Medium";
 
 /*
@@ -193,6 +194,7 @@ regular text and can be used for emphasis. Fallback is a regular style.
 
                 "DejaVu Sans Bold", "DejaVu Sans Book",
 
+                "HanaMinA Regular", "HanaMinB Regular",
                 "Unifont Medium", "unifont Medium", "Unifont Upper Medium";
 
 /*
@@ -266,4 +268,5 @@ For a considerable number of labels this style will make no difference to the re
 
                 "DejaVu Sans Oblique", "DejaVu Sans Book",
 
+                "HanaMinA Regular", "HanaMinB Regular",
                 "Unifont Medium", "unifont Medium", "Unifont Upper Medium";


### PR DESCRIPTION
Our only current fallback font—Unifont—covers Unicode plane 0 completely. The coverage of plane 1 is not that good. And plane 2 is not covered at all.

Plane 2 is used for CJK characters that did not make in into the set of CJK characters in Plane 0. Plane 2 has currently 52 844 characters. Noto covers 2 238 characters of plane 2.

This PR introduced Hanazono as additional fallback font, and earlier in the list before Unifont. Hanazono covers almost all CJK characters up to CJK-ExtD. In plane 2, it covers 47 082 characters. CJK-ExtE (Unicode 8) stays uncovered. CJK-ExtF (to be released in Unicode 10 later this year) stays also uncovered. Hanazono is dual-licensed under a particular MIT-style license and the well-known SIL OFL. It is normally available as package on modern Linux distributions.

As I do not use Ubuntu, I could not actually test the package install instruction for Ubuntu.

Rendering example with some arbitrary CJK characters (ExtA–ExtE):

Before:
![before](https://cloud.githubusercontent.com/assets/6830724/25563684/c4171eaa-2d90-11e7-9868-10a41a51d1e7.png)

After:
![after](https://cloud.githubusercontent.com/assets/6830724/25563688/cf175054-2d90-11e7-8e80-fd6134199601.png)
