### PR TITLE
Move ferries to zoomlevel 8

### DIFF
--- a/ferry-routes.mss
+++ b/ferry-routes.mss
@@ -2,7 +2,7 @@
 @ferry-route-text: @ferry-route;
 
 #ferry-routes {
-  [zoom >= 7] {
+  [zoom >= 8] {
     /* background prevents problems with overlapping ferry-routes, see #457 */
     background/line-color: @water-color;
     background/line-width: 1; /* Needs to be a bit wider than the route itself because of antialiasing */

--- a/project.mml
+++ b/project.mml
@@ -613,7 +613,7 @@ Layer:
           WHERE route = 'ferry'
         ) AS ferry_routes
     properties:
-      minzoom: 7
+      minzoom: 8
   - id: turning-circle-casing
     geometry: point
     <<: *extents


### PR DESCRIPTION
This moves the minimum zoomlevel of ferries from zoomlevel 7 to 8.