### PR TITLE
Removing z-ordering in landcover

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -160,7 +160,7 @@ Layer:
               OR highway IN ('services', 'rest_area')
               OR railway = 'station')
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
-            ORDER BY COALESCE(layer,0), way_area DESC
+            ORDER BY way_area DESC
           ) AS landcover
         ) AS features
     properties:


### PR DESCRIPTION
Resolves #53.
Follow up to #2740.

A basic testing was made to make sure rendering is not just broken after this.