### PR TITLE
Add Shading for places defined as areas

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -474,7 +474,7 @@
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
- 
+
   [feature = 'wetland_swamp'][zoom >= 8] {
     polygon-fill: @forest;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
@@ -766,7 +766,7 @@
       b/line-color: @tourism;
       b/line-opacity: 0.3;
       b/line-join: round;
-      b/line-cap: round;    
+      b/line-cap: round;
     }
     [zoom >= 17] {
       a/line-width: 2;

--- a/landcover.mss
+++ b/landcover.mss
@@ -227,6 +227,25 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
+  [feature = 'place_village'],
+  [feature = 'place_hamlet'] {
+    [zoom >= 10] {
+      polygon-fill: @built-up-lower-lowzoom;
+      polygon-opacity: 0.3;
+      [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+      [zoom >= 13] { polygon-fill: @residential; }
+      [zoom >= 16] {
+        line-width: .5;
+        line-color: @residential-line;
+        [name != ''] {
+          line-width: 0.7;
+        }
+      }
+    }
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  
   [feature = 'landuse_garages'][zoom >= 13] {
     polygon-fill: @garages;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }

--- a/landcover.mss
+++ b/landcover.mss
@@ -228,24 +228,21 @@
   }
 
   [feature = 'place_village'],
-  [feature = 'place_hamlet'] {
-    [zoom >= 10] {
-      polygon-fill: @built-up-lower-lowzoom;
-      polygon-opacity: 0.3;
-      [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
-      [zoom >= 13] { polygon-fill: @residential; }
-      [zoom >= 16] {
-        line-width: .5;
-        line-color: @residential-line;
-        [name != ''] {
-          line-width: 0.7;
-        }
+  [feature = 'place_hamlet'][zoom >= 10] {
+    polygon-fill: @built-up-lower-lowzoom;
+    [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+    [zoom >= 13] { polygon-fill: lighten(@residential, 30%); }
+    [zoom >= 16] {
+      line-width: .5;
+      line-color: lighten(@residential-line, 30%);
+      [name != ''] {
+        line-width: 0.7;
       }
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
-  
+
   [feature = 'landuse_garages'][zoom >= 13] {
     polygon-fill: @garages;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }

--- a/project.mml
+++ b/project.mml
@@ -135,6 +135,7 @@ Layer:
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
                                                     'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial',
                                                     'brownfield', 'landfill', 'construction', 'plant_nursery') THEN landuse ELSE NULL END)) AS landuse,
+              ('place_' || (CASE WHEN place IN ('village', 'hamlet') THEN place ELSE NULL END)) AS place,
               ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'common', 'garden',
                                                     'golf_course', 'miniature_golf', 'picnic_table', 'fitness_centre', 'sports_centre', 'stadium', 'pitch',
                                                     'track', 'dog_park') THEN leisure ELSE NULL END)) AS leisure,
@@ -149,6 +150,7 @@ Layer:
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
             WHERE (landuse IS NOT NULL
+              OR place IN ('village','hamlet')
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten',
@@ -1905,7 +1907,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
                                                     'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier') THEN "natural" ELSE NULL END,
-              'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
+              'place_' || CASE WHEN place IN ('island', 'islet', 'village', 'hamlet') THEN place ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
@@ -1934,7 +1936,7 @@ Layer:
               OR landuse IS NOT NULL
               OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'pier', 'breakwater', 'groyne', 'obelisk')
               OR "natural" IS NOT NULL
-              OR place IN ('island', 'islet')
+              OR place IN ('island', 'islet', 'village', 'hamlet')
               OR military IN ('danger_area')
               OR historic IN ('memorial', 'monument', 'archaeological_site')
               OR tags->'memorial' IN ('plaque')


### PR DESCRIPTION
Add shading for places defined as areas. Currently only applies to
Villages and Hamlets but can be extended. Opacity is low to expose
other land use within villages.