### PR TITLE
Move lighthouse icon and label to man-made color

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -936,7 +936,7 @@
     marker-file: url('symbols/lighthouse.svg');
     marker-placement: interior;
     marker-clip: false;
-    marker-fill: @transportation-icon;
+    marker-fill: @man-made-icon;
   }
 
   [feature = 'natural_peak'][zoom >= 11] {
@@ -1829,7 +1829,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @transportation-text;
+    text-fill: @man-made-icon;
     text-dy: 16;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;


### PR DESCRIPTION
Lighthouses are currently rendered in transportation-blue.

After:
<img width="76" alt="screen shot 2017-09-14 at 21 32 39" src="https://user-images.githubusercontent.com/5251909/30452376-c61bfd4e-9995-11e7-861f-33f5bbd164a3.png">
