### PR TITLE
Move plaque rendering to higher zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -544,7 +544,14 @@
   }
 
   [feature = 'historic_memorial'][zoom >= 17] {
-    marker-file: url('symbols/memorial.svg');
+    marker-file: url('symbols/memorial.svg');    
+    marker-fill: @amenity-brown;
+    marker-placement: interior;
+    marker-clip: false;
+  }
+
+  [feature = 'historic_memorial_plaque'][zoom >= 19] {
+    marker-file: url('symbols/plaque.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
@@ -1245,6 +1252,7 @@
 
   [feature = 'tourism_artwork'][zoom >= 17],
   [feature = 'historic_memorial'][zoom >= 17],
+  [feature = 'historic_memorial_plaque'][zoom >= 19],
   [feature = 'man_made_obelisk'][zoom >= 16],
   [feature = 'historic_monument'][zoom >= 16],
   [feature = 'historic_archaeological_site'][zoom >= 17] {

--- a/project.mml
+++ b/project.mml
@@ -1571,7 +1571,9 @@ Layer:
               'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('spring') THEN "natural" ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') 
+                             THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END) 
+                             ELSE NULL END, 
               'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END
@@ -1611,6 +1613,7 @@ Layer:
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk')
             OR "natural" IN ('spring')
             OR historic IN ('memorial', 'monument', 'archaeological_site')
+            OR tags->'memorial' IN ('plaque')
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
             OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> 'power_source=>wind'))
           ORDER BY way_area desc
@@ -1643,7 +1646,9 @@ Layer:
                                                   'dog_park') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN "natural" ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') 
+                             THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END) 
+                             ELSE NULL END,
               'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford') THEN highway ELSE NULL END,
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,
@@ -1694,6 +1699,7 @@ Layer:
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
+            OR tags->'memorial' IN ('plaque')
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals', 'ford')
             OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> 'power_source=>wind'))
           ORDER BY score DESC NULLS LAST
@@ -2033,7 +2039,9 @@ Layer:
                                                     'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') 
+                             THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END) 
+                             ELSE NULL END,
               'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford') THEN highway ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
               'waterway_' || CASE WHEN waterway IN ('dam') THEN waterway ELSE NULL END,
@@ -2061,6 +2069,7 @@ Layer:
               OR place IN ('island', 'islet')
               OR military IN ('danger_area')
               OR historic IN ('memorial', 'monument', 'archaeological_site')
+              OR tags->'memorial' IN ('plaque')
               OR highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford')
               OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
               OR boundary IN ('national_park')
@@ -2163,7 +2172,9 @@ Layer:
                                                         THEN "natural" ELSE NULL END,
                   'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                   'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
-                  'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') THEN historic ELSE NULL END,
+                  'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site') 
+                                 THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END) 
+                                 ELSE NULL END,
                   'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'ford') THEN highway ELSE NULL END,
                   'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
                   'waterway_' || CASE WHEN waterway IN ('dam', 'weir') THEN waterway ELSE NULL END,
@@ -2204,6 +2215,7 @@ Layer:
                   OR place IN ('island', 'islet')
                   OR military IN ('danger_area')
                   OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
+                  OR tags->'memorial' IN ('plaque')
                   OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator', 'ford')
                   OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
                   OR boundary IN ('national_park')

--- a/symbols/plaque.svg
+++ b/symbols/plaque.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 14 14"
+   id="svg2">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="M 2.5,2 C 1.6887616,2 1,2.6887616 1,3.5 l 0,7 C 1,11.269291 1.667788,12 2.5,12 l 9,0 c 0.748318,0 1.5,-0.709735 1.5,-1.5 l 0,-7 C 13,2.7307086 12.269291,2 11.5,2 z m 0,1 C 2.7761424,3 3,3.2238576 3,3.5 3,3.7761424 2.7761424,4 2.5,4 2.2238576,4 2,3.7761424 2,3.5 2,3.2238576 2.2238576,3 2.5,3 z m 9,0 C 11.776142,3 12,3.2238576 12,3.5 12,3.7761424 11.776142,4 11.5,4 11.223858,4 11,3.7761424 11,3.5 11,3.2238576 11.223858,3 11.5,3 z M 5,4 6,4 6,5 5,5 z M 7,4 9,4 9,5 7,5 z M 3,6 11,6 11,7 3,7 z M 5,8 9,8 9,9 5,9 z M 2.5,10 C 2.7761424,10 3,10.223858 3,10.5 3,10.776142 2.7761424,11 2.5,11 2.2238576,11 2,10.776142 2,10.5 2,10.223858 2.2238576,10 2.5,10 z m 9,0 C 11.776142,10 12,10.223858 12,10.5 12,10.776142 11.776142,11 11.5,11 11.223858,11 11,10.776142 11,10.5 11,10.223858 11.223858,10 11.5,10 z"
+     id="plaque"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/issues/1560.

With hstore we can finally push such small memorial objects as plaques to other small amenities. In my city there are so many of them, that I skip mapping them to not clutter the map. 

In this code I've used icon from osmic, because it's depicting plaque.

Warsaw
**z18**
Before
![zytwksx6](https://user-images.githubusercontent.com/5439713/28191587-7fb34974-6831-11e7-9fe5-424847e70e67.png)
After
![ekw8t6up](https://user-images.githubusercontent.com/5439713/28191594-8a2e0ede-6831-11e7-8527-6462b29ee21c.png)

**z19**
Before
![vbviuplz](https://user-images.githubusercontent.com/5439713/28191604-9c19e67c-6831-11e7-8053-d232331edfb5.png)
After
![utegl _c](https://user-images.githubusercontent.com/5439713/28191608-a19eeade-6831-11e7-8c61-6fedef578664.png)