### PR TITLE
Moving natural=tree to higher zoom

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2212,17 +2212,11 @@
       }
     }
     [natural = 'tree'] {
-      marker-fill: green;
-      marker-allow-overlap: true;
-      marker-line-width: 0;
-      marker-width: 2.5;
-      marker-height: 2.5;
-      marker-ignore-placement: true;
-      [zoom >= 17] {
-        marker-width: 5;
-        marker-height: 5;
-      }
       [zoom >= 18] {
+        marker-fill: green;
+        marker-allow-overlap: true;
+        marker-line-width: 0;
+        marker-ignore-placement: true;
         marker-width: 10;
         marker-height: 10;
       }


### PR DESCRIPTION
While natural=tree progression is nice in theory, in practice single trees do not belong to z16-z17 when [tagged fully](http://www.openstreetmap.org/#map=16/52.2435/20.9537):

z16
Before
![traa7lcy](https://user-images.githubusercontent.com/5439713/29951066-65c0a2fe-8ec0-11e7-9ed7-a2eb7e19bd46.png)

After
![nnvj8qkd](https://user-images.githubusercontent.com/5439713/29951071-6ff92f52-8ec0-11e7-9e46-ca8975a2ad86.png)

z17
Before
![mpycct0p](https://user-images.githubusercontent.com/5439713/29951069-6bef946e-8ec0-11e7-8ad7-de3f0f2ae60b.png)

After
![oenwo7jg](https://user-images.githubusercontent.com/5439713/29951075-75c044f2-8ec0-11e7-873a-f66ad4d41d21.png)
