### PR TITLE
Moving smaller airports to higher zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -890,7 +890,8 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome'][zoom >= 10][zoom < 14] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
+  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14] {
     marker-file: url('symbols/aerodrome.12.svg');
     marker-placement: interior;
     marker-clip: false;
@@ -2040,7 +2041,8 @@
     text-wrap-width: @standard-wrap-width;
   }
 
-  [feature = 'aeroway_aerodrome'][zoom >= 10][zoom < 14] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
+  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14] {
     text-name: "[name]";
     text-size: @standard-text-size;
     text-fill: darken(@airtransport, 15%);

--- a/project.mml
+++ b/project.mml
@@ -1581,6 +1581,8 @@ Layer:
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
             tags->'power_source' as power_source,
+            tags->'icao' as icao,
+            tags->'iata' as iata,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 
@@ -1661,6 +1663,8 @@ Layer:
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
             tags->'power_source' as power_source,
+            tags->'icao' as icao,
+            tags->'iata' as iata,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer', 
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist', 
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet', 
@@ -2038,6 +2042,8 @@ Layer:
             access,
             name,
             tags->'operator' as operator,
+            tags->'icao' as icao,
+            tags->'iata' as iata,
             ref,
             way_area,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2114,6 +2120,8 @@ Layer:
               ELSE NULL
             END AS score,
             operator,
+            icao,
+            iata,
             ref,
             way_area,
             is_building
@@ -2175,6 +2183,8 @@ Layer:
                 END AS elevation,
                 "natural",
                 tags->'operator' as operator,
+                tags->'icao' as icao,
+                tags->'iata' as iata,
                 ref,
                 NULL AS way_area,
                 CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building


### PR DESCRIPTION
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/1143.

Simply moves aerodromes with access=private or lacking any of ICAO/IATA codes from z10-z14 to z11-z14. 

I was not able to properly add `aerodrome:type` tag to `project.mml` queries, but it would be good to filter also private types here. Still the effect is good enough for me:

**Full London area from Mapzen extract at z10** (click to see unscaled images):
Before
![clyq8fnf](https://user-images.githubusercontent.com/5439713/27887862-3c4d22c6-61e3-11e7-9f11-e520dbb58d30.png)
After
![najltgcp](https://user-images.githubusercontent.com/5439713/27887867-417946a8-61e3-11e7-9eea-51c4b725a617.png)

**Full Indiana area from Geofabrik extract at z10** (click to see unscaled images):
Before
![rwgimflt](https://user-images.githubusercontent.com/5439713/27888795-6b005002-61e8-11e7-9e6b-b2850b0747db.png)
After
![swibtmg_](https://user-images.githubusercontent.com/5439713/27888822-820be19e-61e8-11e7-971d-520800a93d7c.png)