### PR TITLE
Rendering seasonal waterways as intermittent

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -177,7 +177,11 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, waterway, tags->'intermittent' as intermittent,
+            way, 
+            waterway, 
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('stream', 'drain', 'ditch')
@@ -193,7 +197,9 @@ Layer:
         (SELECT
             way,
             waterway,
-            tags->'intermittent' as intermittent
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              THEN 'yes' ELSE 'no' END AS int_intermittent
           FROM planet_osm_line
           WHERE waterway = 'river'
         ) AS water_lines_low_zoom
@@ -276,7 +282,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, waterway, name, tags->'intermittent' as intermittent,
+            way, 
+            waterway, 
+            name, 
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              THEN 'yes' ELSE 'no' END AS int_intermittent,            
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'no' AS bridge
           FROM planet_osm_line
@@ -945,7 +956,9 @@ Layer:
             way,
             waterway,
             name,
-            tags->'intermittent' as intermittent,
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              THEN 'yes' ELSE 'no' END AS int_intermittent,            
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'yes' AS bridge
           FROM planet_osm_line
@@ -2205,7 +2218,9 @@ Layer:
             waterway,
             lock,
             name,
-            tags->'intermittent' as intermittent,
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'derelict_canal', 'stream', 'drain', 'ditch', 'wadi')

--- a/water.mss
+++ b/water.mss
@@ -69,7 +69,7 @@
         [waterway = 'stream'][zoom >= 15] {
           line-width: 3.5;
         }
-        [intermittent = 'yes'] {
+        [int_intermittent = 'yes'] {
           line-dasharray: 4,3;
           line-cap: butt;
           line-join: round;
@@ -82,7 +82,7 @@
 
 #water-lines-low-zoom {
   [waterway = 'river'][zoom >= 8][zoom < 12] {
-    [intermittent = 'yes'] {
+    [int_intermittent = 'yes'] {
       line-dasharray: 8,4;
       line-cap: butt;
       line-join: round;
@@ -123,7 +123,7 @@
     water/line-cap: round;
     water/line-join: round;
 
-    [intermittent = 'yes'],
+    [int_intermittent = 'yes'],
     [waterway = 'wadi'] {
       [bridge = 'yes'][zoom >= 14] {
         bridgefill/line-color: white;
@@ -191,7 +191,7 @@
         }
       }
 
-      [intermittent = 'yes'] {
+      [int_intermittent = 'yes'] {
         water/line-dasharray: 4,3;
         water/line-cap: butt;
         water/line-join: round;


### PR DESCRIPTION
Resolves #2095.

Tag seasonal has basically two values used - yes and no (~96% of 147k uses), but there are also others, like spring or similar. I think it's safer to treat every value other than "no" as a sign, that there is some seasonality, and this code reflects this choice. 

Of course we can also render just some list of values (with seasonal=yes of course), but it's hard to tell what to include exactly. Originally it was proposed to render just "yes", but this is not binary concept.