### PR TITLE
Start showing water labels earlier

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1879,7 +1879,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
-              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END,
+              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
@@ -1888,7 +1888,7 @@ Layer:
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')
-              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water')
               OR "place" IN ('island')
               OR boundary IN ('national_park')
               OR leisure IN ('nature_reserve'))
@@ -1897,7 +1897,7 @@ Layer:
           ORDER BY way_area DESC
         ) AS text_poly_low_zoom
     properties:
-      minzoom: 7
+      minzoom: 6
       maxzoom: 9
   - id: text-poly
     class: text

--- a/water.mss
+++ b/water.mss
@@ -313,12 +313,13 @@
   }
 }
 
+.text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
   [feature = 'natural_water'],
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
-    [zoom >= 10][way_pixels > 3000],
+    [zoom >= 6][way_pixels > 3000],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;


### PR DESCRIPTION
Resolves  #2847.

<s>Current code is incomplete, there is something missing to show labels from `text-poly-low-zoom` layer.</s>

Water labels are safe to render earlier, because they already have to be big (at least 3000 px), so they could start showing along with water areas. This is in general to fix biggest lakes missing labels until zooming into them, as shown on the issue ticket:

[Great Lakes](http://www.openstreetmap.org/relation/1124369#map=6/44.762/-81.354)
z6
![qmhcdcpp](https://user-images.githubusercontent.com/5439713/30744191-3c685522-9fa1-11e7-93a6-a1b406fde2c9.png)

However other big lakes would be better this way, especially where there are no other interesting things around (labels in red just for testing):

[Lake Segozero area](https://www.openstreetmap.org/#map=9/63.4836/33.3971)
z9
![9ro48zp0](https://user-images.githubusercontent.com/5439713/30786541-dc51fe94-a177-11e7-9e2c-59029ab808fd.png)

There can be also some other big water areas, which would benefit from this change, like water=reservoir:

[Rybinsk Reservoir](http://www.openstreetmap.org/relation/1521563)
z9
![fscgwjq8](https://user-images.githubusercontent.com/5439713/30786459-42b3a2f2-a176-11e7-8640-70a2ee8e9f61.png)
