### PR TITLE
Changing borders color to gray [WIP]

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #ac46ac;
+@admin-boundaries: #555555;
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/issues/622.

Simple color change for the borders from violet to gray. Examples:

Warsaw, z12
Before
![af5zg3i3](https://user-images.githubusercontent.com/5439713/28485156-c68d3750-6e77-11e7-8db1-f6143088937d.png)
After
![huj_btnw](https://user-images.githubusercontent.com/5439713/28485159-ca4f09fe-6e77-11e7-81be-0f99c3edd26b.png)

Europe, z4 (see [more examples here](https://github.com/gravitystorm/openstreetmap-carto/issues/2688#issuecomment-317144397))
Before
![ubx5_svd](https://user-images.githubusercontent.com/5439713/28487161-52bb4998-6e8b-11e7-9cbf-8f1af3c845ba.png)
After (borders)
![7uehxsqz](https://user-images.githubusercontent.com/5439713/28487162-5706714e-6e8b-11e7-9b60-7bac841f32df.png)
After (borders+water)
![negfihhr](https://user-images.githubusercontent.com/5439713/28487163-5adcf2b6-6e8b-11e7-9032-d03a2d4e23df.png)