### PR TITLE
Changing embassy color to amenity-brown

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -286,7 +286,7 @@
 
   [feature = 'amenity_embassy'][zoom >= 17] {
     marker-file: url('symbols/embassy.svg');
-    marker-fill: @transportation-icon;
+    marker-fill: @amenity-brown;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -1724,7 +1724,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @transportation-text;
+    text-fill: @amenity-brown;
     text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;


### PR DESCRIPTION
Follow up to @giggls https://github.com/gravitystorm/openstreetmap-carto/pull/2765#issuecomment-323748719.

Embassy icon is rather kind of office (like town hall) than transportation amenity (like bus stop), so I prefer rendering it as such.

Before
![fncnbimh](https://user-images.githubusercontent.com/5439713/29849616-4495d714-8d28-11e7-9927-b3355bc7b53f.png)
After
![1ntyippb](https://user-images.githubusercontent.com/5439713/29849620-4a4ef834-8d28-11e7-9d28-e693afc82468.png)
