### PR TITLE
Adding rendering for amenity=waste_disposal

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1024,6 +1024,17 @@
     marker-placement: interior;
     marker-clip: false;
   }
+  
+  // waste_disposal tagging on ways - tagging on nodes is defined later 
+  [feature = 'amenity_waste_disposal'][zoom >= 19] {
+    [access = null],
+    [access = 'permissive'],
+    [access = 'yes'] {
+      marker-file: url('symbols/waste_disposal.svg');
+      marker-fill: @amenity-brown;
+      marker-placement: interior;
+    }
+  }
 }
 
 .amenity-low-priority {
@@ -1110,6 +1121,17 @@
     marker-file: url('symbols/waste_basket.10.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
+  }
+
+  // waste_disposal tagging on nodes - tagging on ways is defined earlier 
+  [feature = 'amenity_waste_disposal'][zoom >= 19]::amenity {
+    [access = null],
+    [access = 'permissive'],
+    [access = 'yes'] {
+      marker-file: url('symbols/waste_disposal.svg');
+      marker-fill: @amenity-brown;
+      marker-placement: interior;
+    }
   }
 }
 

--- a/project.mml
+++ b/project.mml
@@ -1416,7 +1416,7 @@ Layer:
                                                   'police', 'post_box', 'post_office', 'pub', 'biergarten', 'recycling', 'restaurant', 'food_court',
                                                   'fast_food', 'telephone', 'taxi', 'theatre', 'toilets', 'drinking_water',
                                                   'prison', 'hunting_stand', 'nightclub', 'veterinary', 'social_facility',
-                                                  'charging_station', 'arts_centre', 'ferry_terminal', 'marketplace') THEN amenity ELSE NULL END,
+                                                  'charging_station', 'arts_centre', 'ferry_terminal', 'marketplace', 'waste_disposal') THEN amenity ELSE NULL END,
               'shop' || CASE WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
               'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table',
                                                   'fitness_centre', 'fitness_station') THEN leisure ELSE NULL END,
@@ -2286,17 +2286,18 @@ Layer:
             COALESCE(
               'highway_' || CASE WHEN highway IN ('mini_roundabout') THEN highway ELSE NULL END,
               'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') THEN railway ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket') THEN amenity ELSE NULL END,
+              'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 
+                            'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END
             )  AS feature,
             access,
-            CASE WHEN amenity='waste_basket' THEN 2 ELSE 1 END AS prio
+            CASE WHEN amenity IN ('waste_basket', 'waste_disposal') THEN 2 ELSE 1 END AS prio
           FROM planet_osm_point p
           WHERE highway IN ('mini_roundabout')
              OR railway IN ('level_crossing', 'crossing')
-             OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket')
+             OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket', 'waste_disposal')
              OR historic IN ('wayside_cross')
              OR man_made IN ('cross')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')

--- a/symbols/waste_disposal.svg
+++ b/symbols/waste_disposal.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 14 14"
+   height="14"
+   width="14"
+   id="svg10"
+   version="1.1">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <path
+     id="path817"
+     d="M 6 1 L 6 2 L 3 2 L 3 3 L 11 3 L 11 2 L 8 2 L 8 1 L 6 1 z M 3 5 L 4 14 L 10 14 L 11 5 L 3 5 z M 5 6 L 6 6 L 6 13 L 5 13 L 5 6 z M 8 6 L 9 6 L 9 13 L 8 13 L 8 6 z "
+     style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-opacity:1" />
+</svg>


### PR DESCRIPTION
Resolves #419.

As this feature is both popular (54k+ uses) and small scale, I choose the least obtrusive rendering possible. 

The icon is bigger than waste basket, since in reality it is larger (standard 14 px matrix instead of 10 px), but otherwise they are rendered in a similar way: on z19+ with low priority. I also render only nodes to avoid rendering icons on waste disposal sheds. Nodes are much more popular so this means rendering of 95% such objects.

![jdtv_9jz](https://user-images.githubusercontent.com/5439713/33800650-7bc31230-dd44-11e7-906e-d4bc3f9a6471.png)
![glmdd98c](https://user-images.githubusercontent.com/5439713/33800651-7e4da0f6-dd44-11e7-8cc8-95f643e13ef4.png)

There might be some extreme cases mentioned in a discussion (https://github.com/gravitystorm/openstreetmap-carto/issues/419#issuecomment-193307736) where there are a lot of such sheds, but tagged as nodes, but this might be solved by retagging as `building:part=*` area (which is more precise). I also added dimmed rendering for access tagging (1367 uses) other than `permissive` and `yes` - the same as we do with parkings. Click to see the full scale:

![whqoav2t](https://user-images.githubusercontent.com/5439713/33800654-81afcbfc-dd44-11e7-8fd4-78b06938b98b.png)