### PR TITLE
Adding rendering for boundary=protected_area [WIP]

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1391,7 +1391,8 @@
   [feature = 'natural_wood'],
   [feature = 'landuse_forest'],
   [feature = 'boundary_national_park'],
-  [feature = 'leisure_nature_reserve'] {
+  [feature = 'leisure_nature_reserve'],
+  [feature = 'boundary_protected_area'] {
     [zoom >= 8][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17] {
       text-name: "[name]";
@@ -1420,7 +1421,8 @@
         text-fill: @forest-text;
       }
       [feature = 'boundary_national_park'],
-      [feature = 'leisure_nature_reserve'] {
+      [feature = 'leisure_nature_reserve'],
+      [feature = 'boundary_protected_area'] {
         text-fill: darken(@park, 70%);
       }
     }

--- a/project.mml
+++ b/project.mml
@@ -1157,7 +1157,7 @@ Layer:
             boundary,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')
+          WHERE (boundary = 'national_park' OR leisure = 'nature_reserve' OR boundary = 'protected_area')
             AND building IS NULL
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
         ) AS national_park_boundaries
@@ -1871,7 +1871,7 @@ Layer:
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
-              'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
+              'boundary_' || CASE WHEN boundary IN ('national_park', 'protected_area') THEN boundary ELSE NULL END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
             ) AS feature,
             name,
@@ -1880,7 +1880,7 @@ Layer:
           WHERE (landuse IN ('forest', 'military', 'farmland')
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')
               OR "place" IN ('island')
-              OR boundary IN ('national_park')
+              OR boundary IN ('national_park', 'protected_area')
               OR leisure IN ('nature_reserve'))
             AND building IS NULL
             AND name IS NOT NULL
@@ -1939,7 +1939,7 @@ Layer:
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
               'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
-              'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
+              'boundary_' || CASE WHEN boundary IN ('national_park', 'protected_area') THEN boundary ELSE NULL END,
               'waterway_' || CASE WHEN waterway IN ('dam', 'dock') THEN waterway ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END
             ) AS feature,
@@ -1968,7 +1968,7 @@ Layer:
               OR tags->'memorial' IN ('plaque')
               OR highway IN ('services', 'rest_area', 'bus_stop', 'elevator')
               OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
-              OR boundary IN ('national_park')
+              OR boundary IN ('national_park', 'protected_area')
               OR waterway IN ('dam', 'dock'))
             AND (name IS NOT NULL
                  OR (ref IS NOT NULL AND aeroway IN ('gate'))
@@ -2072,7 +2072,7 @@ Layer:
                                  THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                                  ELSE NULL END,
                   'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
-                  'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
+                  'boundary_' || CASE WHEN boundary IN ('national_park', 'protected_area') THEN boundary ELSE NULL END,
                   'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
                   'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
                   'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
@@ -2114,7 +2114,7 @@ Layer:
                   OR tags->'memorial' IN ('plaque')
                   OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator')
                   OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
-                  OR boundary IN ('national_park')
+                  OR boundary IN ('national_park', 'protected_area')
                   OR waterway IN ('dam', 'weir', 'dock'))
                 AND (name IS NOT NULL
                      OR (tags?'ele' AND ("natural" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter'))
@@ -2247,7 +2247,7 @@ Layer:
             name,
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')
+          WHERE (boundary = 'national_park' OR leisure = 'nature_reserve' OR boundary = 'protected_area')
             AND name IS NOT NULL
         ) AS nature_reserve_text
     properties:


### PR DESCRIPTION
Resolves #603.

This code is currently quite simple (rendering protected_area the same as national parks and nature reserves), but it needs to be enhanced to render only those with `protect_class=1-7,97` (as I understand the outcome of the discussion) and I don't know yet how to write such query, so help would be welcome.

Just a proof that it [really works](https://www.openstreetmap.org/way/199324293) (nothing fancy or new about the rendering):
Before
![i9rc68al](https://user-images.githubusercontent.com/5439713/30382899-af271218-98a0-11e7-84ad-93cbd9d5efde.png)
After
![a8wbjmsy](https://user-images.githubusercontent.com/5439713/30382800-6c279a8c-98a0-11e7-9aaf-47b7115f9161.png)