### PR TITLE
Move highway=traffic_signals later

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -115,7 +115,7 @@
     marker-clip: false;
   }
 
-  [feature = 'highway_traffic_signals'][zoom >= 17] {
+  [feature = 'highway_traffic_signals'][zoom >= 19] {
     marker-file: url('symbols/traffic_light.16.svg');
     marker-fill: #0a0a0a;
     marker-placement: interior;


### PR DESCRIPTION
Related to #1745.

Traffic signals are currently rendered much too early. They are not the destination (like shops or playgrounds), they are not landmarks (like towers), they are just a part of a road infrastructure. 

Roads have some important properties and features - class, name, direction, reference number, access, surface but also bus stops. Traffic lights are not as important to see on the map as any of them, but can still be shown on the highest level, just like other small things that are mapped in OSM.

[Extreme example](https://www.openstreetmap.org/#map=18/52.22984/21.01180) when even z18 is too early visually:
Before 
![qoixk0g4](https://user-images.githubusercontent.com/5439713/34445291-1396a214-ecd3-11e7-94c6-1fcc2a077d17.png)
After
![ghlurapf](https://user-images.githubusercontent.com/5439713/34445300-201a21f0-ecd3-11e7-8518-9cf21a617aa5.png)
