### PR TITLE
Changing area color for railway=station

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -31,7 +31,6 @@
 @railway: @industrial;
 @railway-line: @industrial-line;
 @rest_area: #efc8c8; // also services
-@station: #d4aaaa;
 
 // --- Other ----
 
@@ -539,7 +538,7 @@
   }
 
   [feature = 'railway_station'][zoom >= 10] {
-    polygon-fill: @station;
+    polygon-fill: @railway;
   }
 
   [feature = 'leisure_fitness_centre'],


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/issues/2094.

Currently we're using special color for rendering railway=station area, but it looks like a leftover when it was considered to be a building (like supermarket for example). In general I'd like to unify all transportation areas, but in this case I think railway/industrial color works better, as it is a railway area anyway.

The question is however if we want to imply a landuse color or not fill it at all (so the explicit landuse tagging is needed)? It's the same problem as with https://github.com/gravitystorm/openstreetmap-carto/pull/2700.

Gliwice, z17
Before
![z26fuayx](https://user-images.githubusercontent.com/5439713/28555053-9017cf90-70fd-11e7-8d49-3e99d86f1004.png)
After
![xkgvhe_a](https://user-images.githubusercontent.com/5439713/28555057-96d247a2-70fd-11e7-9eb9-e3deacb6729b.png)