### PR TITLE
Yellow background for amenity=arts_centre

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -522,7 +522,8 @@
   [feature = 'amenity_school'],
   [feature = 'amenity_kindergarten'],
   [feature = 'amenity_community_centre'],
-  [feature = 'amenity_social_facility'] {
+  [feature = 'amenity_social_facility'],
+  [feature = 'amenity_arts_centre'] {
     [zoom >= 10] {
       polygon-fill: @residential;
       [zoom >= 12] {

--- a/project.mml
+++ b/project.mml
@@ -119,7 +119,7 @@ Layer:
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
-                                                    'marketplace', 'community_centre', 'social_facility')
+                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre')
                                                     THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
@@ -143,7 +143,8 @@ Layer:
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten',
-                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility')
+                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
+                             'arts_centre')
               OR man_made IN ('works')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')


### PR DESCRIPTION
Follow up to #2981, related to #2985.

With recent changes with leisure backgrounds, `societal amenities` are better defined and I think amenity=arts_centre is a good candidate to be included, since it is similar to amenity=community_centre.

[Example location](http://www.openstreetmap.org/#map=19/52.16103/21.21327):

Before
![r6nibarp](https://user-images.githubusercontent.com/5439713/34319142-abc050d8-e7da-11e7-9f5b-eab6039a94a3.png)

After
![ffefdz38](https://user-images.githubusercontent.com/5439713/34319144-b0412ac4-e7da-11e7-8fc6-d98a9066c078.png)