### PR TITLE
Render maritime admin boundaries less prominently

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -1,5 +1,5 @@
 @admin-boundaries: #ac46ac;
-@admin-boundaries-maritime: darken(@water-color,15%);
+@admin-boundaries-maritime: darken(@water-color,20%);
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
@@ -17,7 +17,7 @@ overlapping borders correctly.
       background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
-      [maritime = 'yes'] {
+      [maritime = 'true'] {
         line-color: @admin-boundaries-maritime;
       }
       line-width: 1.2;
@@ -47,7 +47,7 @@ overlapping borders correctly.
       background/line-width: 0.6;
       line-join: bevel;
       line-color: @admin-boundaries;
-      [maritime = 'yes'] {
+      [maritime = 'true'] {
         line-color: @admin-boundaries-maritime;
       }
       line-width: 0.6;
@@ -70,7 +70,7 @@ overlapping borders correctly.
       background/line-color: white;
       background/line-width: 0.4;
       line-color: @admin-boundaries;
-      [maritime = 'yes'] {
+      [maritime = 'true'] {
         line-color: @admin-boundaries-maritime;
       }
       line-join: bevel;
@@ -126,7 +126,7 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
-    [maritime = 'yes'] {
+    [maritime = 'true'] {
       line-color: @admin-boundaries-maritime;
     }
     line-width: 2;
@@ -139,7 +139,7 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
-    [maritime = 'yes'] {
+    [maritime = 'true'] {
       line-color: @admin-boundaries-maritime;
     }
     line-width: 2;
@@ -154,7 +154,7 @@ overlapping borders correctly.
       background/line-width: 1.5;
       line-join: bevel;
       line-color: @admin-boundaries;
-      [maritime = 'yes'] {
+      [maritime = 'true'] {
         line-color: @admin-boundaries-maritime;
       }
       line-width: 1.5;
@@ -166,7 +166,8 @@ overlapping borders correctly.
   comp-op: darken;
 }
 
-#admin-high-zoom[zoom >= 13] {
+#admin-high-zoom[zoom >= 13],
+#admin-high-zoom-maritime[zoom >= 13] {
   [admin_level = '9'],
   [admin_level = '10'] {
     [zoom >= 13] {
@@ -175,7 +176,7 @@ overlapping borders correctly.
       background/line-width: 2;
       line-join: bevel;
       line-color: @admin-boundaries;
-      [maritime = 'yes'] {
+      [maritime = 'true'] {
         line-color: @admin-boundaries-maritime;
       }
       line-width: 2;

--- a/admin.mss
+++ b/admin.mss
@@ -1,4 +1,5 @@
 @admin-boundaries: #ac46ac;
+@admin-boundaries-maritime: darken(@water-color,15%);
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
@@ -16,6 +17,9 @@ overlapping borders correctly.
       background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 1.2;
     }
     [zoom >= 5] {
@@ -43,6 +47,9 @@ overlapping borders correctly.
       background/line-width: 0.6;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 0.6;
     }
     [zoom >= 7] {
@@ -63,6 +70,9 @@ overlapping borders correctly.
       background/line-color: white;
       background/line-width: 0.4;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-join: bevel;
       line-width: 0.4;
       line-clip: false;
@@ -116,6 +126,9 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
+    [maritime = 'yes'] {
+      line-color: @admin-boundaries-maritime;
+    }
     line-width: 2;
     line-dasharray: 6,3,2,3,2,3;
     line-clip: false;
@@ -126,6 +139,9 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
+    [maritime = 'yes'] {
+      line-color: @admin-boundaries-maritime;
+    }
     line-width: 2;
     line-dasharray: 6,3,2,3;
     line-clip: false;
@@ -138,6 +154,9 @@ overlapping borders correctly.
       background/line-width: 1.5;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 1.5;
       line-dasharray: 5,2;
       line-clip: false;
@@ -156,6 +175,9 @@ overlapping borders correctly.
       background/line-width: 2;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 2;
       line-dasharray: 2,3;
       line-clip: false;

--- a/project.mml
+++ b/project.mml
@@ -1123,58 +1123,100 @@ Layer:
     properties:
       minzoom: 11
   - id: admin-low-zoom
+    class: admin
     geometry: linestring
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        (
+          (SELECT
             way,
             admin_level,
-            tags->'maritime' as maritime
+            'false' as maritime
+          FROM planet_osm_roads
+          WHERE boundary = 'administrative'
+            AND admin_level IN ('0', '1', '2', '3', '4')
+            AND osm_id < 0
+          )
+          UNION
+          (SELECT
+            way,
+            admin_level,
+            'true' as maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
             AND osm_id > 0
-          ORDER BY admin_level DESC
+            AND tags->'maritime' = 'yes'
+          )
+          ORDER BY maritime, admin_level DESC
         ) AS admin_low_zoom
     properties:
       minzoom: 4
       maxzoom: 10
   - id: admin-mid-zoom
+    class: admin
     geometry: linestring
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        (
+          (SELECT
             way,
             admin_level,
-            boundary
+            'false'as maritime
+          FROM planet_osm_roads
+          WHERE boundary = 'administrative'
+            AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
+            AND osm_id < 0
+          )
+          UNION
+          (SELECT
+            way,
+            admin_level,
+            'true' as maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
             AND osm_id > 0
-          ORDER BY admin_level DESC
+            AND tags->'maritime' = 'yes'
+          )
+          ORDER BY maritime, admin_level DESC
         ) AS admin_mid_zoom
     properties:
       minzoom: 11
       maxzoom: 12
   - id: admin-high-zoom
+    class: admin
     geometry: linestring
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        (
+          (SELECT
             way,
-            admin_level,
-            boundary
+            admin_level::integer, -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+            'false' as maritime
+          FROM planet_osm_roads
+          WHERE boundary = 'administrative'
+            AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
+            AND osm_id < 0
+          )
+          UNION
+          (SELECT
+            way,
+            admin_level::integer, -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+            'true' as maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND osm_id > 0
-          ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
+            AND tags->'maritime' = 'yes'
+          )
+          ORDER BY maritime, admin_level DESC
         ) AS admin_high_zoom
     properties:
       minzoom: 13

--- a/project.mml
+++ b/project.mml
@@ -1130,11 +1130,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            tags->'maritime' as maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
@@ -1148,11 +1149,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            boundary
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
@@ -1166,11 +1168,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            boundary
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:


### PR DESCRIPTION
This requires rendering admin boundaries based on the individual
lines, rather than the entire polygons.

* This fixes #621
* This possibly impacts solutions to #713, #2234 and #2663.