### PR TITLE
Add ordering to roads-low-zoom

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1063,7 +1063,9 @@ Layer:
           WHERE highway IS NOT NULL
             OR (railway IS NOT NULL AND railway != 'preserved'
               AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
-          ORDER BY COALESCE(layer,0)
+          ORDER BY
+            COALESCE(layer,0),
+            z_order
         ) AS roads_low_zoom
     properties:
       minzoom: 5


### PR DESCRIPTION
There is currently no ordering for the roads-low-zoom layer. The issue is most noticeable at zoom 9, the highest zoom level where the roads-low-zoom layer is used.
![download 1](https://user-images.githubusercontent.com/65656/29515554-7c021f8e-8632-11e7-9da2-7996c10a5b7d.png)

Applying #2732 to roads-low-zoom clears things up.
![download 4](https://user-images.githubusercontent.com/65656/29516033-7316bf18-8634-11e7-82c7-e48aecfd0336.png)
