### PR TITLE
Drop halo from ferry labels

### DIFF
--- a/ferry-routes.mss
+++ b/ferry-routes.mss
@@ -25,8 +25,6 @@
     text-fill: @ferry-route-text;
     text-spacing: 1000;
     text-size: 10;
-    text-halo-radius: @standard-halo-radius;
-    text-halo-fill: @standard-halo-fill;
     text-dy: -8;
   }
 }


### PR DESCRIPTION
This makes the labels look more similar in color to the lines they belong.

Before:
<img width="71" alt="screen shot 2017-09-14 at 21 04 01" src="https://user-images.githubusercontent.com/5251909/30449843-92ab92bc-9990-11e7-9db3-a58f86bf2393.png">

After:
<img width="110" alt="screen shot 2017-09-14 at 21 00 59" src="https://user-images.githubusercontent.com/5251909/30449891-a9007f46-9990-11e7-9b2d-1fc6564bef0b.png">

With the new water color, contrast should be strong enough anyway.