### PR TITLE
Airport labels moved under icon

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2044,7 +2044,7 @@
     text-name: "[name]";
     text-size: @standard-text-size;
     text-fill: darken(@airtransport, 15%);
-    text-dy: -10;
+    text-dy: 10;
     text-face-name: @oblique-fonts;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/pull/1881.

Airport labels are currently shown on top of icons, I'd like to unify it with other labels (bus stops, railway stations etc.).

Warsaw, z10
Before
![e93imzmj](https://user-images.githubusercontent.com/5439713/28502333-3d709ed8-6ff0-11e7-9018-da3792f011ef.png)
After
![a5mss5op](https://user-images.githubusercontent.com/5439713/28502334-421f22e2-6ff0-11e7-82fd-907590bf5d04.png)