### PR TITLE
Render place names for polygons if no point exists for area

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -78,6 +78,7 @@
     shield-margin: 7.7; // 0.7 em
     shield-halo-fill: @standard-halo-fill;
     shield-halo-radius: @standard-halo-radius * 1.5;
+    shield-placement: interior;
     shield-placement-type: simple;
     shield-placements: 'S,N,E,W';
     [dir = 1] {
@@ -111,6 +112,7 @@
     text-margin: 9.1; // 0.7 em
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
+    text-placement: interior;
 
     [zoom >= 10] {
       text-size: 14;
@@ -143,6 +145,7 @@
       shield-margin: 7.7; // 0.7 em
       shield-halo-fill: @standard-halo-fill;
       shield-halo-radius: @standard-halo-radius * 1.5;
+      shield-placement: interior;
       shield-placement-type: simple;
       shield-placements: 'S,N,E,W';
       [dir = 1] {
@@ -178,6 +181,7 @@
       text-margin: 9.1; // 0.7 em
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
 
       [zoom >= 10] {
         text-size: 14;
@@ -211,6 +215,7 @@
       shield-wrap-width: 30; // 3.0 em
       shield-line-spacing: -1.5; // -0.15 em
       shield-margin: 7.0; // 0.7 em
+      shield-placement: interior;
       shield-placement-type: simple;
       shield-placements: 'S,N,E,W';
       [dir = 1] {
@@ -228,6 +233,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 40; // 4.0 em
       text-line-spacing: -1.0; // -0.10 em
       text-margin: 7.0; // 0.7 em
@@ -268,6 +274,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 45; // 4.5 em
       text-line-spacing: -0.8; // -0.08 em
       text-margin: 7; // 0.7 em
@@ -301,6 +308,7 @@
     text-face-name: @book-fonts;
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
+    text-placement: interior;
     text-wrap-width: 55; // 5.0 em
     text-line-spacing: -0.55; // -0.05 em
     text-margin: 7.7; // 0.7 em
@@ -336,6 +344,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 50; // 5.0 em
       text-line-spacing: -0.50; // -0.05 em
       text-margin: 7.0; // 0.7 em
@@ -382,6 +391,7 @@
       text-face-name: @book-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement: interior;
       text-wrap-width: 45; // 4.5 em
       text-line-spacing: -0.8; // -0.08 em
       text-margin: 7.0; // 0.7 em

--- a/project.mml
+++ b/project.mml
@@ -1250,11 +1250,30 @@ Layer:
               WHEN (tags->'population' ~ '^[0-9]{1,8}$') THEN (tags->'population')::INTEGER ELSE 0
             END as population,
             round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
-          FROM planet_osm_point
-          WHERE place IN ('city', 'town', 'village', 'hamlet')
-            AND name IS NOT NULL
-            AND tags @> 'capital=>yes'
-          ORDER BY population DESC
+          FROM
+            (SELECT
+                way,
+                osm_id,
+                name,
+                place,
+                tags,
+                NULL AS way_area
+              FROM planet_osm_point
+            UNION ALL
+            SELECT
+                way,
+                osm_id,
+                name,
+                place,
+                tags,
+                way_area
+              FROM planet_osm_polygon
+              ) places
+              WHERE place IN ('city', 'town', 'village', 'hamlet')
+                AND name IS NOT NULL
+                AND tags @> 'capital=>yes'
+          ORDER BY population DESC,
+            way_area DESC NULLS LAST
         ) AS capital_names
     properties:
       minzoom: 3
@@ -1314,7 +1333,25 @@ Layer:
                     ELSE 1
                   END)
                 ) AS score
-              FROM planet_osm_point
+              FROM
+              (SELECT
+                  osm_id,
+                  way,
+                  place,
+                  name,
+                  tags,
+                  NULL AS way_area
+                FROM planet_osm_point
+              UNION ALL
+              SELECT
+                  osm_id,
+                  way,
+                  place,
+                  name,
+                  tags,
+                  way_area
+                FROM planet_osm_polygon
+              ) places
               WHERE place IN ('city', 'town')
                 AND name IS NOT NULL
                 AND NOT (tags @> 'capital=>yes')
@@ -1334,7 +1371,23 @@ Layer:
             way,
             place,
             name
-          FROM planet_osm_point
+          FROM
+          (SELECT
+              way,
+              place,
+              name,
+              tags,
+              NULL AS way_area
+            FROM planet_osm_point
+          UNION ALL
+          SELECT
+              way,
+              place,
+              name,
+              tags,
+              NULL AS way_area
+            FROM planet_osm_polygon
+            ) AS places
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
@@ -1348,7 +1401,10 @@ Layer:
               WHEN place = 'locality' THEN 7
               WHEN place = 'isolated_dwelling' THEN 8
               WHEN place = 'farm' THEN 9
-            END ASC, length(name) DESC, name
+            END ASC,
+            way_area DESC NULLS LAST,
+            length(name) DESC,
+            name
         ) AS placenames_small
     properties:
       minzoom: 12

--- a/project.mml
+++ b/project.mml
@@ -1267,11 +1267,19 @@ Layer:
                 place,
                 tags,
                 way_area
-              FROM planet_osm_polygon
-              ) places
-              WHERE place IN ('city', 'town', 'village', 'hamlet')
-                AND name IS NOT NULL
-                AND tags @> 'capital=>yes'
+            FROM planet_osm_polygon a
+            WHERE 
+                NOT EXISTS (
+                    SELECT
+                      FROM planet_osm_point p
+                     WHERE a.place = p.place 
+                       AND a.name = p.name 
+                       AND ST_Intesects(a.geom, p.geom)
+                 )
+            ) places
+          WHERE place IN ('city', 'town', 'village', 'hamlet')
+            AND name IS NOT NULL
+            AND tags @> 'capital=>yes'
           ORDER BY population DESC,
             way_area DESC NULLS LAST
         ) AS capital_names
