### PR TITLE
Do not order low zoom roads by layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -936,7 +936,6 @@ Layer:
             OR (railway IS NOT NULL AND railway != 'preserved'
               AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
           ORDER BY
-            COALESCE(layer,0),
             z_order
         ) AS roads_low_zoom
     properties:


### PR DESCRIPTION
On low zoom levels (up to z9) it is not important which road crosses
on top of the other. Instead, it is important to always show important
roads on top, so lower classes roads do not hide motorways.