### PR TITLE
Adding place=square name rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1871,10 +1871,14 @@ Layer:
             way,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             highway,
+            place,
+            leisure,
             name
           FROM planet_osm_polygon
           WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
             OR railway IN ('platform')
+            OR (place IN ('square') 
+                AND (leisure IS NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
             AND name IS NOT NULL
           ORDER BY way_area DESC
         ) AS roads_area_text_name


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/2203.

Rendering the same as other `roads_area_text_name` objects.

Warsaw, z16 - two squares which are not simple footway or pedestrian areas:
Before
![6juh9 ku](https://user-images.githubusercontent.com/5439713/27849506-f34ae51c-614d-11e7-87fa-cebb376b0762.png)
After
![vge2zepp](https://user-images.githubusercontent.com/5439713/27849518-0e861a40-614e-11e7-9535-ec62c0a10622.png)
