### PR TITLE
Reduce label clutter on entrances

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -12,8 +12,18 @@
 
 #addresses {
   [zoom >= 17] {
+    text-name: "";
+    text-placement: interior;
+    text-face-name: @book-fonts;
+    text-fill: @address-color;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-size: 10;
+    text-wrap-width: 30; // 3.0 em
+    text-line-spacing: -1.5; // -0.15 em
+    text-margin: 3; // 0.3 em
     text-name: "[addr_housename]";
-    ["addr_housenumber" != null] {
+    ["addr_housenumber" != null]["render" = null] {
       text-name: [addr_housenumber];
       ["addr_housename" != null] {
         text-name: [addr_housenumber] + "\n" + [addr_housename];
@@ -25,20 +35,17 @@
         }
       }
     }
-    text-placement: interior;
-    text-face-name: @book-fonts;
-    text-fill: @address-color;
-    text-halo-radius: @standard-halo-radius;
-    text-halo-fill: @standard-halo-fill;
-    text-size: 10;
-    text-wrap-width: 30; // 3.0 em
-    text-line-spacing: -1.5; // -0.15 em
-    text-margin: 3; // 0.3 em
+    ["addr_unit" != null]["addr_housenumber" = null]["render" = null] {
+      text-name: [addr_unit];
+      ["addr_housename" != null] {
+        text-name: [addr_unit] + "\n" + [addr_housename];
+      }
+    }
+    ["render" = "unit-only"] {
+      text-name: [addr_unit];
+    }
     [zoom >= 18] {
       text-halo-radius: @standard-halo-radius * 1.25;
-      ["addr_unit" != null]["addr_housenumber" = null] {
-        text-name: [addr_unit];
-      }
     }
     [zoom >= 20] {
         text-size: 11;

--- a/project.mml
+++ b/project.mml
@@ -2213,19 +2213,32 @@ Layer:
             "addr:housenumber" AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,
-            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
+            CAST(NULL as text)  AS render,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0)
+              AS way_pixels
           FROM planet_osm_polygon
-          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
+          WHERE (("addr:housenumber" IS NOT NULL)
+            OR ("addr:housename" IS NOT NULL)
+            OR ((tags->'addr:unit') IS NOT NULL))
             AND building IS NOT NULL
         UNION ALL
         SELECT
-            way,
-            "addr:housenumber" AS addr_housenumber,
-            "addr:housename" AS addr_housename,
-            tags->'addr:unit' AS addr_unit,
-            NULL AS way_pixels
-          FROM planet_osm_point
-          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
+            p.way AS way,
+            p."addr:housenumber" AS addr_housenumber,
+            p."addr:housename" AS addr_housename,
+            p.tags->'addr:unit' AS addr_unit,
+            CASE p."addr:housenumber" = (SELECT poly."addr:housenumber"
+                FROM planet_osm_polygon AS poly
+                WHERE ST_Intersects(poly.way, p.way)
+                    AND poly.building IS NOT NULL
+                    AND p.tags ? 'entrance'
+                LIMIT 1)
+            WHEN True THEN 'unit-only' ELSE NULL END AS render,
+            CAST(NULL as real) AS way_pixels
+          FROM planet_osm_point AS p
+          WHERE ((p."addr:housenumber" IS NOT NULL)
+              OR (p."addr:housename" IS NOT NULL)
+              OR ((p.tags->'addr:unit') IS NOT NULL))
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:


### PR DESCRIPTION
Currently correctly address-tagged building entrances have labels showing addr:housenumber + addr:unit. At z=17 this creates quite a bit of text on regions with large apartment buildings, like [here](https://www.openstreetmap.org/#map=17/60.24078/24.87857):
![kannel_old_z17](https://user-images.githubusercontent.com/3215/32441408-2efe4d10-c300-11e7-9a06-6e0affedf311.png)

This PR removes address labels from entrances at z=17 and makes them to have just the addr:unit text at higher zoom levels. At z=17:
![kannel_new_z17](https://user-images.githubusercontent.com/3215/32441634-28d784be-c301-11e7-9521-76dbeae302fa.png)
and at z=18:
![kannel_new_z18](https://user-images.githubusercontent.com/3215/32441671-499740fe-c301-11e7-8846-5e08acdad3d6.png)

Edit: Removed fix related to addr:housenumber and addr:unit rendering on buildings.