### PR TITLE
[WIP] OpenType feature “zero”

### DIFF
--- a/fonts.mss
+++ b/fonts.mss
@@ -175,3 +175,9 @@ Italics are only available for the base font, not the other scripts.
 For a considerable number of labels this style will make no difference to the regular style.
 */
 @oblique-fonts: "Noto Sans Italic", @book-fonts;
+
+/*
+Tailoring OpenType features:
+- “zero” (Slashed zero): enabled to make O and 0 easy to distinguish
+*/
+@opentype-features: "zero 1";

--- a/roads.mss
+++ b/roads.mss
@@ -2420,6 +2420,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-size: 10;
       text-fill: black;
       text-face-name: @book-fonts;
+      text-font-feature-settings: @opentype-features;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: 30;  // 3.0 em
@@ -2875,6 +2876,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
+      text-font-feature-settings: @opentype-features;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @tertiary-fill;
     }


### PR DESCRIPTION
Resolves #2647 

It would look like this:

Before:
![before](https://user-images.githubusercontent.com/6830724/34418149-4ff31880-ebf4-11e7-8a6e-8a2f13230c5f.png)

After:
![after](https://user-images.githubusercontent.com/6830724/34418155-561b6e4c-ebf4-11e7-9ce3-fd6885b1d722.png)

At very small text sizes, it looks a little bit like an “8”. Gets better when font size rises.

(In the image, the road name is at font size 9 pt and looks not so great, the junction name is at font size 10 pt and looks better. Road names are currently the last part in this style that uses font sizes < 10 pt.)

The current code only applies this to junction names and some road names, but we would have to add it to all other texts because we likely want to provide a consistent rendering. (Maybe the most interesting usecase are “ref” values of “highway” objects, because these are typically not hole words, to it’s more difficult to differentiate “0” and “O” just by guessing.)

Questions:

- Do we want this?
- If yes – I suppose there is no other way to set text-font-features globally instead of applying it individually like we are doing with text-face-name, is there?