### PR TITLE
Move emergency=phone to higher zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -504,7 +504,7 @@
     marker-clip: false;
   }
 
-  [feature = 'emergency_phone'][zoom >= 17] {
+  [feature = 'emergency_phone'][zoom >= 19] {
     marker-file: url('symbols/emergency_phone.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;


### PR DESCRIPTION
Related to #1884.

Emergency phones are really small scale, special features and I'm not even sure if they belong to general map - probably not, but even if they do, they should be rendered later, because proper tagging results in z17 clutter:

[Example place on z17](http://www.openstreetmap.org/#map=17/41.30962/-72.92796):

Before
![feoc_qbo](https://user-images.githubusercontent.com/5439713/34283428-f3651456-e6cb-11e7-92b9-e3e7e334807b.png)
After
![g6tcvoqd](https://user-images.githubusercontent.com/5439713/34283431-f76833e4-e6cb-11e7-8e05-1607c10179a7.png)
