### PR TITLE
Introduce text-wrap for stations

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -37,7 +37,8 @@
       text-dy: 9;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
-      text-wrap-width: 0;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
       text-placement: interior;
     }
     [zoom >= 15] {
@@ -66,7 +67,8 @@
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
-      text-wrap-width: 0;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
       text-placement: interior;
     }
   }
@@ -90,7 +92,8 @@
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
-      text-wrap-width: 0;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
       text-placement: interior;
     }
   }
@@ -114,7 +117,8 @@
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
-      text-wrap-width: 0;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
       text-placement: interior;
     }
   }


### PR DESCRIPTION
This enables text-wrap for station labels, in line with other POI labels.

Before:
<img width="182" alt="screen shot 2017-10-24 at 00 20 55" src="https://user-images.githubusercontent.com/5251909/31916089-66f58904-b851-11e7-9f1c-9187627ffd5f.png">

After:
<img width="123" alt="screen shot 2017-10-24 at 00 20 48" src="https://user-images.githubusercontent.com/5251909/31916093-6a5ed3c0-b851-11e7-9fc5-bbe41a853b51.png">
