### PR TITLE
Push non-car parking icons to higher zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1036,8 +1036,8 @@
   }
 
   [feature = 'amenity_parking'][zoom >= 17],
-  [feature = 'amenity_bicycle_parking'][zoom >= 17],
-  [feature = 'amenity_motorcycle_parking'][zoom >= 17] {
+  [feature = 'amenity_bicycle_parking'][zoom >= 18],
+  [feature = 'amenity_motorcycle_parking'][zoom >= 18] {
     [feature = 'amenity_parking'] {
       marker-file: url('symbols/parking.svg');
     }


### PR DESCRIPTION
Related to #1745.

Bicycle and motorcycle parkings are usually quite small comparing to car parkings, about 70% of them are tagged as nodes - most probably because they are small in reality. Especially bicycle parking icons tend to clutter the space, because there can be many of them on not too big urban area.

Another factor is that z17 is generally overused, even after moving shop icons later (see #2945).