### PR TITLE
Bring lightness of farmland color again in line with other landuse

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -19,8 +19,8 @@
 @commercial-line: #d1b2b0;  // Lch(75,12,25)
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line)
-@farmland: #fbecd7;         // Lch(94,12,80)
-@farmland-line: #d6c4ab;    // Lch(80,15,80)
+@farmland: #edddc9;         // Lch(89,12,80)
+@farmland-line: #c8b69e;    // Lch(75,15,80)
 @farmyard: #f5dcba;         // Lch(89,20,80)
 @farmyard-line: #d1b48c;    // Lch(75,25,80)
 


### PR DESCRIPTION
Now that we have fading of landuse on z8-z12, I think we can revert
the fading of farmland (#1701). The reason for fading farmland was
mainly prominence of farmland on the mid-zoom levels, which is not
a problem anymore after the mid-zoom fading.

This brings the lightness of farmland again in line of the lightness
of similar landuses like grassland.