### PR TITLE
Replace VMAP0-data by OSM-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 install:
   - npm install carto@$CARTO
   - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/land-polygons-split-3857
-  - touch data/world_boundaries/builtup_area.shp data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/land-polygons-split-3857/land_polygons.shp
+  - touch data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/land-polygons-split-3857/land_polygons.shp
 script:
   # We're using pipes in the checks, so fail if any part fails
   - set -o pipefail

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ This script generates and populates the *data* directory with all needed shapefi
 
 You can also download them manually at the following paths:
 
-* [`world_bnd_m.shp`, `builtup_area.shp`, `places.shp`, `world_boundaries_m.shp`](http://planet.openstreetmap.org/historical-shapefiles/world_boundaries-spherical.tgz)
+* [`world_bnd_m.shp`, `places.shp`, `world_boundaries_m.shp`](http://planet.openstreetmap.org/historical-shapefiles/world_boundaries-spherical.tgz)
 * [`simplified_land_polygons.shp`](http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip) (updated daily)
 * [`ne_110m_admin_0_boundary_lines_land.shp`](http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip)
 * [`land_polygons.shp`](http://data.openstreetmapdata.com/land-polygons-split-3857.zip) (updated daily)

--- a/landcover.mss
+++ b/landcover.mss
@@ -216,7 +216,7 @@
     line-opacity: 0.329;
   }
 
-  [feature = 'landuse_residential'][zoom >= 10] {
+  [feature = 'landuse_residential'][zoom >= 8] {
     polygon-fill: @built-up-lower-lowzoom;
     [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
     [zoom >= 13] { polygon-fill: @residential; }
@@ -345,7 +345,7 @@
 
   [feature = 'landuse_retail'],
   [feature = 'amenity_marketplace'] {
-    [zoom >= 10] {
+    [zoom >= 8] {
       polygon-fill: @built-up-lower-lowzoom;
       [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
       [zoom >= 13] { polygon-fill: @retail; }
@@ -361,7 +361,7 @@
     }
   }
 
-  [feature = 'landuse_industrial'][zoom >= 10] {
+  [feature = 'landuse_industrial'][zoom >= 8] {
     polygon-fill: @built-up-lower-lowzoom;
     [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
     [zoom >= 13] { polygon-fill: @industrial; }
@@ -413,7 +413,7 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'landuse_commercial'][zoom >= 10] {
+  [feature = 'landuse_commercial'][zoom >= 8] {
     polygon-fill: @built-up-lower-lowzoom;
     [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
     [zoom >= 13] { polygon-fill: @commercial; }

--- a/project.mml
+++ b/project.mml
@@ -70,17 +70,6 @@ Layer:
       type: shape
     properties:
       minzoom: 10
-  - id: builtup
-    geometry: polygon
-    extent: *world
-    srs-name: mercator
-    srs: "+proj=merc +datum=WGS84 +over"
-    Datasource:
-      file: data/world_boundaries/builtup_area.shp
-      type: shape
-    properties:
-      minzoom: 8
-      maxzoom: 9
   - id: necountries
     geometry: linestring
     <<: *extents84
@@ -104,7 +93,6 @@ Layer:
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
-
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial')

--- a/project.mml
+++ b/project.mml
@@ -101,12 +101,13 @@ Layer:
             COALESCE(wetland, landuse, "natural") AS feature
           FROM (SELECT
               way, COALESCE(name, '') AS name, religion,
-              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END)) AS landuse,
+              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
+
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
-            WHERE (landuse IN ('forest', 'military', 'farmland')
+            WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL

--- a/scripts/get-shapefiles.py
+++ b/scripts/get-shapefiles.py
@@ -41,7 +41,6 @@ settings = {
         'type': 'tgz',
         'shp_basename': [
             'world_bnd_m',
-            'builtup_area',
             'places',
             'world_boundaries_m'],
         'long_opt': '--world-boundaries'

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -45,9 +45,3 @@
     }
   }
 }
-
-#builtup {
-  [zoom >= 8][zoom < 10] {
-    polygon-fill: #ddd;
-  }
-}


### PR DESCRIPTION
Currently, we use VMAP0-data instead of OSM-data to indicate built-up areas
on zoom levels 8 and 9. This PR replaces the VMAP0-data with the OSM
landcover data.

Resolves #256.