### PR TITLE
Make regional admin borders solid instead of dashed

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -65,19 +65,19 @@ overlapping borders correctly.
       line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
-      line-dasharray: 4,3;
       line-clip: false;
     }
     [zoom >= 5] {
+      background/line-width: 0.5;
+      line-width: 0.5;
+    }
+    [zoom >= 6] {
       background/line-width: 0.6;
       line-width: 0.6;
     }
-    [zoom >= 6] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-    }
     [zoom >= 7] {
       background/line-width: 1;
+      line-dasharray: 4,3;
       line-width: 1;
     }
     [zoom >= 9] {


### PR DESCRIPTION
Due to the coastline paradox, dashed lines for borders don't work
well on low-zoom: strongly curved borders appear solid instead of
dashed. Also, solid dashes generally are too busy for the crowded
z5-7.

This PR makes regional boundaries (admin_level=4) solid instead of
dashed up to z9.

To prevent the borders from getting too strong, they are also made
thinner.

Before/after:

z4:
<img width="205" alt="screen shot 2017-09-14 at 23 40 26" src="https://user-images.githubusercontent.com/5251909/30457142-9996b136-99a6-11e7-9e5e-4389b51b36a0.png"> <img width="205" alt="screen shot 2017-09-14 at 23 40 03" src="https://user-images.githubusercontent.com/5251909/30457139-99907d84-99a6-11e7-8a84-bd86714bb247.png">

z5:
<img width="281" alt="screen shot 2017-09-14 at 23 40 57" src="https://user-images.githubusercontent.com/5251909/30457143-999889e8-99a6-11e7-88c3-2729658c7e99.png"> <img width="283" alt="screen shot 2017-09-14 at 23 41 18" src="https://user-images.githubusercontent.com/5251909/30457144-999ab40c-99a6-11e7-83fb-0b04c5da6eb6.png">

z6:
<img width="193" alt="screen shot 2017-09-14 at 23 41 41" src="https://user-images.githubusercontent.com/5251909/30457140-99959fda-99a6-11e7-81a2-0a066deda413.png"> <img width="215" alt="screen shot 2017-09-14 at 23 41 31" src="https://user-images.githubusercontent.com/5251909/30457141-999686fc-99a6-11e7-9cde-cab65b220e6d.png">

z7:
<img width="303" alt="screen shot 2017-09-14 at 23 42 19" src="https://user-images.githubusercontent.com/5251909/30457149-99b58750-99a6-11e7-82ca-7df08649f65b.png"> <img width="297" alt="screen shot 2017-09-14 at 23 42 10" src="https://user-images.githubusercontent.com/5251909/30457145-99aa66b8-99a6-11e7-9d62-8cd832be45d0.png">

z8:
<img width="344" alt="screen shot 2017-09-14 at 23 42 46" src="https://user-images.githubusercontent.com/5251909/30457147-99b04d12-99a6-11e7-84f3-41c8ec969cae.png"> <img width="310" alt="screen shot 2017-09-14 at 23 42 39" src="https://user-images.githubusercontent.com/5251909/30457146-99ad7d1c-99a6-11e7-996a-ffea2035e091.png">

z9:
<img width="362" alt="screen shot 2017-09-14 at 23 43 00" src="https://user-images.githubusercontent.com/5251909/30457150-99bb4e1a-99a6-11e7-8efe-af78a9375b7b.png"> <img width="363" alt="screen shot 2017-09-14 at 23 42 54" src="https://user-images.githubusercontent.com/5251909/30457148-99b26bd8-99a6-11e7-914c-e5e5500ba903.png">

