### PR TITLE
Show island and islet labels earlier

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1092,9 +1092,9 @@
 /* Note that .text is also used in water.mss */
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
-  [feature = 'place_island'][zoom >= 7][way_pixels > 3000][way_pixels < 800000],
+  [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels < 800000],
   [feature = 'place_island'][zoom >= 16][way_pixels < 800000],
-  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000][way_pixels < 800000],
+  [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels < 800000],
   [feature = 'place_islet'][zoom >= 17][way_pixels < 800000] {
     text-name: "[name]";
     text-fill: #000;


### PR DESCRIPTION
Resolves #1448.

Island names are currently rendered on z7+, but they should be rendered on z4+ (as early as possible, but not compete with country labels on z3) and islets also 3 zoom levels earlier.

@rrzefox: Could you test this patch on your server?

Nunavut (Canada) example

z4
Before
![screenshot-2017-10-14 openstreetmap carto kosmtik](https://user-images.githubusercontent.com/5439713/31573345-1e7aaf2c-b0ba-11e7-8dc7-5c594d989f99.png)
After
![screenshot-2017-10-14 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/31573348-24c4e1f4-b0ba-11e7-9cb5-d8a43dd358e9.png)