### PR TITLE
Hide tiny zoos and theme parks

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -755,8 +755,10 @@
 }
 
 #tourism-boundary {
-  [tourism = 'zoo'][zoom >= 10][way_pixels >= 20],
-  [tourism = 'theme_park'][zoom >= 10][way_pixels >= 20] {
+  [tourism = 'zoo'][zoom >= 10][way_pixels >= 750],
+  [tourism = 'zoo'][zoom >= 17],
+  [tourism = 'theme_park'][zoom >= 10][way_pixels >= 750],
+  [tourism = 'theme_park'][zoom >= 17] {
     a/line-width: 1;
     a/line-offset: -0.5;
     a/line-color: @tourism;


### PR DESCRIPTION
This starts showing zoos and theme parks from one zoomlevel before
they are large enough to get a name.

Example of theme parks of the size that will disappear now:

<img width="171" alt="screen shot 2017-09-15 at 00 50 52" src="https://user-images.githubusercontent.com/5251909/30459296-1ae3559c-99b0-11e7-9b1b-6ce62bfe9419.png">
<img width="77" alt="screen shot 2017-09-15 at 00 51 22" src="https://user-images.githubusercontent.com/5251909/30459293-17bddbd0-99b0-11e7-9806-21dff3b85348.png">
