### PR TITLE
Bus Guideways

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1067,7 +1067,7 @@ Layer:
           WHERE highway = 'bus_guideway'
         ) AS guideways
     properties:
-      minzoom: 13
+      minzoom: 11
   - id: aeroways
     geometry: linestring
     <<: *extents

--- a/roads.mss
+++ b/roads.mss
@@ -2579,9 +2579,14 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #guideways {
+  [zoom >= 11][zoom < 13] {
+    line-width: 0.6;
+    line-color: #6699ff;
+    [zoom >= 12] { line-width: 1; }
+  }
   [zoom >= 13] {
     line-width: 3;
-    line-color: #6666ff;
+    line-color: #6699ff;
     line-join: round;
     b/line-width: 1;
     b/line-color: white;


### PR DESCRIPTION
Make them visible from z11, but not have them dominate the map.
Involves a colour change the also affects other zoom levels.
Resolves https://github.com/gravitystorm/openstreetmap-carto/issues/2965 .