### PR TITLE
Rendering natural=sand earlier on midzoom

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1934,11 +1934,11 @@
     }
   }
 
-  [feature = 'natural_scree'],
-  [feature = 'natural_shingle'],
-  [feature = 'natural_bare_rock'],
+  [feature = 'natural_scree'][zoom >= 9],
+  [feature = 'natural_shingle'][zoom >= 9],
+  [feature = 'natural_bare_rock'][zoom >= 9],
   [feature = 'natural_sand'] {
-    [zoom >= 9][way_pixels > 3000][is_building = 'no'],
+    [zoom >= 8][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17][is_building = 'no'] {
       text-name: "[name]";
       text-size: @landcover-font-size;

--- a/landcover.mss
+++ b/landcover.mss
@@ -455,7 +455,7 @@
     }
   }
 
-  [feature = 'natural_sand'][zoom >= 9] {
+  [feature = 'natural_sand'][zoom >= 8] {
     polygon-fill: @sand;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }


### PR DESCRIPTION
Related to #2654, follow up to #2722.

Another landuse type that can be rendered on midzoom on z8+ (instead of z9+), just like the forest and farmland, because there are already places where it can be quite big (=visible even on the low zoom scale) and it helps diversity.

@rrzefox: Could you add this patch too and check the performance implications?

Examples  (click to see unscaled images):

Egypt, z8
![wvvtbkza](https://user-images.githubusercontent.com/5439713/29237532-4dffb0ce-7f20-11e7-82c5-05aca5c369be.png)

Africa, z8 (converted to JPG to fit in GitHub filesize limit)
[-> link to big image](https://user-images.githubusercontent.com/5439713/29237544-a19b77fe-7f20-11e7-956c-9b9129ee4e42.jpg)