### PR TITLE
station typography

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -37,13 +37,15 @@
       text-dy: 9;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
-      text-wrap-width: @standard-wrap-width;
-      text-line-spacing: @standard-line-spacing-size;
+      text-wrap-width: 30; // 3 em
+      text-line-spacing: -1.5; // -0.15 em
       text-placement: interior;
     }
     [zoom >= 15] {
       marker-width: 9;
       text-size: 11;
+      text-wrap-width: 33; // 3 em
+      text-line-spacing: -1.65; // -0.15 em
       text-dy: 10;
     }
   }
@@ -62,7 +64,7 @@
     [zoom >= 15] {
       text-name: "[name]";
       text-face-name: @bold-fonts;
-      text-size: 10;
+      text-size: @standard-font-size;
       text-fill: @station-text;
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
@@ -87,7 +89,7 @@
     [zoom >= 14] {
       text-name: "[name]";
       text-face-name: @book-fonts;
-      text-size: 10;
+      text-size: @standard-font-size;
       text-fill: @station-text;
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
@@ -112,7 +114,7 @@
     [zoom >= 16] {
       text-name: "[name]";
       text-face-name: @book-fonts;
-      text-size: 10;
+      text-size: @standard-font-size;
       text-fill: @station-text;
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;


### PR DESCRIPTION
Resolves #2918

Use @standard-font-size in stations.mss whereever variables are also used for wrap width and line spacing. As wrap width and line spacing depend on the font size, this keeps together the values that are used together and interact together…

Because railway stations use different font sizes on different zoom levels, switching here to absolute values instead of variables for all (font size, wrap width and line spacing).

Only visible rendering difference should be for railway stations on zoom levels ≥ 15.