### PR TITLE
Same line wrap of amenitys for all zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -13,7 +13,7 @@
 @landform-color: #d08f55;
 
 @landcover-font-size: 10;
-@landcover-wrap-width-size: 25; // 2.5 em
+@landcover-wrap-width-size: 30; // 3 em
 @landcover-line-spacing-size: -1.5; // -0.15 em
 @landcover-font-size-big: 12;
 @landcover-wrap-width-size-big: 36; // 3 em


### PR DESCRIPTION
As proposed by @math1985 at https://github.com/gravitystorm/openstreetmap-carto/pull/2730#issuecomment-322591915 here is a PR that unifies the line wrap for amenity points over all zoom levels. I think that indeed it makes sense, because amenity points are rather small (at difference to other features like cities or lakes that have larger line wrap at higher zoom levels because they are much bigger), and anyway the difference is not big compared to the current code. This PR will make zoom-in/zoom-out less surprising, because you get always the same line wrap for amenities.