### PR TITLE
Showing all stations as major buildings

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -23,7 +23,9 @@
   [zoom >= 13] {
     [aeroway = 'terminal'],
     [amenity = 'place_of_worship'],
-    [building = 'train_station'] {
+    [building = 'train_station'],
+    [aerialway = 'station'],
+    [public_transport = 'station'] {
       polygon-fill: @building-major-fill;
       polygon-clip: false;
       [zoom >= 15] {

--- a/project.mml
+++ b/project.mml
@@ -409,6 +409,8 @@ Layer:
             AND (aeroway IS NULL OR aeroway != 'terminal')
             AND (amenity IS NULL OR amenity != 'place_of_worship')
             AND building != 'train_station'
+            AND (aerialway IS NULL OR aerialway != 'station')
+            AND (tags->'public_transport' IS NULL OR tags->'public_transport' != 'station')
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS buildings
@@ -424,11 +426,17 @@ Layer:
             way,
             building,
             amenity,
-            aeroway
+            aeroway,
+            aerialway,
+            tags->'public_transport' as public_transport
           FROM planet_osm_polygon
           WHERE building IS NOT NULL
             AND building != 'no'
-            AND (aeroway = 'terminal' OR amenity = 'place_of_worship' OR building = 'train_station')
+            AND (aeroway = 'terminal'
+                 OR amenity = 'place_of_worship'
+                 OR building = 'train_station'
+                 OR aerialway = 'station'
+                 OR tags->'public_transport' = 'station')
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC)
         AS buildings_major


### PR DESCRIPTION
Part of a transport unification effort, related to #2094 and #2763.

We have no unified solution for transportation areas in practice, but they all can have station/terminal. I'd like to make them all look similar, because for the passengers this is the most important building on such area, no matter what kind of transport is involved.

[Example aerial station](http://www.openstreetmap.org/way/267743094)
z18
Before
![y2s5btt0](https://user-images.githubusercontent.com/5439713/30840863-00b16380-a27a-11e7-8679-0a7b947198be.png)
After
![u9zyqxjn](https://user-images.githubusercontent.com/5439713/30840868-04dfe742-a27a-11e7-9d06-e1ff3a5d0997.png)

[Example public transport station](http://www.openstreetmap.org/way/97985328)
z18
Before
![l53umamo](https://user-images.githubusercontent.com/5439713/30840905-1f03b5d6-a27a-11e7-8ee5-f038887b1845.png)
After
![yzn2ezlr](https://user-images.githubusercontent.com/5439713/30840911-282d408c-a27a-11e7-81ae-88c60b002edd.png)