### PR TITLE
Rendering farmland earlier on midzoom

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -313,7 +313,7 @@
 
   [feature = 'landuse_farmland'],
   [feature = 'landuse_greenhouse_horticulture'] {
-    [zoom >= 10] {
+    [zoom >= 8] {
       polygon-fill: @farmland;
       [zoom >= 16] {
         line-width: .5;

--- a/project.mml
+++ b/project.mml
@@ -101,12 +101,12 @@ Layer:
             COALESCE(wetland, landuse, "natural") AS feature
           FROM (SELECT
               way, COALESCE(name, '') AS name, religion,
-              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END)) AS landuse,
+              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
-            WHERE (landuse IN ('forest', 'military')
+            WHERE (landuse IN ('forest', 'military', 'farmland')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL
@@ -1966,7 +1966,7 @@ Layer:
             way,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             COALESCE(
-              'landuse_' || CASE WHEN landuse IN ('forest', 'military') THEN landuse ELSE NULL END,
+              'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
@@ -1975,7 +1975,7 @@ Layer:
             name,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
-          WHERE (landuse IN ('forest', 'military')
+          WHERE (landuse IN ('forest', 'military', 'farmland')
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')
               OR "place" IN ('island')
               OR boundary IN ('national_park')


### PR DESCRIPTION
Related to https://github.com/gravitystorm/openstreetmap-carto/pull/2654.

Start rendering farmlands on z8+ instead of z10+. I don't want to touch lowzoom yet (https://github.com/gravitystorm/openstreetmap-carto/issues/2688), but when we start showing forests/woods on midzoom, we can also show the farmlands, because both are very popular and with color fading they enhance the background in a subtle way.

Full Poland extract (click to see unscaled images):
z8
![poland-z8-farmland](https://user-images.githubusercontent.com/5439713/28853477-102dac16-7731-11e7-8cbe-d5a0fd995f0a.png)
z9 (converted to JPG to fit in the GitHub filesize limit)
![poland-z9-farmland](https://user-images.githubusercontent.com/5439713/28853377-77a634f4-7730-11e7-9208-91125bc32548.jpg)