### PR TITLE
Dropping subpixel accuracy for areas

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -25,18 +25,21 @@ CREATE INDEX planet_osm_polygon_water
   WHERE waterway IN ('dock', 'riverbank', 'canal')
     OR landuse IN ('reservoir', 'basin')
     OR "natural" IN ('water', 'glacier');
-CREATE INDEX planet_osm_polygon_military
-  ON planet_osm_polygon USING GIST (way)
-  WHERE landuse = 'military';
 CREATE INDEX planet_osm_polygon_nobuilding
   ON planet_osm_polygon USING GIST (way)
   WHERE building IS NULL;
 CREATE INDEX planet_osm_polygon_name
   ON planet_osm_polygon USING GIST (way)
   WHERE name IS NOT NULL;
+CREATE INDEX planet_osm_polygon_way_area_z10
+  ON planet_osm_polygon USING GIST (way)
+  WHERE way_area > 23300;
+CREATE INDEX planet_osm_polygon_military
+  ON planet_osm_polygon USING GIST (way)
+  WHERE landuse = 'military';
 CREATE INDEX planet_osm_polygon_way_area_z6
   ON planet_osm_polygon USING GIST (way)
-  WHERE way_area > 59750;
+  WHERE way_area > 5980000;
 CREATE INDEX planet_osm_point_place
   ON planet_osm_point USING GIST (way)
   WHERE place IS NOT NULL AND name IS NOT NULL;

--- a/indexes.yml
+++ b/indexes.yml
@@ -28,7 +28,9 @@ polygon:
           OR landuse IN ('reservoir', 'basin')
           OR "natural" IN ('water', 'glacier')
   way_area_z6:
-    where: way_area > 59750
+    where: way_area > 5980000
+  way_area_z10:
+    where: way_area > 23300
 roads:
   # The roads table only has a subset of data, so it's just got some low-zoom
   # indexes and some fairly selective ones for high zoom

--- a/project.mml
+++ b/project.mml
@@ -97,7 +97,7 @@ Layer:
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland'))
-              AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+              AND way_area > 1*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL
             ORDER BY way_area DESC
           ) AS features
@@ -152,7 +152,7 @@ Layer:
               OR tourism IN ('camp_site', 'caravan_site', 'picnic_site')
               OR highway IN ('services', 'rest_area')
               OR railway = 'station')
-              AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+              AND way_area > 1*!pixel_width!::real*!pixel_height!::real
             ORDER BY way_area DESC
           ) AS landcover
         ) AS features
@@ -265,7 +265,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE ("natural" IN ('marsh', 'mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub', 'sand') OR landuse = 'forest')
             AND building IS NULL
-            AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS landcover_area_symbols
     properties:
@@ -434,7 +434,7 @@ Layer:
             AND building != 'train_station'
             AND (aerialway IS NULL OR aerialway != 'station')
             AND ((tags->'public_transport') IS NULL OR tags->'public_transport' != 'station')
-            AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS buildings
     properties:
@@ -460,7 +460,7 @@ Layer:
                  OR building = 'train_station'
                  OR aerialway = 'station'
                  OR tags->'public_transport' = 'station')
-            AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC)
         AS buildings_major
     properties:
@@ -1371,7 +1371,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary = 'national_park' OR leisure = 'nature_reserve')
             AND building IS NULL
-            AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
         ) AS national_park_boundaries
     properties:
       minzoom: 8


### PR DESCRIPTION
Follow up to #2873.
Related to #1604.

It needs some testing, but it looks that dropping subpixel accuracy from SQL queries does not have visible effect on rendering - if any - while increasing performance (at least decreasing memory usage).

Affected objects: water, landcovers, buildings and nature reserves.