### PR TITLE
Move aeroways to their own layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -440,9 +440,8 @@ Layer:
     <<: *extents
     Datasource:
       <<: *osm2pgsql
-      # This query is quite large, having to deal with both roads, railways and
-      # runways. To allow for ways that are both railways and roads, a UNION
-      # ALL is present.
+      # This query is quite large, having to deal with both roads, railways. To
+      # allow for ways that are both railways and roads, a UNION ALL is present.
       table: |-
         (SELECT
             way,
@@ -457,7 +456,7 @@ Layer:
             service,
             link,
             layernotnull
-          FROM ( -- subselect that contains both roads and rail/aero
+          FROM ( -- subselect that contains both roads and rail
             SELECT
                 way,
                 ('highway_' || highway) AS feature, --only motorway to tertiary links are accepted later on
@@ -492,11 +491,9 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                COALESCE(
-                  ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
                                        WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),
-                  ('aeroway_' || aeroway)
+                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)
                 ) AS feature,
                 horse,
                 foot,
@@ -515,12 +512,12 @@ Layer:
                 z_order
               FROM planet_osm_line
               WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
-                AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select
+                AND railway IS NOT NULL -- end of rail select
             ) AS features
           ORDER BY
             layernotnull,
             z_order,
-            CASE WHEN substring(feature for 8) = 'aeroway_' THEN 0 WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
@@ -713,11 +710,9 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                COALESCE(
-                  ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
                                        WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),
-                  ('aeroway_' || aeroway)
+                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)
                 ) AS feature,
                 horse,
                 foot,
@@ -738,12 +733,12 @@ Layer:
               WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))
                 AND (covered IS NULL OR NOT covered = 'yes')
                 AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))
-                AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select
+                AND railway IS NOT NULL -- end of rail select
             ) AS features
           ORDER BY
             layernotnull,
             z_order,
-            CASE WHEN substring(feature for 8) = 'aeroway_' THEN 0 WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
@@ -833,11 +828,9 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                COALESCE(
-                  ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
                                        WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),
-                  ('aeroway_' || aeroway)
+                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)
                 ) AS feature,
                 horse,
                 foot,
@@ -858,12 +851,12 @@ Layer:
               WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))
                 AND (covered IS NULL OR NOT covered = 'yes')
                 AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))
-                AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select
+                AND railway IS NOT NULL -- end of rail select
             ) AS features
           ORDER BY
             layernotnull,
             z_order,
-            CASE WHEN substring(feature for 8) = 'aeroway_' THEN 0 WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
@@ -1019,11 +1012,9 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                COALESCE(
-                  ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
                                        WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)),
-                  ('aeroway_' || aeroway)
+                                       WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END)
                 ) AS feature,
                 horse,
                 foot,
@@ -1042,12 +1033,12 @@ Layer:
                 z_order
               FROM planet_osm_line
               WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')
-                AND (railway IS NOT NULL OR aeroway IS NOT NULL) -- end of rail/aero select
+                AND railway IS NOT NULL -- end of rail select
             ) AS features
           ORDER BY
             layernotnull,
             z_order,
-            CASE WHEN substring(feature for 8) = 'aeroway_' THEN 0 WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
@@ -1068,6 +1059,23 @@ Layer:
         ) AS guideways
     properties:
       minzoom: 13
+  - id: aeroways
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aeroway,
+            bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct') AS bridge
+          FROM planet_osm_line
+          WHERE aeroway IN ('runway', 'taxiway')
+          ORDER BY bridge NULLS FIRST,
+            CASE WHEN aeroway = 'runway' THEN 10 ELSE 0 END
+        ) AS aeroways
+    properties:
+      minzoom: 11
   - id: admin-low-zoom
     geometry: linestring
     <<: *extents

--- a/roads.mss
+++ b/roads.mss
@@ -785,28 +785,6 @@
       }
     }
 
-    [feature = 'aeroway_runway'] {
-      .bridges-casing {
-        [zoom >= 14] {
-          line-width: 13;
-          [zoom >= 15] { line-width: 19; }
-          [zoom >= 16] { line-width: 25; }
-          line-color: @bridge-casing;
-          line-join: round;
-        }
-      }
-    }
-
-    [feature = 'aeroway_taxiway'] {
-      .bridges-casing {
-        [zoom >= 14] {
-          line-width: 5;
-          line-color: @bridge-casing;
-          line-join: round;
-          [zoom >= 15] { line-width: 7; }
-        }
-      }
-    }
   }
 
   ::bridges_and_tunnels_background {
@@ -2082,29 +2060,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line-color: #999;
       }
     }
