### PR TITLE
Better minimal distance between housenumbers

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -26,7 +26,6 @@
       }
     }
     text-placement: interior;
-    text-min-distance: 1;
     text-face-name: @book-fonts;
     text-fill: @address-color;
     text-halo-radius: @standard-halo-radius;
@@ -34,6 +33,7 @@
     text-size: 10;
     text-wrap-width: 30; // 3.0 em
     text-line-spacing: -1.5; // -0.15 em
+    text-margin: 3; // 0.3 em
     [zoom >= 18]["addr_unit" != null]["addr_housenumber" = null] {
       text-name: [addr_unit];
     }
@@ -41,6 +41,7 @@
         text-size: 11;
         text-wrap-width: 22; // 2.0 em
         text-line-spacing: -1.65; // -0.15 em
+        text-margin: 3.3; // 0.3 em
     }
   }
 }


### PR DESCRIPTION
Better minimal distance between housenumbers

The current distance is too small. Sometimes you cannot distinguish the individual housenumbers on est-west-roads (see bottom-right on the screenshot).

Before:
![z_1_before_screenshot 6](https://user-images.githubusercontent.com/6830724/31312695-c9378f44-abb9-11e7-84ef-897424bff21c.png)

After:
![z_3_after_screenshot 5](https://user-images.githubusercontent.com/6830724/31312697-ce84b454-abb9-11e7-8a2b-f164e6203c42.png)
