### PR TITLE
mention U.S states in usecases

### DIFF
--- a/USECASES.md
+++ b/USECASES.md
@@ -13,12 +13,14 @@ As we are still experimenting with this way of design, this document is restrict
 | Long distance road trip planning | Motorways | City names | z6, z7 |
 
 This gives us the following features:
+
 * z5: Map subject: Country names, country borders, city names. Map context: seas, oceans.
 * z5 in USA: Map subject: Province/state names and borders. Map context: Country names, country borders, seas oceans
 * z6: Map subject: Country names, country borders, province/state names and borders, motorways, city names. Map context: Seas, oceans, country borders, city names.
 * z7: Map subject: Province/state names and borders, city names, motorways. Map context: Seas, oceans, country names, country borders.
 
 Some features that we currently render for which we do not (yet) have a use case:
+
 * Province/state names and borders (except USA) on z5
 * Roads on z5
 * National parks on z7

--- a/USECASES.md
+++ b/USECASES.md
@@ -7,17 +7,19 @@ As we are still experimenting with this way of design, this document is restrict
 | Use case | Map subject | Map context | Zoom level |
 | --- | --- | --- | --- |
 | Looking up country location | Country names, country borders | Seas and oceans | z5, z6 |
+| Looking up U.S. state location | state names and borders in USA  | Seas and oceans, country bnorders | z5, z6, z7 |
 | Looking up province/state location|Province/state names and borders|Country borders | z6, z7 |
 | Looking up city location | City names | Seas, oceans, country names, country borders | z5, z6, z7 |
 | Long distance road trip planning | Motorways | City names | z6, z7 |
 
 This gives us the following features:
 * z5: Map subject: Country names, country borders, city names. Map context: seas, oceans.
+* z5 in USA: Map subject: Province/state names and borders. Map context: Country names, country borders, seas oceans
 * z6: Map subject: Country names, country borders, province/state names and borders, motorways, city names. Map context: Seas, oceans, country borders, city names.
 * z7: Map subject: Province/state names and borders, city names, motorways. Map context: Seas, oceans, country names, country borders.
 
 Some features that we currently render for which we do not (yet) have a use case:
-* Province/state names and borders on z5
+* Province/state names and borders (except USA) on z5
 * Roads on z5
 * National parks on z7
 * Railways on z7


### PR DESCRIPTION
maybe for other countries internal division is also useful from z5 - in that case it also should be mentioned