### PR TITLE
Start showing water areas from z0

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -237,11 +237,11 @@ Layer:
               OR landuse IN ('reservoir', 'basin')
               OR "natural" IN ('water', 'glacier'))
             AND building IS NULL
-            AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS water_areas
     properties:
-      minzoom: 4
+      minzoom: 0
   - id: landcover-area-symbols
     geometry: polygon
     <<: *extents
@@ -1879,7 +1879,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
-              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END,
+              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
@@ -1888,7 +1888,7 @@ Layer:
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')
-              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water')
               OR "place" IN ('island')
               OR boundary IN ('national_park')
               OR leisure IN ('nature_reserve'))
@@ -1897,7 +1897,7 @@ Layer:
           ORDER BY way_area DESC
         ) AS text_poly_low_zoom
     properties:
-      minzoom: 7
+      minzoom: 0
       maxzoom: 9
   - id: text-poly
     class: text

--- a/water.mss
+++ b/water.mss
@@ -43,7 +43,7 @@
   [natural = 'water']::natural,
   [landuse = 'reservoir']::landuse,
   [waterway = 'riverbank']::waterway {
-    [zoom >= 6] {
+    [zoom >= 0] {
       polygon-fill: @water-color;
       [way_pixels >= 4] {
         polygon-gamma: 0.75;
@@ -313,12 +313,13 @@
   }
 }
 
+.text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
   [feature = 'natural_water'],
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
-    [zoom >= 10][way_pixels > 3000],
+    [zoom >= 0][way_pixels > 3000],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;


### PR DESCRIPTION
Resolves #1604.
Closes #2864.

Test shows that changing pixel query factor from 0.01 to 1 probably does not make visual difference (or the change is subtle), but improves performance a lot and we can reasonably render all the water areas from z0. For details see discussion in #1604.

Only water layer:
![no-subpixel-select-biglakes-z6](https://user-images.githubusercontent.com/5439713/30996741-38c1454c-a4c3-11e7-9a85-671fea91b6a9.png)