### PR TITLE
Leisure POI category

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -12,6 +12,7 @@
 @gastronomy: @amenity-brown;
 @man-made-icon: #555;
 @landform-color: #d08f55;
+@leisure-green: darken(@park, 60%);
 
 @landcover-font-size: 10;
 @landcover-wrap-width-size: 30; // 3 em
@@ -854,20 +855,20 @@
   [feature = 'leisure_water_park'][zoom >= 17] {
     marker-file: url('symbols/water_park.svg');
     marker-placement: interior;
-    marker-fill: @amenity-brown;
+    marker-fill: @leisure-green;
     marker-clip: false;
   }
 
   [feature = 'leisure_dog_park'][zoom >= 17] {
     marker-file: url('symbols/shop/pet.svg');
     marker-placement: interior;
-    marker-fill: @amenity-brown;
+    marker-fill: @leisure-green;
     marker-clip: false;
   }
 
   [feature = 'leisure_playground'][zoom >= 17] {
     marker-file: url('symbols/playground.svg');
-    marker-fill: @amenity-brown;
+    marker-fill: @leisure-green;
     marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
@@ -877,14 +878,14 @@
 
   [feature = 'leisure_miniature_golf'][zoom >= 17] {
     marker-file: url('symbols/miniature_golf.svg');
-    marker-fill: darken(@park, 60%);
+    marker-fill: @leisure-green;
     point-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'leisure_golf_course'][zoom >= 15] {
     marker-file: url('symbols/golf.svg');
-    marker-fill: darken(@park, 60%);
+    marker-fill: @leisure-green;
     point-placement: interior;
     marker-clip: false;
   }
@@ -1314,7 +1315,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: darken(@park, 60%);
+    text-fill: @leisure-green;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
@@ -1331,7 +1332,7 @@
       text-size: @standard-font-size;
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
-      text-fill: darken(@park, 60%);
+      text-fill: @leisure-green;
       text-dy: 11;
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
@@ -1376,7 +1377,7 @@
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
       text-dy: 13;
-      text-fill: darken(@park, 60%);
+      text-fill: @leisure-green;
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
@@ -1560,7 +1561,7 @@
       [feature = 'landuse_village_green'],
       [feature = 'leisure_common'],
       [feature = 'leisure_garden'] {
-        text-fill: darken(@park, 60%);
+        text-fill: @leisure-green;
       }
       [feature = 'landuse_quarry'] {
         text-fill: darken(@quarry, 60%);
@@ -1645,7 +1646,7 @@
         text-fill: darken(@stadium, 70%);
       }
       [feature = 'leisure_dog_park'] {
-        text-fill: darken(@park, 60%);
+        text-fill: @leisure-green;
         text-halo-radius: @standard-halo-radius * 1.5; /* Extra halo needed to stand out from paw pattern. */
         text-halo-fill: @standard-halo-fill;
       }


### PR DESCRIPTION
Follow up to #2824.

This is a bit more complex PR, because it's not only about making another POI color group sharing the same variable name, but it's also icon/label unification, fixing part of the problem described in #1355, #1794 and https://github.com/gravitystorm/openstreetmap-carto/pull/2268#issuecomment-237856186.

While amenity brown is overused, leisure-green (dark leisure-related color) is underused currently. It's used for many labels and only for some icons - namely both golf-related ones. I have changed the color of playground, water park and dog park icons to match their label color (leisure-green). I have not tried to match zoom levels for labels and icons nor was I touching other aspects of text.

Here's the result:

Before
![j3rpg8cz](https://user-images.githubusercontent.com/5439713/30299121-8c80af1a-974e-11e7-9cc9-e7e9c078673f.png)
After
![jjedkrhr](https://user-images.githubusercontent.com/5439713/30299115-866c3158-974e-11e7-9725-0b3fe7ed9bf1.png)

Before
![5fompwzs](https://user-images.githubusercontent.com/5439713/30299103-7da2818a-974e-11e7-8034-bd233d334f63.png)
After
![xv4wizp0](https://user-images.githubusercontent.com/5439713/30299098-784f77ec-974e-11e7-8783-3d6c991131cf.png)

Before
![ls6ekttu](https://user-images.githubusercontent.com/5439713/30300027-cc52cb7e-9752-11e7-8200-a90afc85cf62.png)
After
![wbnhknzu](https://user-images.githubusercontent.com/5439713/30300033-d071af18-9752-11e7-9adc-0328e697fe13.png)