### PR TITLE
Clean up low-zoom levels

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -190,7 +190,7 @@ overlapping borders correctly.
 }
 
 #nature-reserve-boundaries {
-  [way_pixels > 100][zoom >= 7] {
+  [way_pixels > 100][zoom >= 8] {
     [zoom < 10] {
       ::fill {
         opacity: 0.05;

--- a/project.mml
+++ b/project.mml
@@ -943,7 +943,7 @@ Layer:
             z_order
         ) AS roads_low_zoom
     properties:
-      minzoom: 5
+      minzoom: 6
       maxzoom: 9
   - id: waterway-bridges
     class: water-lines
@@ -1181,7 +1181,7 @@ Layer:
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
         ) AS national_park_boundaries
     properties:
-      minzoom: 7
+      minzoom: 8
   - id: tourism-boundary
     geometry: polygon
     <<: *extents

--- a/roads.mss
+++ b/roads.mss
@@ -60,8 +60,8 @@
 @residential-tunnel-fill: darken(@residential-fill, 5%);
 @living-street-tunnel-fill: lighten(@living-street-fill, 10%);
 
-@motorway-width-z5:               0.5;
-@trunk-width-z5:                  0.4;
+@motorway-width-z6:               0.5;
+@trunk-width-z6:                  0.4;
 
 @motorway-width-z7:               0.8;
 @trunk-width-z7:                  0.6;
@@ -1170,10 +1170,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_motorway'] {
-      [zoom >= 5][link != 'yes'],
+      [zoom >= 6][link != 'yes'],
       [zoom >= 10] {
         line-color: @motorway-low-zoom;
-        line-width: @motorway-width-z5;
+        line-width: @motorway-width-z6;
         [zoom >= 7] { line-width: @motorway-width-z7; }
         [zoom >= 8] { line-width: @motorway-width-z8; }
         [zoom >= 9] { line-width: @motorway-width-z9; }
@@ -1221,9 +1221,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_trunk'] {
-      [zoom >= 5][link != 'yes'],
+      [zoom >= 6][link != 'yes'],
       [zoom >= 10] {
-        line-width: @trunk-width-z5;
+        line-width: @trunk-width-z6;
         line-color: @trunk-low-zoom;
         [zoom >= 7] { line-width: @trunk-width-z7; }
         [zoom >= 8] { line-width: @trunk-width-z8; }
@@ -1825,7 +1825,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
 
-    [feature = 'railway_rail'][zoom >= 7],
+    [feature = 'railway_rail'][zoom >= 8],
     [feature = 'railway_INT-spur-siding-yard'][zoom >= 13] {
       [zoom < 13] {
         line-color: #787878;


### PR DESCRIPTION
* Render roads from z6 instead of z5
* Render national parks from z8 instead of z7
* Render railways from z8 instead of z7

This is in line with the discussion on use cases and USECASES.md.

This contributes towards #2925 and #2688.