### PR TITLE
Changing tourism=picnic_site icon colour to green

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -912,7 +912,7 @@
 
   [feature = 'tourism_picnic_site'][zoom >= 16] {
     marker-file: url('symbols/picnic.svg');
-    marker-fill: @amenity-brown;
+    marker-fill: @leisure-green;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -1266,6 +1266,9 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: @amenity-brown;
+    [feature = 'tourism_picnic_site'] {
+      text-fill: @leisure-green;
+    }
     text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;


### PR DESCRIPTION
Resolves #2915.

[Example place](https://www.openstreetmap.org/#map=19/52.11688/21.08482) with both `tourism=picnic_site` and `leisure=picnic_table`:

Before
![n 6jqh3v](https://user-images.githubusercontent.com/5439713/34236949-4f7e9d98-e5fa-11e7-8479-f7597ab36307.png)

After
![fkf1l1zq](https://user-images.githubusercontent.com/5439713/34236951-542ec0fc-e5fa-11e7-8d5d-ace47b391a3c.png)
