### PR TITLE
Adding rendering for historic=wayside_shrine

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -451,6 +451,13 @@
     marker-clip: false;
   }
 
+  [feature = 'historic_wayside_shrine'][zoom >= 17] {
+    marker-file: url('symbols/shrine.svg');
+    marker-fill: @man-made-icon;
+    marker-placement: interior;
+    marker-clip: false;
+  }
+    
   [feature = 'amenity_police'][zoom >= 16] {
     marker-file: url('symbols/police.svg');
     marker-fill: @public-service;
@@ -1389,6 +1396,7 @@
 
   [feature = 'man_made_cross'][zoom >= 17],
   [feature = 'historic_wayside_cross'][zoom >= 17],
+  [feature = 'historic_wayside_shrine'][zoom >= 17],
   [feature = 'natural_cave_entrance'][zoom >= 15],
   [feature = 'man_made_mast'][zoom >= 17],
   [feature = 'man_made_water_tower'][zoom >= 17] {
@@ -1430,7 +1438,8 @@
     text-placement: interior;
   }
   
-  [feature = 'military_bunker'][zoom >= 17] {
+  [feature = 'military_bunker'][zoom >= 17],
+  [feature = 'historic_wayside_shrine'][zoom >= 17] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;

--- a/project.mml
+++ b/project.mml
@@ -1544,7 +1544,7 @@ Layer:
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END
+              'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END
             ) AS feature,
             access,
             CASE
@@ -1583,7 +1583,7 @@ Layer:
                            'dog_park', 'fitness_centre', 'fitness_station', 'firepit')
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
-            OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort')
+            OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine')
             OR tags->'memorial' IN ('plaque')
             OR military IN ('bunker')
             OR tags @> 'emergency=>phone'
@@ -2123,7 +2123,7 @@ Layer:
                   'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
                   'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
                   'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-                  'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END
+                  'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END
                 ) AS feature,
                 access,
                 name,
@@ -2158,7 +2158,7 @@ Layer:
                   OR "natural" IS NOT NULL
                   OR place IN ('island', 'islet')
                   OR military IN ('danger_area', 'bunker')
-                  OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort')
+                  OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine')
                   OR tags->'memorial' IN ('plaque')
                   OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator')
                   OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
@@ -2318,7 +2318,7 @@ Layer:
               'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') THEN railway ELSE NULL END,
               'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 
                             'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,
+              'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log') THEN barrier ELSE NULL END
             )  AS feature,
@@ -2328,7 +2328,7 @@ Layer:
           WHERE highway IN ('mini_roundabout')
              OR railway IN ('level_crossing', 'crossing')
              OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket', 'waste_disposal')
-             OR historic IN ('wayside_cross')
+             OR historic IN ('wayside_cross', 'wayside_shrine')
              OR man_made IN ('cross')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log')
           ORDER BY prio

--- a/symbols/shrine.svg
+++ b/symbols/shrine.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 14 14"
+   height="14"
+   width="14"
+   id="svg109"
+   version="1.1">
+  <metadata
+     id="metadata115">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs113" />
+  <path
+     id="rect3696-2"
+     d="M 7 0 L 4.2929688 2.8867188 L 4.2890625 2.8867188 L 4.2890625 2.890625 L 4.2890625 12.263672 L 9.7109375 12.263672 L 9.7109375 2.890625 L 9.7109375 2.8867188 L 9.7070312 2.8867188 L 7 0 z M 7 3.5 A 1.3368738 1.3368738 0 0 1 8.3359375 4.7949219 L 8.3378906 4.7949219 L 8.3378906 8.3320312 L 5.6621094 8.3320312 L 5.6621094 4.7949219 L 5.6660156 4.7949219 A 1.3368738 1.3368738 0 0 1 7 3.5 z M 3.453125 13.09375 L 3.453125 14 L 10.546875 14 L 10.546875 13.09375 L 3.453125 13.09375 z "
+     style="fill:#000000;stroke:none;stroke-width:3.22851586;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>


### PR DESCRIPTION
Resolves  #131.

It seems that we can render shrines from z17, the same as crosses, because it doesn't look too bad even in this extreme example (see https://github.com/gravitystorm/openstreetmap-carto/issues/131#issuecomment-142845653):

![wazyzeyt](https://user-images.githubusercontent.com/5439713/34461073-8090b702-ee21-11e7-9ec3-49143fcc5ec4.png)

Another, [much more common example](https://www.openstreetmap.org/node/4281335169#map=17/52.17459/21.04477), where the religion is christian (in the example above shrines lack `religion=*` tag) - we also have the name (30% shrines have it too):
![hk9yyxxh](https://user-images.githubusercontent.com/5439713/34461091-427bacb4-ee22-11e7-9c93-e2af985ea0be.png)

The difference between christian and generic shrine is subtle, but it's always good to promote diversity if possible (it's not always the case).
