### PR TITLE
Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!get-shapefiles.sh
+!openstreetmap-carto.style

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 *
-!get-shapefiles.sh
 !openstreetmap-carto.style

--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# environment defaults for import
+
+OSM2PGSQL_CACHE=512
+OSM2PGSQL_NUMPROC=1
+OSM2PGSQL_DATAFILE=data.osm.pbf

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 .thumb.png
 layers/
 data/
+tmp/
 *.xml
+*.osm.pbf
 node_modules/
 localconfig.json
 localconfig.js
+.kosmtik-config.yml
 
 # Generated at runtime by Python.
 *.pyc

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,1 @@
+# Running OpenStreetMap Carto with Docker

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,1 +1,50 @@
 # Running OpenStreetMap Carto with Docker
+
+[Docker](https://docker.com) is a virtualized environment that allows you to run software without altering your system permanently.
+The software runs in so called containers that are easy to setup and tear down. It makes setting up a
+development environment for openstreetmap-carto much easier. The development environment consists of a
+PostgreSQL database to store the data and [Kosmtik](https://github.com/kosmtik/kosmtik) for previewing the style.
+
+## Prerequisites
+
+Docker is available for Linux, macOS and Windows. [Install](https://www.docker.com/get-docker) the software in order
+to be able to run Docker containers. You also need Docker Compose, which should be available once you installed
+Docker itself. Otherwise you need to [install Docker Compose manually](https://docs.docker.com/compose/install/).
+
+## Importing data
+
+openstreetmap-carto needs a database populated with rendering data to work. You first need a data file to import.
+It's probably easiest to grab an PBF of OSM data from [Mapzen](https://mapzen.com/metro-extracts/) or [geofabrik](http://download.geofabrik.de/).
+Once you have that file put it into the openstreetmap-carto directory and run `docker-compose up import` in the openstreetmap-carto directory.
+This downloads (if not present) and starts the PostgreSQL container and builds (if not present) and starts a container that runs
+[osm2pgsql](https://github.com/openstreetmap/osm2pgsql) to import the data.
+
+osm2pgsql has a few [command line options](https://manpages.debian.org/testing/osm2pgsql/osm2pgsql.1.en.html) and the import by default uses
+a RAM cache of 512 MB, 1 worker and expects the import file to be named `data.osm.pbf`. If you want to customize any of these parameters you have
+to set the environment variables `OSM2PGSQL_CACHE` (e.g. `export OSM2PGSQL_CACHE=1024` on Linux to set the cache to 1 GB)
+for the RAM cache (the value depends on the amount of RAM you have available, the more you can use
+here the faster the import may be), `OSM2PGSQL_NUMPROC` for the number of workers (this depends on the number of processors you have and whether your
+harddisk is fast enough e.g. is a SSD), or `OSM2PGSQL_DATAFILE` if your file has a different name. If you instead want
+to customize the default values you find them in the file `.env`.
+
+Depending on your machine and the size of the extract the import can take a while. When it is finished you should have the data necessary to
+render it with openstreetmap-carto.
+
+## Test Rendering
+
+After you have the necessary data available you can start Kosmtik to produce a test rendering. For that
+you run `docker-compose up kosmtik` in the openstreetmap-carto directory. This builds (if not present) and starts a container
+that installs Kosmtik. It also downloads (if not present) and starts the PostgreSQL database container if it is not already running.
+After install the script `scripts/docker-startup.sh` is invoked which downloads necessary
+shapefiles with `scripts/get-shapefiles.py` (if not present) and indexes them. It afterwards runs Kosmtik. If you
+have to customize anything you can do so in the script. The Kosmtik config file can be found in `.kosmtik-config.yml`.
+If you want to have a [local configuration](https://github.com/kosmtik/kosmtik#local-config) for our `project.mml` you
+can place a `localconfig.js` or `localconfig.json` file into the openstreetmap-carto directory.
+
+The shapefile data that is downloaded is owned by the user with UID 1000. If you have another default user id on your system consider
+changing the line `USER 1000` in the file `Dockerfile`.
+
+After startup is complete you can browse to `http://localhost:6789` to view the output of Kosmtik. By pressing Ctrl + C on the
+command line you can stop the container. The PostgreSQL database container is still running then (you can check with `docker ps`). If you
+want to stop the database container as well you can do so by running `docker-compose stop db` in the
+openstreetmap-carto directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+# Style dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    unzip curl ca-certificates \
+    fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted ttf-unifont \
+    mapnik-utils \
+    nodejs nodejs-legacy npm \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /openstreetmap-carto
+WORKDIR /openstreetmap-carto
+RUN npm install kosmtik
+
+# Get the shapefiles
+ADD get-shapefiles.sh ./
+RUN ./get-shapefiles.sh
+
+CMD nodejs ./node_modules/kosmtik/index.js serve /openstreetmap-carto/project.yaml --host 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,20 @@ FROM debian:stretch
 
 # Style dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    unzip curl ca-certificates \
+    unzip curl ca-certificates gnupg python \
     fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted ttf-unifont \
     mapnik-utils \
-    nodejs nodejs-legacy npm \
     && rm -rf /var/lib/apt/lists/*
+
+# Node.js 6.x LTS
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash \
+    && apt-get install --no-install-recommends -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g kosmtik
 
 RUN mkdir -p /openstreetmap-carto
 WORKDIR /openstreetmap-carto
-RUN npm install kosmtik
 
-# Get the shapefiles
-ADD get-shapefiles.sh ./
-RUN ./get-shapefiles.sh
-
-CMD nodejs ./node_modules/kosmtik/index.js serve /openstreetmap-carto/project.yaml --host 0.0.0.0
+USER 1000
+CMD sh scripts/docker-startup.sh

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,0 +1,11 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl ca-certificates osm2pgsql postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD openstreetmap-carto.style /
+
+CMD createdb gis && psql -d gis -c 'CREATE EXTENSION postgis;' && \
+    osm2pgsql --slim --cache 512 -d gis --style openstreetmap-carto.style \
+    $OSM_DATA

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -6,6 +6,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 ADD openstreetmap-carto.style /
 
-CMD createdb gis && psql -d gis -c 'CREATE EXTENSION postgis;' && \
-    osm2pgsql --slim --cache 512 -d gis --style openstreetmap-carto.style \
-    $OSM_DATA
+RUN mkdir -p /openstreetmap-carto
+WORKDIR /openstreetmap-carto
+
+CMD psql -c "SELECT 1 FROM pg_database WHERE datname = 'gis';" | grep -q 1 || createdb gis && \
+    psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS postgis;' && \
+    psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS hstore;' && \
+    osm2pgsql \
+    --cache $OSM2PGSQL_CACHE \
+    --number-processes $OSM2PGSQL_NUMPROC \
+    --hstore \
+    --multi-geometry \
+    --database gis \
+    --style openstreetmap-carto.style \
+    --tag-transform-script openstreetmap-carto.lua \
+    $OSM2PGSQL_DATAFILE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  kosmtik:
+    image: kosmtik:v1
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/openstreetmap-carto
+    depends_on:
+      - db
+    ports:
+      - "6789:6789"
+    environment:
+      - PGHOST=db
+      - PGUSER=postgres
+    restart: on-failure
+  db:
+    image: mdillon/postgis:9.6
+  import:
+    image: import:v1
+    build:
+      context: .
+      dockerfile: Dockerfile.import
+    depends_on:
+      - db
+    environment:
+      - OSM_DATA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     environment:
       - PGHOST=db
       - PGUSER=postgres
-    restart: on-failure
   db:
     image: mdillon/postgis:9.6
   import:
@@ -22,7 +21,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.import
+    volumes:
+      - .:/openstreetmap-carto
     depends_on:
       - db
     environment:
-      - OSM_DATA
+      - PGHOST=db
+      - PGUSER=postgres
+      - OSM2PGSQL_CACHE
+      - OSM2PGSQL_NUMPROC
+      - OSM2PGSQL_DATAFILE

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+python scripts/get-shapefiles.py
+
+mkdir -p .config
+if [ ! -e ".kosmtik-config.yml" ]; then
+  touch .kosmtik-config.yml
+  # this can be removed once https://github.com/kosmtik/kosmtik/issues/236 is resolved
+  echo "plugins:" >> .kosmtik-config.yml
+fi
+export KOSMTIK_CONFIGPATH=".kosmtik-config.yml"
+
+kosmtik serve project.mml --host 0.0.0.0

--- a/scripts/get-shapefiles.py
+++ b/scripts/get-shapefiles.py
@@ -259,7 +259,9 @@ def main():
    (indexing shapes is suggested for performance improvement).\n""")
 
     if args.option_force:
-        os.chdir(os.path.dirname(__file__))
+        path = os.path.dirname(__file__)
+        if len(path) > 0:
+            os.chdir(path)
     else:
         os.chdir(os.path.join(os.path.dirname(__file__), '..'))
         if not os.path.isfile("project.mml"):


### PR DESCRIPTION
Fixes #657.

This adds necessary files and documentation to setup a development environment for openstreetmap-carto with Docker.

Builds upon work done by @pnorman.

We still have to work out
* if we can prevent get-shapefiles.py from indexing every time it runs and if we need to improve other things with this script
* if the shapefile data is owned by the right user (currently UID 1000). What about systemes where 1000 is not the default user?
* if we should build the containers and upload them to the Docker registry to avoid that everybody has to build them on startup

Would require testing on other platforms than Linux, which I don't have.

cc @Ircama 