### PR TITLE
Render entrances.

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -34,8 +34,11 @@
     text-wrap-width: 30; // 3.0 em
     text-line-spacing: -1.5; // -0.15 em
     text-margin: 3; // 0.3 em
-    [zoom >= 18]["addr_unit" != null]["addr_housenumber" = null] {
-      text-name: [addr_unit];
+    [zoom >= 18] {
+      text-halo-radius: @standard-halo-radius * 1.25;
+      ["addr_unit" != null]["addr_housenumber" = null] {
+        text-name: [addr_unit];
+      }
     }
     [zoom >= 20] {
         text-size: 11;

--- a/buildings.mss
+++ b/buildings.mss
@@ -5,6 +5,8 @@
 @building-major-fill: darken(@building-fill, 20%);
 @building-major-line: darken(@building-major-fill, 25%);
 
+@entrance-permissive: darken(@building-line, 15%);
+@entrance-normal: @building-line;
 
 #buildings {
   [zoom >= 13] {
@@ -40,5 +42,47 @@
 #bridge {
   [zoom >= 12] {
     polygon-fill: #B8B8B8;
+  }
+}
+
+#entrances {
+  [zoom >= 18]["entrance" != null]  {
+    marker-fill: @entrance-normal;
+    marker-allow-overlap: true;
+    marker-ignore-placement: true;
+    marker-file: url('symbols/rect.svg');
+    marker-width: 5.0;
+    marker-height: 5.0;
+    marker-opacity: 0.0;
+    ["entrance" = "main"] {
+      marker-opacity: 1.0;
+      marker-file: url('symbols/square.svg');
+    }
+  }
+  [zoom >= 19] {
+    ["entrance" = "yes"],
+    ["entrance" = "main"],
+    ["entrance" = "home"],
+    ["entrance" = "service"],
+    ["entrance" = "staircase"] {
+      marker-opacity: 1.0;
+      marker-width: 6.0;
+      marker-height: 6.0;
+      ["entrance" = "service"] {
+        marker-file: url('symbols/corners.svg');
+      }
+    }
+    ["access" = "yes"],
+    ["access" = "permissive"] {
+      marker-fill: @entrance-permissive;
+    }
+    ["access" = "no"] {
+      marker-fill: @entrance-normal;
+      marker-file: url('symbols/rectdiag.svg');
+    }
+  }
+  [zoom >= 20]["entrance" != null] {
+    marker-width: 8.0;
+    marker-height: 8.0;
   }
 }

--- a/project.mml
+++ b/project.mml
@@ -1070,6 +1070,22 @@ Layer:
         ) AS guideways
     properties:
       minzoom: 11
+  - id: entrances
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            tags->'entrance' AS entrance,
+            access
+          FROM planet_osm_point
+          WHERE tags->'indoor' = 'no'
+            OR tags->'indoor' IS NULL)
+        AS entrances
+    properties:
+      minzoom: 18
   - id: aeroways
     geometry: linestring
     <<: *extents

--- a/symbols/corners.svg
+++ b/symbols/corners.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4"
+   height="1"
+   width="1"
+   version="1.1">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <path
+     id="path2"
+     d="m 0.00390625,0.00390625 c 0,0.13203125 0,0.2640625 0,0.39609375 H 0.20507812 V 0.20507812 H 0.4 V 0.00390625 Z m 0.59609375,0 V 0.20507812 H 0.8046875 V 0.4 H 1 V 0.6 H 0.8046875 V 0.8046875 H 0.6 V 0.99609375 H 0.4 V 0.8046875 H 0.20507812 V 0.6 H 0.00390625 V 1.0039062 H 1.0039062 V 0.00390625 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+</svg>

--- a/symbols/rect.svg
+++ b/symbols/rect.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4"
+   height="1"
+   width="1"
+   version="1.1">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <path
+     id="path2"
+     d="m 0.00423729,0.00423729 v 0.1 0.90000001 H 1.0042373 V 0.00423729 Z m 0.2,0.2 h 0.6 v 0.6 h -0.6 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+</svg>

--- a/symbols/rectdiag.svg
+++ b/symbols/rectdiag.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="1"
+   height="1"
+   id="svg4">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 0,0.141 0.859,1 1,0.859375 0.140625,0 Z M 0.355,0 0.57,0.2 0.80078125,0.19921875 V 0.43 L 1,0.645 V 0 Z M 0,0.35607813 V 1 H 0.64410937 L 0.44489063,0.80078125 H 0.19921875 L 0.2,0.57092187 Z"
+     id="path2" />
+</svg>


### PR DESCRIPTION
Render entrances starting at z=17. The "main" and "staircase" entrances are rendered with a square marker, the "service" entrance with a circle (starting at z=18) and other entrances with a disc.

Three levels of marker brightness reflect the access permissions of the entrance. Darker color means more permissive access. The "main" entrances are dark by default. The access tag modifies the brightness such that access="yes" and "permissive" set the marker to darkest and access=no to the lightest colour. Entrances with other access tag values have intermediate brightness.

Exits, such as entrance=exit and entrance=emergency are not rendered.

Address label text-halo-radius is increased at z>=18 to improve readability of labels on top of entrance markers.

**Examples:**

[Buildings](http://www.openstreetmap.org/#map=19/60.17520/24.79240) with "main" and "service" entrances, z=17-18:
![main_service_z17](https://user-images.githubusercontent.com/3215/32547542-6d87ace8-c48b-11e7-8546-71ab1a675190.png) ![main_service_z18](https://user-images.githubusercontent.com/3215/32547582-930ebfd8-c48b-11e7-8799-fee076760c6a.png)

[School](https://www.openstreetmap.org/#map=18/60.25117/24.85294) with several entrance="yes" and access="permissive"|"private", z=17-18:
![school_z17](https://user-images.githubusercontent.com/3215/32547721-183eebb0-c48c-11e7-9137-c9415737bf37.png) ![school_z18](https://user-images.githubusercontent.com/3215/32547729-1d9092bc-c48c-11e7-9f1d-d415a3eb61e0.png)

[Apartment building](http://www.openstreetmap.org/#map=18/60.24282/24.88029) with entrance="staircase" tagged with addr:unit, z=17-18:
![unit_z17](https://user-images.githubusercontent.com/3215/32548001-c67f550c-c48c-11e7-9d30-18a972180a8a.png) 
![unit_z18](https://user-images.githubusercontent.com/3215/32548007-cd481766-c48c-11e7-95f7-f30e3bc299b5.png)



