### PR TITLE
Minor release instruction fixes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,7 +50,7 @@ For a full list of commits, see
 https://github.com/gravitystorm/openstreetmap-carto/compare/$OLD_VERSION...$NEW_VERSION
 
 As always, we welcome any bug reports at
-https://github.com/gravitystorm/openstreetmap-carto/issues.
+https://github.com/gravitystorm/openstreetmap-carto/issues
 ```
 
 3. Post an [openstreetmap.org diary entry](http://www.openstreetmap.org/diary/new) with the text from the email. Add links and other markdown if needed.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@ Decide among the maintainers if a new release is due.
 2. Change the Unreleased section in [`CHANGELOG.md`](CHANGELOG.md) to the new version. Add any changes that are missing from the changelog and a new Unreleased section.
 3. Commit the changelog changes and tag a release with `git tag -a $NEW_VERSION -m "Tag $NEW_VERSION"`. *Optional: Add `-s` and GPG sign the tag.*
 4. Push the tag with `git push origin $NEW_VERSION`. If you use a different name for the gravitystorm/openstreetmap-carto remote, use it instead.
-5. If there are any long-running development branches (e.g. `lua`) check them out and merge the new release with `git merge $NEW_RELEASE`.
+5. If there are any long-running development branches check them out and merge the new release with `git merge $NEW_RELEASE`.
 
 # Notifications
 


### PR DESCRIPTION
Fix a trailing `.` and reference to a branch we're no longer using.