### PR TITLE
Change sports_centre and stadium color to green

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -61,7 +61,7 @@
 
 @pitch: #aae0cb; // also track
 @track: @pitch;
-@stadium: @societal_amenities; // also sports_centre
+@stadium: @leisure; // also sports_centre
 @golf_course: #b5e3b5;
 
 #landcover-low-zoom[zoom < 10],


### PR DESCRIPTION
Now that we use light green for different small leisure areas, we could use it also for big ones, as they typically don't overlap. 

That unification would also offload societal_amenities color a bit (so we have less problem defining what it really is) and tie green color closer with the physical activities, which makes the system more predictable.

Examples in Warsaw (with different landuses around):

Before
![hr2sr3by](https://user-images.githubusercontent.com/5439713/33140495-72d2d2f6-cfb0-11e7-8da7-d18c8cfbbf05.png)
After
![qgxsvwqh](https://user-images.githubusercontent.com/5439713/33140501-77096c0e-cfb0-11e7-8f36-6e4eb968df2b.png)

Before
![ao4jenlr](https://user-images.githubusercontent.com/5439713/33140513-7e6d26de-cfb0-11e7-96d7-ff09fbc95c73.png)
After
![8ix4kxxz](https://user-images.githubusercontent.com/5439713/33140518-82e8c88a-cfb0-11e7-82e7-bc3b386f8aa0.png)

Before
![obc7earf](https://user-images.githubusercontent.com/5439713/33140528-898a7a4e-cfb0-11e7-82ac-0e536a385196.png)
After
![ru3lypoj](https://user-images.githubusercontent.com/5439713/33140531-8d433eb4-cfb0-11e7-88f2-e6de551ea750.png)

Before
![e01zrfvz](https://user-images.githubusercontent.com/5439713/33140540-959a499a-cfb0-11e7-8501-c1b6305c4d29.png)
After
![marl4vhc](https://user-images.githubusercontent.com/5439713/33140549-98733da2-cfb0-11e7-8b35-d3af94ca53f8.png)
