### PR TITLE
Improving water labels [WIP]

### DIFF
--- a/water.mss
+++ b/water.mss
@@ -244,8 +244,6 @@
       text-fill: @water-text;
       text-spacing: 400;
       text-size: 10;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
       [zoom >= 14] { text-size: 12; }
       [int_tunnel = 'yes'] { text-min-distance: 200; }
     }
@@ -253,8 +251,6 @@
     [waterway = 'canal'][zoom >= 13][zoom < 14] {
       text-name: "[name]";
       text-face-name: @oblique-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
       text-size: 10;
       text-placement: line;
       text-fill: @water-text;
@@ -265,8 +261,6 @@
       text-size: 10;
       text-face-name: @oblique-fonts;
       text-fill: @water-text;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
       text-spacing: 600;
       text-placement: line;
       text-vertical-alignment: middle;
@@ -282,8 +276,6 @@
         text-fill: @water-text;
         text-spacing: 600;
         text-placement: line;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
       }
     }
 
@@ -293,8 +285,6 @@
       text-fill: @water-text;
       text-placement: line;
       text-face-name: @oblique-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
     }
 
     [waterway = 'derelict_canal'][zoom >= 13] {
@@ -304,8 +294,6 @@
       text-face-name: @oblique-fonts;
       text-placement: line;
       text-spacing: 600;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
       [zoom >= 14] {
         text-size: 12;
       }
@@ -341,8 +329,6 @@
       }
       text-fill: @water-text;
       text-face-name: @oblique-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
       text-placement: interior;
     }
   }


### PR DESCRIPTION
Follow up to #2832.

Just dropping halo from all the water labels to make them more readable.

[Testing place](http://www.openstreetmap.org/#map=16/54.4055/18.6703) with different water labels (ferry lines halo is already dropped):

Before
![q zwquhd](https://user-images.githubusercontent.com/5439713/30465984-eddee20c-99da-11e7-9ad5-918672bff446.png)
After
![xr56yawa](https://user-images.githubusercontent.com/5439713/30466016-20c47150-99db-11e7-9d15-fb186d5576f7.png)

@rrzefox Could you deploy a current code with this patch on your server? This would be a massive change for a water features, so it needs worldwide testing.