### PR TITLE
Fixing .env file creation for Docker

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-# environment defaults for import
-
-OSM2PGSQL_CACHE=512
-OSM2PGSQL_NUMPROC=1
-OSM2PGSQL_DATAFILE=data.osm.pbf

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 localconfig.json
 localconfig.js
 .kosmtik-config.yml
+.env
 
 # Generated at runtime by Python.
 *.pyc

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -3,6 +3,7 @@
 # This script is used to start the import or kosmtik containers for the Docker development environment.
 # You can read details about that in DOCKER.md
 
+# Testing if database is ready
 i=1
 MAXCOUNT=60
 echo "Waiting for PostgreSQL to be running"
@@ -16,9 +17,27 @@ test $i -gt $MAXCOUNT && echo "Timeout while waiting for PostgreSQL to be runnin
 
 case "$1" in
 import)
+  # Creating default database
   psql -c "SELECT 1 FROM pg_database WHERE datname = 'gis';" | grep -q 1 || createdb gis && \
   psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS postgis;' && \
   psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS hstore;' && \
+
+  # Creating default import settings file editable by user and passing values for osm2pgsql
+  if [ ! -e ".env" ]; then
+    cat > .env <<EOF
+# Environment settings for importing to a Docker container database
+
+OSM2PGSQL_CACHE=512
+OSM2PGSQL_NUMPROC=1
+OSM2PGSQL_DATAFILE=data.osm.pbf
+EOF
+    chmod a+rw .env
+    export OSM2PGSQL_CACHE=512
+    export OSM2PGSQL_NUMPROC=1
+    export OSM2PGSQL_DATAFILE=data.osm.pbf
+  fi
+
+  # Importing data to a database
   osm2pgsql \
   --cache $OSM2PGSQL_CACHE \
   --number-processes $OSM2PGSQL_NUMPROC \
@@ -29,15 +48,20 @@ import)
   --tag-transform-script openstreetmap-carto.lua \
   $OSM2PGSQL_DATAFILE
   ;;
+
 kosmtik)
+  # Downloading needed shapefiles
   python scripts/get-shapefiles.py -n
 
+  # Creating default Kosmtik settings file
   if [ ! -e ".kosmtik-config.yml" ]; then
     cp /tmp/.kosmtik-config.yml .kosmtik-config.yml  
   fi
   export KOSMTIK_CONFIGPATH=".kosmtik-config.yml"
 
+  # Starting Kosmtik
   kosmtik serve project.mml --host 0.0.0.0
-  # It needs Control C to be interrupted
+  # It needs Ctrl+C to be interrupted
   ;;
+
 esac


### PR DESCRIPTION
Follow up to https://github.com/gravitystorm/openstreetmap-carto/pull/2679#issuecomment-313905873.

The only strange thing is that when there is no .env file, import fails, even though this file should be just created. Next time the import is invoked, everything works. That's why I marked it as a work in progress.