### PR TITLE
Rendering natural=bare_rock earlier

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2030,7 +2030,7 @@
 
   [feature = 'natural_scree'][zoom >= 9],
   [feature = 'natural_shingle'][zoom >= 9],
-  [feature = 'natural_bare_rock'][zoom >= 9],
+  [feature = 'natural_bare_rock'],
   [feature = 'natural_sand'] {
     [zoom >= 8][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17][is_building = 'no'] {

--- a/landcover.mss
+++ b/landcover.mss
@@ -440,14 +440,16 @@
     }
   }
 
-  [feature = 'natural_bare_rock'][zoom >= 9] {
+  [feature = 'natural_bare_rock'][zoom >= 8] {
     polygon-fill: @bare_ground;
-    [way_pixels >= 4]  { polygon-gamma: 0.75; }
-    [way_pixels >= 64] { polygon-gamma: 0.3;  }
-    [zoom >= 13] {
-      polygon-pattern-file: url('symbols/rock_overlay.png');
-      [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
-      [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
+    polygon-pattern-file: url('symbols/rock_overlay.png');
+    [way_pixels >= 4] {
+      polygon-gamma: 0.75;
+      polygon-pattern-gamma: 0.75;
+    }
+    [way_pixels >= 64] {
+      polygon-gamma: 0.3;
+      polygon-pattern-gamma: 0.3;
     }
   }
 


### PR DESCRIPTION
The area of a bare rock can be substantial - and lack of overlay pattern doesn't help to recognize what it is.

[Area in Libya](http://www.openstreetmap.org/way/138017567)

z8
Before
![hgoab9nm](https://user-images.githubusercontent.com/5439713/30568173-0f267e10-9cd4-11e7-9bf9-ed49074728fa.png)
After
![nlzevzxd](https://user-images.githubusercontent.com/5439713/30568149-f482e06c-9cd3-11e7-9edd-0fa17c2fe866.png)

z9
Before
![vbapdvya](https://user-images.githubusercontent.com/5439713/30568211-3759273e-9cd4-11e7-8fde-77e346e55940.png)
After
![nub8piae](https://user-images.githubusercontent.com/5439713/30568232-553924fc-9cd4-11e7-9443-7f4f58501a4c.png)