### PR TITLE
Use Noto Sans Arabic

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ Put these shapefiles at `path/to/openstreetmap-carto/data`.
 ## Fonts
 The stylesheet uses Noto, an openly licensed font family from Google with support for multiple scripts. The stylesheet uses Noto's "Sans" style where available. If not available, this stylesheet uses another appropriate style of the Noto family. The "UI" version is used where available, with its vertical metrics which fit better with Latin text.
 
-DejaVu Sans is used as an optional fallback font for systems without Noto Sans. If all the Noto fonts are installed, it should never be used.
+DejaVu Sans is used as an optional fallback font for systems without Noto Sans. If all the Noto fonts are installed, it should never be used. Noto Naskh Arabic UI is used an an optional fallback font for systems without Noto Sans Arabic.
 
 Hanazono is used a fallback for seldom used CJK characters that are not covered by Noto.
 
@@ -63,13 +63,13 @@ Unifont is used as a last resort fallback, with it's excellent coverage, common 
 
 ### Installation on Ubuntu/Debian
 
-On Ubuntu 16.04 or Debian Testing you can download and install the required fonts except Noto Emoji Regular with
+On Ubuntu 16.04 or Debian Testing you can download and install the required fonts except Noto Emoji Regular and Noto Sans Arabic UI Regular/Bold with
 
 ```
 sudo apt-get install fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted fonts-hanazono ttf-unifont
 ```
 
