### PR TITLE
Fixing line wrapping bug in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:xenial
 
 # Style dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     curl ca-certificates osm2pgsql postgresql-client \


### PR DESCRIPTION
Resolves #2755.

There are different ways to skin this cat, but this is the easiest and fastest for us to use. I've changed the import container distribution too just to be consistent with a kosmtik container.