### PR TITLE
Move small amenity=recycling bins to z19

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -472,7 +472,8 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_recycling'][zoom >= 17] {
+  [feature = 'amenity_recycling'][recycling_type = 'centre'][zoom >= 17],
+  [feature = 'amenity_recycling'][zoom >= 19] {
     marker-file: url('symbols/recycling.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -1893,7 +1894,8 @@
     text-placement: interior;
   }
 
-  [feature = 'amenity_recycling'][zoom >= 17] {
+  [feature = 'amenity_recycling'][recycling_type = 'centre'][zoom >= 17],
+  [feature = 'amenity_recycling'][zoom >= 19] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;

--- a/project.mml
+++ b/project.mml
@@ -1437,6 +1437,7 @@ Layer:
             tags->'power_source' as power_source,
             tags->'icao' as icao,
             tags->'iata' as iata,
+            tags->'recycling_type' as recycling_type,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1538,6 +1539,7 @@ Layer:
             tags->'power_source' as power_source,
             tags->'icao' as icao,
             tags->'iata' as iata,
+            tags->'recycling_type' as recycling_type,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1967,6 +1969,7 @@ Layer:
             tags->'operator' as operator,
             tags->'icao' as icao,
             tags->'iata' as iata,
+            tags->'recycling_type' as recycling_type,
             ref,
             way_area,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2046,6 +2049,7 @@ Layer:
             operator,
             icao,
             iata,
+            recycling_type,
             ref,
             way_area,
             is_building
@@ -2112,6 +2116,7 @@ Layer:
                 tags->'operator' as operator,
                 tags->'icao' as icao,
                 tags->'iata' as iata,
+                tags->'recycling_type' as recycling_type,
                 ref,
                 NULL AS way_area,
                 CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building


### PR DESCRIPTION
Resolves #847 (I guess, because this code is broader).

Only recycling centres (11k+ uses) will stay on z17+, all the other recycling features are supposed to be small or less important - including very popular recycling_type=container (107k+ uses) and all the other non-standard values.