### PR TITLE
Adding Kosmtik plugins to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,21 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash \
     && apt-get install --no-install-recommends -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Kosmtik with plugins
 RUN npm install -g kosmtik
 
+WORKDIR /usr/lib/node_modules/kosmtik/ 
+RUN kosmtik plugins --install kosmtik-overpass-layer \
+                    --install kosmtik-fetch-remote \
+                    --install kosmtik-overlay \
+                    --install kosmtik-open-in-josm \
+                    --install kosmtik-map-compare \ 
+                    --install kosmtik-osm-data-overlay \
+                    --install kosmtik-mapnik-reference \
+                    --install kosmtik-geojson-overlay \
+    && cp /root/.config/kosmtik.yml /tmp/.kosmtik-config.yml
+
+# Closing section
 RUN mkdir -p /openstreetmap-carto
 WORKDIR /openstreetmap-carto
 

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -32,11 +32,8 @@ import)
 kosmtik)
   python scripts/get-shapefiles.py -n
 
-  mkdir -p .config
   if [ ! -e ".kosmtik-config.yml" ]; then
-    touch .kosmtik-config.yml
-    # this can be removed once https://github.com/kosmtik/kosmtik/issues/236 is resolved
-    echo "plugins:" >> .kosmtik-config.yml
+    cp /tmp/.kosmtik-config.yml .kosmtik-config.yml  
   fi
   export KOSMTIK_CONFIGPATH=".kosmtik-config.yml"
 


### PR DESCRIPTION
This code adds some plugins to make Kosmtik more usable.

I don't see why `.config` directory was created, because `.kosmtik-config.yml` seems to be used outside it, so I removed that line.