### PR TITLE
Render railway labels

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1974,6 +1974,37 @@ Layer:
         ) AS paths_text_name
     properties:
       minzoom: 15
+  - id: railways-text-name
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
+                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END AS railway,
+            CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
+            tags->'highspeed' as highspeed,
+            tags->'usage' as usage,
+            construction,
+            name
+          FROM planet_osm_line l
+          WHERE railway IN ('rail', 'subway', 'narrow_gauge', 'light_rail', 'preserved', 'funicular',
+                            'monorail', 'miniature', 'tram', 'disused', 'construction')
+            AND (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))
+            AND highway IS NULL -- Prevent duplicate rendering
+            AND name IS NOT NULL
+          ORDER BY
+            z_order DESC, -- put important rails first
+            COALESCE(layer, 0), -- put top layered rails first
+            length(name) DESC, -- Try to fit big labels in first
+            name DESC, -- Force a consistent ordering between differently named railways
+            l.osm_id DESC -- Force an ordering for railways of the same name, e.g. dualized rails
+        ) AS railways_text_name
+    properties:
+      minzoom: 11
   - id: text-poly-low-zoom
     class: text-low-zoom
     geometry: polygon

--- a/roads.mss
+++ b/roads.mss
@@ -3106,3 +3106,113 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 }
+#railways-text-name {
+  /* Mostly started from z17. */
+  [railway = 'rail'],
+  [railway = 'subway'],
+  [railway = 'narrow_gauge'],
+  [railway = 'light_rail'],
+  [railway = 'preserved'],
+  [railway = 'funicular'],
+  [railway = 'monorail'],
+  [railway = 'tram'] {
+    [zoom >= 17] {
+      text-name: "[name]";
+      text-fill: #666666;
+      text-size: 10;
+      text-dy: 6;
+      text-spacing: 900;
+      text-clip: false;
+      text-placement: line;
+      text-min-distance: 18;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+    }
+    [zoom >= 19] {
+      text-size: 11;
+      text-dy: 7;
+    }
+  }
+  [railway = 'rail'] {
+    /* Render highspeed rails from z11,
+       other main routes at z14. */
+    [highspeed = 'yes'] {
+      [zoom >= 11] {
+        text-name: "[name]";
+        text-fill: #666666;
+        text-size: 10;
+        text-dy: 3;
+        text-spacing: 300;
+        text-clip: false;
+        text-placement: line;
+        text-min-distance: 18;
+        text-face-name: @book-fonts;
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: @standard-halo-fill;
+      }
+      [zoom >= 13] {
+        text-dy: 6;
+      }
+      [zoom >= 14] {
+        text-spacing: 600;
+      }
+      [zoom >= 17] {
+        text-size: 11;
+        text-dy: 7;
+      }
+      [zoom >= 19] {
+        text-size: 12;
+        text-dy: 8;
+      }
+    }
+    [highspeed != 'yes'][usage = 'main'] {
+      [zoom >= 14] {
+        text-name: "[name]";
+        text-fill: #666666;
+        text-size: 10;
+        text-dy: 6;
+        text-spacing: 300;
+        text-clip: false;
+        text-placement: line;
+        text-min-distance: 18;
+        text-face-name: @book-fonts;
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: @standard-halo-fill;
+      }
+      [zoom >= 17] {
+        text-spacing: 600;
+        text-size: 11;
+        text-dy: 7;
+      }
+      [zoom >= 19] {
+        text-size: 12;
+        text-dy: 8;
+      }
+    }
+  }
+  /* Other minor railway styles. For service rails, see:
+     https://github.com/gravitystorm/openstreetmap-carto/pull/2687 */
+  [railway = 'preserved'],
+  [railway = 'miniature'],
+  [railway = 'disused'],
+  [railway = 'construction'] {
+    [zoom >= 17] {
+      text-name: "[name]";
+      text-fill: #666666;
+      text-size: 10;
+      text-dy: 6;
+      text-spacing: 900;
+      text-clip: false;
+      text-placement: line;
+      text-min-distance: 18;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+    }
+    [zoom >= 19] {
+      text-size: 11;
+      text-dy: 7;
+    }
+  }
+}


### PR DESCRIPTION
This will fix #505.

Rendering railway labels will make maps in some railway-centric area better, especially Japan.

I did some copy-and-paste work and make this pull request, hoping to get some feedback about how the label should be styled.

My two cents:

- Should the style of railway lines be changed to match the label?
- Subway under highways is mostly not rendered. Can we render that?

By following is some rendered images of the initial commit in Tokyo, Japan:

![2017-07-12 4 05 40](https://user-images.githubusercontent.com/82419/28088699-1e1410b4-66b9-11e7-92e2-da9731fc68f0.png)
<img width="748" alt="2017-07-12 4 00 16" src="https://user-images.githubusercontent.com/82419/28089420-8c421020-66bb-11e7-934c-0722fa33bc40.png">
![2017-07-12 4 04 20](https://user-images.githubusercontent.com/82419/28089478-b42993c4-66bb-11e7-90df-9fcd3ea191a1.png)