-
-    [feature = 'aeroway_runway'] {
-      [zoom >= 11] {
-        line-color: @runway-fill;
-        line-width: 2;
-        [zoom >= 12] { line-width: 4; }
-        [zoom >= 13] { line-width: 6; }
-        [zoom >= 14] { line-width: 12; }
-        [zoom >= 15] { line-width: 18; }
-        [zoom >= 16] { line-width: 24; }
-      }
-    }
-
-    [feature = 'aeroway_taxiway'] {
-      [zoom >= 11] {
-        line-color: @taxiway-fill;
-        line-width: 1;
-        [zoom >= 13] { line-width: 2; }
-        [zoom >= 14] { line-width: 4; }
-        [zoom >= 15] { line-width: 6; }
-        [zoom >= 16] { line-width: 8; }
-      }
-    }
   }
 }
 
@@ -2637,6 +2592,52 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
   [zoom >= 14] {
     b/line-dasharray: 0,11,8,1;
+  }
+}
+
+#aeroways {
+  [aeroway = 'runway'] {
+    [zoom >= 11] {
+      ::casing[bridge = true][zoom >= 14] {
+        line-width: 12 + 2*@major-casing-width-z14;
+        line-color: @bridge-casing;
+        line-join: round;
+        [zoom >= 15] { line-width: 18 + 2*@major-casing-width-z15; }
+        [zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }
+        [zoom >= 17] { line-width: 24 + 2*@major-casing-width-z17; }
+        [zoom >= 18] { line-width: 24 + 2*@major-casing-width-z18; }
+      }
+      ::fill {
+        line-color: @runway-fill;
+        line-width: 2;
+        [zoom >= 12] { line-width: 4; }
+        [zoom >= 13] { line-width: 6; }
+        [zoom >= 14] { line-width: 12; }
+        [zoom >= 15] { line-width: 18; }
+        [zoom >= 16] { line-width: 24; }
+      }
+    }
+  }
+  [aeroway = 'taxiway'] {
+    [zoom >= 11] {
+      ::casing[bridge = true][zoom >= 14] {
+        line-width: 4 + 2*@secondary-casing-width-z14;
+        line-color: @bridge-casing;
+        line-join: round;
+        [zoom >= 15] { line-width: 6 + 2*@secondary-casing-width-z15; }
+        [zoom >= 16] { line-width: 8 + 2*@secondary-casing-width-z16; }
+        [zoom >= 17] { line-width: 8 + 2*@secondary-casing-width-z17; }
+        [zoom >= 18] { line-width: 8 + 2*@secondary-casing-width-z18; }
+      }
+      ::fill {
+        line-color: @taxiway-fill ;
+        line-width: 1;
+        [zoom >= 13] { line-width: 2; }
+        [zoom >= 14] { line-width: 4; }
+        [zoom >= 15] { line-width: 6; }
+        [zoom >= 16] { line-width: 8; }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
More progress on #2046. The cartographic changes are minimal and involve some strange real-world situations.

This is done as part of road layer simplification, but also fixes a few layering bugs showing up where there are aeroway bridges, and some casing width problems with invisible bridges.

There are no changes to the typical airport

![image](https://user-images.githubusercontent.com/1190866/30516984-52cde99a-9b04-11e7-9c45-8b86d1bce8cf.png)
(left v4.2.0 on osmf servers, right this PR)

The weirder situations are bridges
![image](https://user-images.githubusercontent.com/1190866/30516999-e0313ac6-9b04-11e7-9f38-85be5691d7cf.png)
17/47.92228/-122.27635

![image](https://user-images.githubusercontent.com/1190866/30517016-2dd765fc-9b05-11e7-880c-d1f26f6c835f.png)
16/33.6224/-84.4291

Where there is a road crossing a runway (e.g. Gibralter) the runway will remain rendered on top of the road.

There is one case of a runway tagged as a tunnel in OSM where the runway goes through a mountain [in North Korea](http://www.openstreetmap.org/#map=14/39.0937/127.4091), and that case will remain unhandled and rendered like a normal runway.

The current rendering has bugs with bridge casing widths for aeroways, and these are fixed by using the same road casing constructions as highways.

The code changes are worth explaining, because they're the real reason for this PR

- Aeroways are a special case of roads where we assume they're always on top of any roads (layer-wise). This assumption combined with the z_order rendering them on top means they can be their own layer. Most styles wouldn't bother with aeroway bridges

- Fixing the casing width bugs brought up the MSS code length, otherwise it would be shorter. Because a lot of the new code is repetitive line-width stuff (e.g. `[zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }`) I find it simpler

- Using an attachment is a technique I [mentioned in 2016](https://github.com/gravitystorm/openstreetmap-carto/issues/2046#issuecomment-205492887) and is a better solution than duplicate layers for ground level and bridges.

tl;dr: Moves aeroways to their own layers, modernizes aeroway code, fixes aeroway bridge bugs.

