### PR TITLE
Fine-tuning of bridge labels

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1680,6 +1680,7 @@ Layer:
             name
           FROM planet_osm_polygon
           WHERE man_made = 'bridge'
+          ORDER BY way_area DESC
         ) AS bridge_text
     properties:
       minzoom: 11

--- a/roads.mss
+++ b/roads.mss
@@ -2449,30 +2449,36 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-min-distance: 2;
+      text-margin: 3; // 0.3 em
       text-wrap-width: 30;
       text-placement: interior;
       [way_pixels > 250] {
         text-size: 11;
+        text-margin: 3.3; // 0.3 em
         text-wrap-width: 33; // 3 em
         text-line-spacing: -1.35; // -0.15 em
+        text-halo-radius: @standard-halo-radius * 1.1;
       }
       [way_pixels > 1000] {
         text-size: 12;
+        text-margin: 3.6; // 0.3 em
         text-wrap-width: 36; // 3 em
         text-line-spacing: -1.65; // -0.15 em
-        text-halo-radius: @standard-halo-radius * 1.5;
+        text-halo-radius: @standard-halo-radius * 1.2;
       }
       [way_pixels > 4000] {
         text-size: 13;
+        text-margin: 3.9; // 0.3 em
         text-wrap-width: 39; // 3 em
         text-line-spacing: -1.80; // -0.15 em
+        text-halo-radius: @standard-halo-radius * 1.3;
       }
       [way_pixels > 16000] {
         text-size: 14;
+        text-margin: 4.2; // 0.3 em
         text-wrap-width: 42; // 3 em
         text-line-spacing: -1.95; // -0.15 em
-        text-halo-radius: 2;
+        text-halo-radius: @standard-halo-radius * 1.4;
       }
     }
   }


### PR DESCRIPTION
Fine-tuning of bridge labels

Now the names of bigger bridges are preferred over the names of smaller bridges. The deprecated `text-min-distance` has replaces by a (slightly bigger) text-margin to avoid confusion with labels that are too near from each other. And margin and halo now scale smoothly with increasing text size.

Before:
![screenshot 1](https://user-images.githubusercontent.com/6830724/34436410-9f44a388-ec8d-11e7-99cd-d3d1ae09cb79.png)

After:
![screenshot 2](https://user-images.githubusercontent.com/6830724/34436411-a3d5b8ce-ec8d-11e7-9d04-b601b6feeb10.png)

Before:
![screenshot 3](https://user-images.githubusercontent.com/6830724/34436417-ae462758-ec8d-11e7-8446-4d750051e321.png)

After:
![screenshot 4](https://user-images.githubusercontent.com/6830724/34436420-b29d1172-ec8d-11e7-8ff3-6620b40204c6.png)

Before:
![screenshot 5](https://user-images.githubusercontent.com/6830724/34436421-b674eda6-ec8d-11e7-9b6b-bc872e1fcfa1.png)

After:
![screenshot 6](https://user-images.githubusercontent.com/6830724/34436424-be52f8a6-ec8d-11e7-9b5f-e59d24c81817.png)
