### PR TITLE
Render place names from both points and polygons

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -78,6 +78,7 @@
     shield-margin: 7.7; // 0.7 em
     shield-halo-fill: @standard-halo-fill;
     shield-halo-radius: @standard-halo-radius * 1.5;
+    shield-placement: interior;
     shield-placement-type: simple;
     shield-placements: 'S,N,E,W';
     [dir = 1] {
@@ -111,6 +112,7 @@
     text-margin: 9.1; // 0.7 em
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
+    text-placement: interior;
 
     [zoom >= 10] {
       text-size: 14;
@@ -143,6 +145,7 @@
       shield-margin: 7.7; // 0.7 em
       shield-halo-fill: @standard-halo-fill;
       shield-halo-radius: @standard-halo-radius * 1.5;
+      shield-placement: interior;
       shield-placement-type: simple;
       shield-placements: 'S,N,E,W';
       [dir = 1] {
@@ -178,6 +181,7 @@
       text-margin: 9.1; // 0.7 em
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
 
       [zoom >= 10] {
         text-size: 14;
@@ -211,6 +215,7 @@
       shield-wrap-width: 30; // 3.0 em
       shield-line-spacing: -1.5; // -0.15 em
       shield-margin: 7.0; // 0.7 em
+      shield-placement: interior;
       shield-placement-type: simple;
       shield-placements: 'S,N,E,W';
       [dir = 1] {
@@ -228,6 +233,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 40; // 4.0 em
       text-line-spacing: -1.0; // -0.10 em
       text-margin: 7.0; // 0.7 em
@@ -268,6 +274,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 45; // 4.5 em
       text-line-spacing: -0.8; // -0.08 em
       text-margin: 7; // 0.7 em
@@ -301,6 +308,7 @@
     text-face-name: @book-fonts;
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
+    text-placement: interior;
     text-wrap-width: 55; // 5.0 em
     text-line-spacing: -0.55; // -0.05 em
     text-margin: 7.7; // 0.7 em
@@ -336,6 +344,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 50; // 5.0 em
       text-line-spacing: -0.50; // -0.05 em
       text-margin: 7.0; // 0.7 em
@@ -382,6 +391,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 45; // 4.5 em
       text-line-spacing: -0.8; // -0.08 em
       text-margin: 7.0; // 0.7 em

--- a/project.mml
+++ b/project.mml
@@ -1232,11 +1232,30 @@ Layer:
               WHEN (tags->'population' ~ '^[0-9]{1,8}$') THEN (tags->'population')::INTEGER ELSE 0
             END as population,
             round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
-          FROM planet_osm_point
-          WHERE place IN ('city', 'town', 'village', 'hamlet')
-            AND name IS NOT NULL
-            AND tags @> 'capital=>yes'
-          ORDER BY population DESC
+          FROM
+            (SELECT
+                way,
+                osm_id,
+                name,
+                place,
+                tags,
+                NULL AS way_area
+              FROM planet_osm_point
+            UNION ALL
+            SELECT
+                way,
+                osm_id,
+                name,
+                place,
+                tags,
+                way_area
+              FROM planet_osm_polygon
+              ) places
+              WHERE place IN ('city', 'town', 'village', 'hamlet')
+                AND name IS NOT NULL
+                AND tags @> 'capital=>yes'
+          ORDER BY population DESC,
+            way_area DESC NULLS LAST
         ) AS capital_names
     properties:
       minzoom: 3
@@ -1296,7 +1315,25 @@ Layer:
                     ELSE 1
                   END)
                 ) AS score
-              FROM planet_osm_point
+              FROM
+              (SELECT
+                  osm_id,
+                  way,
+                  place,
+                  name,
+                  tags,
+                  NULL AS way_area
+                FROM planet_osm_point
+              UNION ALL
+              SELECT
+                  osm_id,
+                  way,
+                  place,
+                  name,
+                  tags,
+                  way_area
+                FROM planet_osm_polygon
+              ) places
               WHERE place IN ('city', 'town')
                 AND name IS NOT NULL
                 AND NOT (tags @> 'capital=>yes')
@@ -1316,7 +1353,23 @@ Layer:
             way,
             place,
             name
-          FROM planet_osm_point
+          FROM
+          (SELECT
+              way,
+              place,
+              name,
+              tags,
+              NULL AS way_area
+            FROM planet_osm_point
+          UNION ALL
+          SELECT
+              way,
+              place,
+              name,
+              tags,
+              NULL AS way_area
+            FROM planet_osm_polygon
+            ) AS places
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
@@ -1330,7 +1383,10 @@ Layer:
               WHEN place = 'locality' THEN 7
               WHEN place = 'isolated_dwelling' THEN 8
               WHEN place = 'farm' THEN 9
-            END ASC, length(name) DESC, name
+            END ASC,
+            way_area DESC NULLS LAST,
+            length(name) DESC,
+            name
         ) AS placenames_small
     properties:
       minzoom: 12


### PR DESCRIPTION
Fixes #103 

According to the description of the other PR, fixes #2804

This doesn't change the cartography, but reveals two errors in OSM data that have been showing up on other maps

== Incorrect city tags ==
There's a lot of areas with place=city on them in the US which shouldn't have it.

![image](https://user-images.githubusercontent.com/1190866/30235712-8c2c4cb2-94c0-11e7-8454-034fa3912d24.png)

Because osm-carto doesn't show them, they've largely gone undetected, but show up as problems on other maps

== Duplicate places ==

Frequently there's places which are mapped as both points and areas

![image](https://user-images.githubusercontent.com/1190866/30235747-18225950-94c1-11e7-9be9-ff46b024e547.png)

Again, this has been hidden by osm-carto, and is a problem for other maps.

Aside from the obvious fixing of #103, this will make us consistent with other maps and much easier for developers of other maps using OSM data.

This was done as part of my WMF work on https://phabricator.wikimedia.org/T163819