### PR TITLE
Make installation process more explicit

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -17,7 +17,7 @@ If you are eager to get started here is an overview over the necessary steps.
 Read on below to get the details.
 
 * clone openstreetmap-carto repository
-* Download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory.
+* download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory
 * `docker-compose up import` to import the data (only necessary the first time or when you change the data file)
 * `docker-compose up kosmtik` to run the style preview application
 * browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,9 +16,11 @@ Docker itself. Otherwise you need to [install Docker Compose manually](https://d
 If you are eager to get started here is an overview over the necessary steps.
 Read on below to get the details.
 
+* clone openstreetmap-carto repository
 * Download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory.
 * `docker-compose up import` to import the data (only necessary the first time or when you change the data file)
 * `docker-compose up kosmtik` to run the style preview application
+* browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik
 * Ctrl+C to stop the style preview application
 * `docker-compose stop db` to stop the database container
 


### PR DESCRIPTION
subtask of #2291 

I think that `Quick start` section should be self-contained and require no digging in other parts of documentation (especially with "Read on below to get the details.").

It reduces confusion - for example at start I missed fact that `openstreetmap-carto` is obviously necessary. Info how to see anything is currently hidden in the later part.