### PR TITLE
Better shades for recreation_ground and other green areas

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -1,10 +1,10 @@
 // --- Parks, woods, other green things ---
 
-@grass: #cdebb0; // also meadow, common, garden, village_green
+@grass: #cdebb0; // also grassland, meadow, common, village_green
 @scrub: #b5e3b5;
 @forest: #add19e;       // Lch(80,30,135)
 @forest-text: #46673b;  // Lch(40,30,135)
-@park: #c8facc;         // Lch(94,30,145) also recreation_ground
+@park: #c8facc;         // Lch(94,30,145) also garden
 @orchard: #aedfa3; // also vineyard, plant_nursery
 
 // --- "Base" landuses ---
@@ -97,6 +97,8 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
+  [feature = 'leisure_recreation_ground'][zoom >= 10],
+  [feature = 'landuse_recreation_ground'][zoom >= 10],
   [feature = 'leisure_playground'][zoom >= 13],
   [feature = 'leisure_fitness_station'][zoom >= 13] {
     polygon-fill: @leisure;
@@ -251,7 +253,7 @@
   }
 
   [feature = 'leisure_park'],
-  [feature = 'leisure_recreation_ground'] {
+  [feature = 'leisure_garden'] {
     [zoom >= 10] {
       polygon-fill: @park;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
@@ -332,10 +334,8 @@
   [feature = 'landuse_meadow'],
   [feature = 'natural_grassland'],
   [feature = 'landuse_grass'],
-  [feature = 'landuse_recreation_ground'],
   [feature = 'landuse_village_green'],
-  [feature = 'leisure_common'],
-  [feature = 'leisure_garden'] {
+  [feature = 'leisure_common'] {
     [zoom >= 10] {
       polygon-fill: @grass;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }


### PR DESCRIPTION
Resolves #2956.

This should make the use of green backgrounds more consistent:
- `landuse=recreation_ground` and `leisure=recreation_ground` should look the same and use leisure green
- `leisure=garden` should use park green

[Update:] `leisure=common` changes are reverted (needs additional discussion)

landuse=recreation_ground
Before
![a0b_vfza](https://user-images.githubusercontent.com/5439713/33449654-adba0416-d609-11e7-9a4a-8efdceca1194.png)
After
![stogufma](https://user-images.githubusercontent.com/5439713/33449665-b43d6b3e-d609-11e7-909e-0d2fc0f7e6e7.png)

leisure=recreation_ground
Before
![g6vxnl91](https://user-images.githubusercontent.com/5439713/33449598-8ef925c0-d609-11e7-99cd-1bd1ef249ab6.png)
After
![qpnahivb](https://user-images.githubusercontent.com/5439713/33449604-93ecb79a-d609-11e7-8aa7-3d7f4e67e60f.png)

leisure=garden
Before
![g2hddlgc](https://user-images.githubusercontent.com/5439713/33449518-4fdff8aa-d609-11e7-8982-c5f4f18052ef.png)
After
![b fesehn](https://user-images.githubusercontent.com/5439713/33449512-4c02c26c-d609-11e7-8aef-04b21317f8c7.png)