### PR TITLE
Fix color for man_made icons

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -13,7 +13,7 @@
 @memorials: @amenity-brown;
 @culture: @amenity-brown;
 @public-service: @amenity-brown;
-@man-made-icon: #555;
+@man-made: #555;
 @landform-color: #d08f55;
 @leisure-green: darken(@park, 60%);
 
@@ -334,7 +334,7 @@
 
   [feature = 'man_made_mast'][zoom >= 17] {
     marker-file: url('symbols/communications.svg');
-    marker-fill: @man-made-icon;
+    marker-fill: @man-made;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -555,7 +555,7 @@
 
   [feature = 'man_made_water_tower'][zoom >= 17] {
     marker-file: url('symbols/water_tower.svg');
-    marker-fill: @man-made-icon;
+    marker-fill: @man-made;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -950,7 +950,7 @@
     marker-file: url('symbols/lighthouse.svg');
     marker-placement: interior;
     marker-clip: false;
-    marker-fill: @man-made-icon;
+    marker-fill: @man-made;
   }
 
   [feature = 'natural_peak'][zoom >= 11] {
@@ -982,7 +982,7 @@
   
   [feature = 'military_bunker'][zoom >= 17] {
     marker-file: url('symbols/bunker.svg');
-    marker-fill: @man-made-icon;    
+    marker-fill: @man-made;
     marker-placement: interior;
     marker-clip: false;
   }  
@@ -998,7 +998,7 @@
     [zoom >= 15] {
       marker-file: url('symbols/power_wind.svg');
       marker-placement: interior;
-      marker-fill: black;
+      marker-fill: @man-made;
       marker-clip: false;
     }
   }
@@ -1006,13 +1006,13 @@
   [feature = 'man_made_windmill'][zoom >= 16] {
     marker-file: url('symbols/windmill.svg');
     marker-placement: interior;
-    marker-fill: @man-made-icon;
+    marker-fill: @man-made;
     marker-clip: false;
   }
 
   [feature = 'amenity_hunting_stand'][zoom >= 16] {
     marker-file: url('symbols/hunting_stand.svg');
-    marker-fill: @man-made-icon;
+    marker-fill: @man-made;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -1312,14 +1312,29 @@
 
   [feature = 'man_made_cross'][zoom >= 17],
   [feature = 'historic_wayside_cross'][zoom >= 17],
-  [feature = 'natural_cave_entrance'][zoom >= 15],
-  [feature = 'man_made_mast'][zoom >= 17],
+  [feature = 'natural_cave_entrance'][zoom >= 15] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-dy: 11;
+    [feature = 'man_made_cross'],
+    [feature = 'historic_wayside_cross'] {
+      text-dy: 6;
+    }
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+  }
+
+
+  [feature = 'mast'][zoom >= 17],
   [feature = 'man_made_water_tower'][zoom >= 17] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: black;
     [feature = 'natural_cave_entrance'],
     [feature = 'man_made_water_tower'] {
       text-dy: 11;
@@ -1357,7 +1372,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @man-made-icon;
+    text-fill: @man-made;
     text-dy: 11;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
@@ -1856,7 +1871,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @man-made-icon;
+    text-fill: @man-made;
     text-dy: 16;
     [feature = 'man_made_windmill'] { text-dy: 12; }
     text-face-name: @standard-font;
@@ -2196,7 +2211,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-dy: 11;
-    text-fill: @man-made-icon;
+    text-fill: @man-made;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
* Labels for masts and water towers are now the same color of dark gray
  as mast/water tower icons, rather than the current black color.
* Windmill icons are now rendered in man_made gray rather than black

Before:

<img width="57" alt="screen shot 2017-11-20 at 01 32 04" src="https://user-images.githubusercontent.com/5251909/32997681-70d5c392-cd93-11e7-8b13-a5f07b08157d.png"> <img width="64" alt="screen shot 2017-11-20 at 01 43 11" src="https://user-images.githubusercontent.com/5251909/32997733-319b7e50-cd94-11e7-97f7-33414a7a4d49.png">

After:

<img width="77" alt="screen shot 2017-11-20 at 01 29 31" src="https://user-images.githubusercontent.com/5251909/32997684-7126ee84-cd93-11e7-8e8c-ec84f1acff3d.png"> <img width="52" alt="screen shot 2017-11-20 at 01 41 19" src="https://user-images.githubusercontent.com/5251909/32997717-f68873c2-cd93-11e7-9f3e-73cd7efbd002.png">
