### PR TITLE
Yellow background for community_centre and social_facility

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -520,7 +520,9 @@
   [feature = 'amenity_university'],
   [feature = 'amenity_college'],
   [feature = 'amenity_school'],
-  [feature = 'amenity_kindergarten'] {
+  [feature = 'amenity_kindergarten'],
+  [feature = 'amenity_community_centre'],
+  [feature = 'amenity_social_facility'] {
     [zoom >= 10] {
       polygon-fill: @residential;
       [zoom >= 12] {

--- a/project.mml
+++ b/project.mml
@@ -118,7 +118,8 @@ Layer:
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school',
-                                                    'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal', 'marketplace')
+                                                    'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
+                                                    'marketplace', 'community_centre', 'social_facility')
                                                     THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
@@ -142,7 +143,7 @@ Layer:
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten',
-                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace')
+                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility')
               OR man_made IN ('works')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')


### PR DESCRIPTION
Related to #2087.

I think it's safe to add community_centre (#506) and social_facility (#1295) as societal amenities - with a light yellow background.

I would also like to add arts_centre, since this is sometimes similar to community_centre, but I'm not sure if this would be accepted - what do you think about it? We don't have a clean, generic solution for lot of "campuses" and social services, so I prefer to make smaller steps where this seems quite consistent rather than try to solve as much as it's possible.

amenity=social_facility 
Before
![i5qq_aje](https://user-images.githubusercontent.com/5439713/33867645-77b46750-defe-11e7-8f99-f63cc1cb24f8.png)

After
![glqi5ovz](https://user-images.githubusercontent.com/5439713/33867649-7a494ce2-defe-11e7-8ee3-48b034a687c9.png)

amenity=community_centre 
Before
![phkevc4e](https://user-images.githubusercontent.com/5439713/33867652-7cebc538-defe-11e7-8cdf-00b1043e7d29.png)

After
![hydv oni](https://user-images.githubusercontent.com/5439713/33867655-7f7f6638-defe-11e7-97ed-1de1751d2b69.png)