@@ -1350,7 +1358,15 @@ Layer:
                   name,
                   tags,
                   way_area
-                FROM planet_osm_polygon
+              FROM planet_osm_polygon a
+              WHERE 
+                  NOT EXISTS (
+                      SELECT
+                        FROM planet_osm_point p
+                       WHERE a.place = p.place 
+                         AND a.name = p.name 
+                         AND ST_Intesects(a.geom, p.geom)
+                  )
               ) places
               WHERE place IN ('city', 'town')
                 AND name IS NOT NULL
@@ -1386,7 +1402,15 @@ Layer:
               name,
               tags,
               NULL AS way_area
-            FROM planet_osm_polygon
+           FROM planet_osm_polygon a
+           WHERE 
+               NOT EXISTS (
+                   SELECT
+                     FROM planet_osm_point p
+                    WHERE a.place = p.place 
+                      AND a.name = p.name 
+                      AND ST_Intesects(a.geom, p.geom)
+                )
             ) AS places
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -1274,7 +1274,7 @@ Layer:
                       FROM planet_osm_point p
                      WHERE a.place = p.place 
                        AND a.name = p.name 
-                       AND ST_Intesects(a.geom, p.geom)
+                       AND ST_Intersects(a.way, p.way)
                  )
             ) places
           WHERE place IN ('city', 'town', 'village', 'hamlet')
@@ -1365,7 +1365,7 @@ Layer:
                         FROM planet_osm_point p
                        WHERE a.place = p.place 
                          AND a.name = p.name 
-                         AND ST_Intesects(a.geom, p.geom)
+                         AND ST_Intersects(a.way, p.way)
                   )
               ) places
               WHERE place IN ('city', 'town')
@@ -1409,7 +1409,7 @@ Layer:
                      FROM planet_osm_point p
                     WHERE a.place = p.place 
                       AND a.name = p.name 
-                      AND ST_Intesects(a.geom, p.geom)
+                      AND ST_Intersects(a.way, p.way)
                 )
             ) AS places
           WHERE place IN ('village', 'hamlet')


### PR DESCRIPTION
A patch to #2816 that doesn't create duplicate labels and compatible with current node-and-polygons data.