### PR TITLE
Move natural=heath earlier

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -478,7 +478,7 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'natural_heath'][zoom >= 10] {
+  [feature = 'natural_heath'][zoom >= 8] {
     polygon-fill: @heath;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }

--- a/project.mml
+++ b/project.mml
@@ -91,12 +91,12 @@ Layer:
           FROM (SELECT
               way, COALESCE(name, '') AS name, religion,
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial') THEN landuse ELSE NULL END)) AS landuse,
-              ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock') THEN "natural" ELSE NULL END)) AS "natural",
+              ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial')
-              OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock'))
+              OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL
             ORDER BY way_area DESC


### PR DESCRIPTION
Showing natural=heath on z8+ (instead of z10+) gives England nature reserves a context:

z8
Before
![sacmenr9](https://user-images.githubusercontent.com/5439713/34329240-8a26a08e-e8f8-11e7-9038-81bd5afec9c8.png)

After
![xxmcorby](https://user-images.githubusercontent.com/5439713/34329248-a5aab1e2-e8f8-11e7-8d9c-f354d729096a.png)

z9 (click to see full images)
Before
![ustumfwg](https://user-images.githubusercontent.com/5439713/34329243-90559078-e8f8-11e7-8eae-326d93ce88bb.png)

After
![a na nxy](https://user-images.githubusercontent.com/5439713/34329249-aa82367c-e8f8-11e7-9a90-5f36e3da92dd.png)
