### PR TITLE
Add names to places that are mapped as areas

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1523,7 +1523,9 @@
   [feature = 'leisure_stadium'],
   [feature = 'leisure_track'],
   [feature = 'leisure_dog_park'],
-  [feature = 'leisure_pitch'] {
+  [feature = 'leisure_pitch'],
+  [feature = 'place_village'],
+  [feature = 'place_hamlet'] {
     [zoom >= 10][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17][is_building = 'no'],
     [zoom >= 10][way_pixels > 3000][feature = 'shop_mall'],
@@ -1573,7 +1575,9 @@
         text-fill: darken(@cemetery, 50%);
         text-halo-radius: @standard-halo-radius * 1.5; /* extra halo needed to overpower the cemetery polygon pattern */
       }
-      [feature = 'landuse_residential'] {
+      [feature = 'landuse_residential'],
+      [feature = 'place_village'],
+      [feature = 'place_hamlet'] {
         text-fill: darken(@residential, 50%);
       }
       [feature = 'landuse_meadow'],

--- a/project.mml
+++ b/project.mml
@@ -1905,7 +1905,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
                                                     'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier') THEN "natural" ELSE NULL END,
-              'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
+              'place_' || CASE WHEN place IN ('island', 'islet', 'village', 'hamlet') THEN place ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
@@ -1934,7 +1934,7 @@ Layer:
               OR landuse IS NOT NULL
               OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk')
               OR "natural" IS NOT NULL
-              OR place IN ('island', 'islet')
+              OR place IN ('island', 'islet', 'village', 'hamlet')
               OR military IN ('danger_area')
               OR historic IN ('memorial', 'monument', 'archaeological_site')
               OR tags->'memorial' IN ('plaque')


### PR DESCRIPTION
Proof of concept using villages and hamlets where confusion with places
identified as points should be easily identifiable and rectifiable by
contributors.

Can be extended to larger place areas.

Typography can be changed in future to be aligned with existing point
place typography, but not made now to simplify audit