### PR TITLE
Bullet-proof Docker variable turning with PostGIS.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
+!scripts/tune-postgis.sh
 !openstreetmap-carto.style

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -30,7 +30,20 @@ Once you have that file put it into the openstreetmap-carto directory and run `d
 This starts the PostgreSQL container (downloads it if it not exists) and starts a container that runs [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) to import the data. The container is built the first time you run that command if it not exists.
 At startup of the container the script `scripts/docker-startup.sh` is invoked which prepares the database and itself starts osm2pgsql for importing the data.
 
-osm2pgsql has a few [command line options](https://manpages.debian.org/testing/osm2pgsql/osm2pgsql.1.en.html) and the import by default uses a RAM cache of 512 MB, 1 worker and expects the import file to be named `data.osm.pbf`. If you want to customize any of these parameters you have to set the environment variables `OSM2PGSQL_CACHE` (e.g. `export OSM2PGSQL_CACHE=1024` on Linux to set the cache to 1 GB) for the RAM cache (the value depends on the amount of RAM you have available, the more you can use here the faster the import may be), `OSM2PGSQL_NUMPROC` for the number of workers (this depends on the number of processors you have and whether your harddisk is fast enough e.g. is a SSD), or `OSM2PGSQL_DATAFILE` if your file has a different name. If you instead want to customize the default values, you find them in the file `.env`.
+osm2pgsql has a few [command line options](https://manpages.debian.org/testing/osm2pgsql/osm2pgsql.1.en.html) and the import by default uses a RAM cache of 512 MB, 1 worker and expects the import file to be named `data.osm.pbf`. If you want to customize any of these parameters you have to set the environment variables `OSM2PGSQL_CACHE` (e.g. `export OSM2PGSQL_CACHE=1024` on Linux to set the cache to 1 GB) for the RAM cache (the value depends on the amount of RAM you have available, the more you can use here the faster the import may be), `OSM2PGSQL_NUMPROC` for the number of workers (this depends on the number of processors you have and whether your harddisk is fast enough e.g. is a SSD), or `OSM2PGSQL_DATAFILE` if your file has a different name. 
+
+You can also [turn the PostgreSQL](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server) during the import phases, with `PG_WORK_MEM` (default to 16MB) and `PG_MAINTENANCE_WORK_MEM` (default to 256MB), which will eventually write `work_mem` and `maintenance_work_mem` to the `postgresql.auto.conf` once, making them applied each time the database started. Note that unlike osm2pgsql variables, once thay are set, you can only change them by running `ALTER SYSTEM` on your own, changing `postgresql.auto.conf` or remove the database volume by `docker-compose down -v && docker-compose rm -v` and import again.
+
+If you want to customize and remember the values, supply it during your first import:
+
+```
+PG_WORK_MEM=128MB PG_MAINTENANCE_WORK_MEM=2GB \
+OSM2PGSQL_CACHE=2048 OSM2PGSQL_NUMPROC=4 \
+OSM2PGSQL_DATAFILE=taiwan.osm.pbf \
+docker-compose up import 
+```
+
+Variables will be remembered in `.env` if you don't have that file, and values in the file will be applied unless you manually assign them.
 
 Depending on your machine and the size of the extract the import can take a while. When it is finished you should have the data necessary to render it with openstreetmap-carto.
 

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,3 @@
+FROM mdillon/postgis:9.6
+
+ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,13 @@ services:
       - PGHOST=db
       - PGUSER=postgres
   db:
-    image: mdillon/postgis:9.6
+    image: db:v1
+    build:
+      context: .
+      dockerfile: Dockerfile.db
+    environment:
+      - PG_WORK_MEM
+      - PG_MAINTENANCE_WORK_MEM
   import:
     image: import:v1
     build:
@@ -28,6 +34,8 @@ services:
     environment:
       - PGHOST=db
       - PGUSER=postgres
+      - PG_WORK_MEM
+      - PG_MAINTENANCE_WORK_MEM
       - OSM2PGSQL_CACHE
       - OSM2PGSQL_NUMPROC
       - OSM2PGSQL_DATAFILE

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -26,15 +26,16 @@ import)
   if [ ! -e ".env" ]; then
     cat > .env <<EOF
 # Environment settings for importing to a Docker container database
-
-OSM2PGSQL_CACHE=512
-OSM2PGSQL_NUMPROC=1
-OSM2PGSQL_DATAFILE=data.osm.pbf
+PG_WORK_MEM=${PG_WORK_MEM:-16MB}
+PG_MAINTENANCE_WORK_MEM=${PG_MAINTENANCE_WORK_MEM:-256MB}
+OSM2PGSQL_CACHE=${OSM2PGSQL_CACHE:-512}
+OSM2PGSQL_NUMPROC=${OSM2PGSQL_NUMPROC:-1}
+OSM2PGSQL_DATAFILE=${OSM2PGSQL_DATAFILE:-data.osm.pbf}
 EOF
     chmod a+rw .env
-    export OSM2PGSQL_CACHE=512
-    export OSM2PGSQL_NUMPROC=1
-    export OSM2PGSQL_DATAFILE=data.osm.pbf
+    export OSM2PGSQL_CACHE=${OSM2PGSQL_CACHE:-512}
+    export OSM2PGSQL_NUMPROC=${OSM2PGSQL_NUMPROC:-1}
+    export OSM2PGSQL_DATAFILE=${OSM2PGSQL_DATAFILE:-data.osm.pbf}
   fi
 
   # Importing data to a database

--- a/scripts/tune-postgis.sh
+++ b/scripts/tune-postgis.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+export PGUSER="$POSTGRES_USER"
+
+"${psql[@]}" -c "ALTER SYSTEM SET work_mem='${PG_WORK_MEM:-16MB}';"
+"${psql[@]}" -c "ALTER SYSTEM SET maintenance_work_mem='${PG_MAINTENANCE_WORK_MEM:-256MB}';"


### PR DESCRIPTION
Should fix #2698 in a very good way.

This will:
- Giving user a good out-of-a-box PostgreSQL / osm2pgsql turing.
- ... but still allow user to supply args during their first import;
- ...then generating `.env` based on args above.

Also fix the document about the behavior.

There are some steps to see how it just works, you can try:

1. For the first time, running `docker-compose up import` without any custom args
2. Check `.env`, change some value, then destroy all volumes using `docker-compose down -v && docker-compose rm -v` (PostgreSQL turnings will only applied once the volume is created)
3. Run `docker-compose up import` again to see whether settings from `.env` applied
4. Destroy volumes again
5. Prepend args different from those in `.env` in import command, like stated in `DOCKER.md`, import again
6. Settings shall use prepended args but `.env` shall not be changed.