### PR TITLE
Adding area rendering for amenity=bus_station

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -26,7 +26,7 @@
 
 // --- Transport ----
 
-@aerodrome: #e9e7e2;
+@transportation-area: #e9e7e2;
 @apron: #e9d1ff;
 @garages: #dfddce;
 @parking: #eeeeee;
@@ -568,10 +568,11 @@
   }
 
   [feature = 'aeroway_aerodrome'][zoom >= 10],
-  [feature = 'amenity_ferry_terminal'][zoom >= 15] {
-    polygon-fill: @aerodrome;
+  [feature = 'amenity_ferry_terminal'][zoom >= 15],
+  [feature = 'amenity_bus_station'][zoom >= 15] {
+    polygon-fill: @transportation-area;
     line-width: 0.2;
-    line-color: saturate(darken(@aerodrome, 40%), 20%);
+    line-color: saturate(darken(@transportation-area, 40%), 20%);
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }

--- a/project.mml
+++ b/project.mml
@@ -119,7 +119,7 @@ Layer:
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
-                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space')
+                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space', 'bus_station')
                                                     THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
@@ -144,7 +144,7 @@ Layer:
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'taxi', 'university', 'college', 'school', 'hospital', 'kindergarten',
                              'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
-                             'arts_centre', 'parking_space')
+                             'arts_centre', 'parking_space', 'bus_station')
               OR man_made IN ('works')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')


### PR DESCRIPTION
Part of a transport unification effort, related to #2094. Using the same subtle area color for bus station as for the other transportation areas (taken from the airport area).

Cracow, z19
Before
![hallbrvv](https://user-images.githubusercontent.com/5439713/29495795-752acb3c-85c6-11e7-886d-7b7547db63d9.png)
After
![pk2eehc_](https://user-images.githubusercontent.com/5439713/29495797-7a9822ea-85c6-11e7-9477-a8e84218d4fe.png)