-Noto Emoji Regular can be downloaded [from the Noto Emoji repository](https://github.com/googlei18n/noto-emoji).
+Noto Emoji Regular can be downloaded [from the Noto Emoji repository](https://github.com/googlei18n/noto-emoji). Noto Sans Arabic UI Regular/Bold can be downloaded [from the Noto repository](https://github.com/googlei18n/noto-fonts).
 
 It might be useful to have a more recent version of the fonts for [rare non-latin scripts](#non-latin-scripts). This can be installed [from source](https://github.com/googlei18n/noto-fonts/blob/master/FAQ.md#where-are-the-fonts).
 

--- a/fonts.mss
+++ b/fonts.mss
@@ -25,7 +25,7 @@ but there are some exceptions
 
 2. Noto provides various variants of Arabic: Noto Kufi Arabic, Noto Naskh
 Arabic, Noto Nastaliq Urdu and Noto Sans Arabic. Kufi and Urdu styles are not
-widespread in use. Noto Sans Arabic (a Naskh-like low-contrast “Sans” font) and
+widespread in use. Noto Sans Arabic (a Naskh-style low-contrast “Sans” font) and
 Noto Naskh Arabic are the fonts with the greatest coverage and provide an UI
 variant. This style uses Noto Sans Arabic UI because it’s consistent with the
 other Sans fonts and legible. The Arabic fonts are placed behind Sans fonts
@@ -37,11 +37,12 @@ colour variant is a SVG flavoured OpenType font that contains coloured emojis.
 This is not useful in cartography, so we use the “normal” monochromatic
 Noto Emoji.
 
-4. The list still includes DejaVu for compatibility on systems without Noto.
-The list still includes Noto Naskh Arabic UI for compatibility on systems
+4. The list still includes Noto Naskh Arabic UI for compatibility on systems
 without Noto Sans Arabic UI.
 
-5. Fallback fonts. Hanazono covers almost all CJK characters, even in Unicode
+5. The list still includes DejaVu for compatibility on systems without Noto.
+
+6. Fallback fonts. Hanazono covers almost all CJK characters, even in Unicode
 Plane 2. Unifont is a fallback of last resort with full coverage in Plane 0
 (Unifont Medium), some coverage in Plane 1 (Unifont Upper Medium) and no
 coverage in Plane 2. Unifont Medium Sample would cover the BMP PUA with
@@ -116,7 +117,9 @@ A regular style.
 
                 "Noto Emoji Regular",
 
-                "DejaVu Sans Book", "Noto Naskh Arabic UI Regular",
+                "Noto Naskh Arabic UI Regular",
+
+                "DejaVu Sans Book",
 
                 "HanaMinA Regular", "HanaMinB Regular",
                 "Unifont Medium", "unifont Medium", "Unifont Upper Medium";
@@ -151,7 +154,9 @@ regular text and can be used for emphasis. Fallback is a regular style.
 
                 "Noto Sans Arabic UI Bold",
 
-                "DejaVu Sans Bold", "Noto Naskh Arabic UI Bold",
+                "Noto Naskh Arabic UI Bold",
+
+                "DejaVu Sans Bold",
 
                 @book-fonts;
 

--- a/fonts.mss
+++ b/fonts.mss
@@ -23,13 +23,14 @@ but there are some exceptions
     to Japanese. However, this choise stays somewhat arbitrary and subjective.
     See also https://github.com/gravitystorm/openstreetmap-carto/issues/2208)
 
-2. Noto provides three variants of Arabic: Noto Kufi Arabic, Noto Naskh Arabic
-and Noto Nastaliq Urdu. Naskh is the most commonly used style of Arabic.
-Furthermore, Noto Naskh is the Arabic font of the Noto family with the greatest
-coverage and the only one that has an UI variant. Therefor this style uses
-Noto Naskh Arabic UI. The Arabic fonts are placed behind Sans fonts because
-they might re-define some commonly used signs like parenthesis or quotation
-marks, and the arabic design should not overwrite the standard design.
+2. Noto provides various variants of Arabic: Noto Kufi Arabic, Noto Naskh
+Arabic, Noto Nastaliq Urdu and Noto Sans Arabic. Kufi and Urdu styles are not
+widespread in use. Noto Sans Arabic (a Naskh-like low-contrast “Sans” font) and
+Noto Naskh Arabic are the fonts with the greatest coverage and provide an UI
+variant. This style uses Noto Sans Arabic UI because it’s consistent with the
+other Sans fonts and legible. The Arabic fonts are placed behind Sans fonts
+because they might re-define some commonly used signs like parenthesis or
+quotation marks, and the arabic design should not overwrite the standard design.
 
 3. Noto provides two variants of Emoji: Noto Color Emoji and Noto Emoji. The
 colour variant is a SVG flavoured OpenType font that contains coloured emojis.
@@ -37,6 +38,8 @@ This is not useful in cartography, so we use the “normal” monochromatic
 Noto Emoji.
 
 4. The list still includes DejaVu for compatibility on systems without Noto.
+The list still includes Noto Naskh Arabic UI for compatibility on systems
+without Noto Sans Arabic UI.
 
 5. Fallback fonts. Hanazono covers almost all CJK characters, even in Unicode
 Plane 2. Unifont is a fallback of last resort with full coverage in Plane 0
@@ -109,11 +112,11 @@ A regular style.
                 "Noto Sans Vai Regular",
                 "Noto Sans Yi Regular",
 
-                "Noto Naskh Arabic UI Regular",
+                "Noto Sans Arabic UI Regular",
 
                 "Noto Emoji Regular",
 
-                "DejaVu Sans Book",
+                "DejaVu Sans Book", "Noto Naskh Arabic UI Regular",
 
                 "HanaMinA Regular", "HanaMinB Regular",
                 "Unifont Medium", "unifont Medium", "Unifont Upper Medium";
@@ -145,6 +148,11 @@ regular text and can be used for emphasis. Fallback is a regular style.
                 "Noto Sans Thaana Bold",
                 "Noto Sans Thai UI Bold",
                 "Noto Sans Tibetan Bold",
+
+                "Noto Sans Arabic UI Bold",
+
+                "DejaVu Sans Bold", "Noto Naskh Arabic UI Bold",
+
                 @book-fonts;
 
 /*


### PR DESCRIPTION
Use Noto Sans Arabic.

With the recent release of Noto, there is now a true “Sans” (=low constrast) arabic font available. It seems Naskh-like, but because it’s Sans, it fits much better with the rest of scripts and the styling is nevertheless Naskh-like. It is a little bigger with more spacing, what should improve legibility:

Before:
![screenshot 1](https://user-images.githubusercontent.com/6830724/31315162-518e4372-ac02-11e7-992c-1310736f2c57.png)

After:
![screenshot 2](https://user-images.githubusercontent.com/6830724/31315167-81c38980-ac02-11e7-8185-12cc18cfa6d5.png)

As this release is not yet available as Ubuntu package (and therefor OSM servers unlikely to provide it right now), the current Naskh style is kept as fallback.

This PR contains now also code for Bold variant of Arabic and fallback.