### PR TITLE
Render glaciers and icesheets from z8 instead of z6

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -217,7 +217,7 @@ Layer:
       file: data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp
       type: shape
     properties:
-      minzoom: 4
+      minzoom: 8
   - id: water-areas
     geometry: polygon
     <<: *extents
@@ -277,7 +277,7 @@ Layer:
       file: data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp
       type: shape
     properties:
-      minzoom: 4
+      minzoom: 8
   - id: water-lines
     class: water-lines
     geometry: linestring

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -24,13 +24,13 @@
 }
 
 #icesheet-poly {
-  [zoom >= 6] {
+  [zoom >= 8] {
     polygon-fill: @glacier;
   }
 }
 
 #icesheet-outlines {
-  [zoom >= 6] {
+  [zoom >= 8] {
     [ice_edge = 'ice_ocean'],
     [ice_edge = 'ice_land'] {
       line-width: 0.375;

--- a/water.mss
+++ b/water.mss
@@ -4,13 +4,10 @@
 
 #water-areas {
   [natural = 'glacier']::natural {
-    [zoom >= 6] {
-      line-width: 0.75;
+    [zoom >= 8] {
+      line-width: 1.0;
       line-color: @glacier-line;
       polygon-fill: @glacier;
-      [zoom >= 8] {
-        line-width: 1.0;
-      }
       [zoom >= 10] {
         line-dasharray: 4,2;
         line-width: 1.5;


### PR DESCRIPTION
We don't render other landcover at z6/z7, and the glaciers, especially in
the Alps, currently attract too much attention.