### PR TITLE
Adding .gitattributes to Docker configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
Adding .gitattributes to avoid that Git for Windows converts docker-startup.sh newlines to DOS, so that this script can run inside a UNIX container.

This configuration affects all *.sh files of the repository.

Tested with Ubuntu and with Windows.