### PR TITLE
Make nature reserves border thinner

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -203,7 +203,7 @@ overlapping borders correctly.
     a/line-opacity: 0.15;
     a/line-join: round;
     a/line-cap: round;
-    b/line-width: 2;
+    b/line-width: 1;
     b/line-offset: -1;
     b/line-color: green;
     b/line-opacity: 0.15;
@@ -212,7 +212,7 @@ overlapping borders correctly.
     [zoom >= 10] {
       a/line-width: 2;
       a/line-offset: -1;
-      b/line-width: 4;
+      b/line-width: 2;
       b/line-offset: -2;
     }
     [zoom >= 14] {


### PR DESCRIPTION
Follow up to #2119.
Resolves #1950 (I guess this is the real problem behind this ticket).

Protected areas like national parks and nature reserves can still be too strong, when they are clustered. The problem is with the borders between them - they are sometimes too strong and dominate everything. Hiding smaller ones makes it less severe, but in some places such "internal" borders are still too visible.

I propose to make lines a bit thinner, mostly on z8-z9 but also on z10-z13. It would make it safer to add rendering for boundary=protected_area (#603), which I plan to do. The chosen values should not make other places, where the borders are not clustered and which are shown on busy backgrounds, to disappear.

Okanogan, z8
Before
![wdxk7_pj](https://user-images.githubusercontent.com/5439713/33809749-06abd834-ddfc-11e7-9c88-d4de0d14a635.png)
After
![cytw0y1m](https://user-images.githubusercontent.com/5439713/33809751-0afee3a4-ddfc-11e7-91e3-f6266411c9ae.png)

Adirondack, z8
Before
![orleviua](https://user-images.githubusercontent.com/5439713/33809842-6fee0d84-ddfd-11e7-9b2c-06dc4dfaafc0.png)
After
![gqoqy9qr](https://user-images.githubusercontent.com/5439713/33809841-6d992d5c-ddfd-11e7-8e71-dc8dd1e5aef8.png)

Wrocław, z8
Before
![vx3gkysz](https://user-images.githubusercontent.com/5439713/33809878-eea75644-ddfd-11e7-84c2-b3cd0609ae61.png)
After
![yyueusus](https://user-images.githubusercontent.com/5439713/33809880-f13ae808-ddfd-11e7-989c-d9ebfb235a61.png)

Okanogan, z10
Before
![3ntezmnf](https://user-images.githubusercontent.com/5439713/33809927-91e185f0-ddfe-11e7-8f3a-a22ecb767ff7.png)
After
![prsai5pw](https://user-images.githubusercontent.com/5439713/33809928-964525ac-ddfe-11e7-847b-2998cab0f793.png)

Wrocław, z10
Before
![oc96ze_k](https://user-images.githubusercontent.com/5439713/33809901-3d79306c-ddfe-11e7-8877-d2ef0064c3c7.png)
After
![y7_dlj3u](https://user-images.githubusercontent.com/5439713/33809904-3ec7f58e-ddfe-11e7-9620-edcce585d254.png)



