### PR TITLE
toll booth symbol

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -122,6 +122,13 @@
     marker-clip: false;
   }
 
+  [feature = 'barrier_toll_booth'][zoom >= 16] {
+    marker-file: url('symbols/toll_booth.svg');
+    marker-fill: @transportation-icon;
+    marker-placement: interior;
+    marker-clip: false;
+  }
+
   [feature = 'amenity_cafe'][zoom >= 17] {
     marker-file: url('symbols/cafe.svg');
     marker-fill: @gastronomy;
@@ -1209,6 +1216,7 @@
 
   [feature = 'amenity_car_rental'][zoom >= 17],
   [feature = 'amenity_bicycle_rental'][zoom >= 17],
+  [feature = 'barrier_toll_booth'][zoom >= 17],
   [feature = 'leisure_slipway'][zoom >= 17] {
     text-name: "[name]";
     text-size: @standard-font-size;
@@ -1217,6 +1225,7 @@
     text-fill: @transportation-text;
     [feature = 'amenity_car_rental']     { text-dy: 10; }
     [feature = 'amenity_bicycle_rental'] { text-dy: 10; }
+    [feature = 'barrier_toll_booth']     { text-dy: 13; }
     [feature = 'leisure_slipway']        { text-dy: 13; }
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;

--- a/project.mml
+++ b/project.mml
@@ -1542,6 +1542,7 @@ Layer:
                                 WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' ELSE NULL END,
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,
+              'barrier_' || CASE WHEN barrier IN ('toll_booth') THEN barrier ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END
             ) AS feature,
@@ -1580,6 +1581,7 @@ Layer:
             OR shop IS NOT NULL
             OR leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',
                            'dog_park', 'fitness_centre', 'fitness_station', 'firepit')
+            OR barrier IN ('toll_booth')
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
@@ -2113,6 +2115,7 @@ Layer:
                                                         'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree')
                                                         THEN "natural" ELSE NULL END,
                   'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
+                  'barrier_' || CASE WHEN barrier IN ('toll_booth') THEN barrier ELSE NULL END,
                   'military_' || CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
                   'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
                                  THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
@@ -2156,6 +2159,7 @@ Layer:
                   OR man_made IN ('lighthouse', 'windmill', 'mast', 'water_tower', 'cross', 'obelisk', 'works')
                   OR "natural" IS NOT NULL
                   OR place IN ('island', 'islet')
+                  OR barrier IN ('toll_booth')
                   OR military IN ('danger_area', 'bunker')
                   OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
                   OR tags->'memorial' IN ('plaque')

--- a/symbols/toll_booth.svg
+++ b/symbols/toll_booth.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 14 14"
+   height="14"
+   width="14">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+    <path
+       id="path4136"
+       d="M 7.1679688 4.5117188 L 0 6 L 0 14.009766 L 6 14.009766 L 6 11.5 A 1 1 0 0 0 6.9960938 10.560547 L 13.722656 7.1972656 L 13.277344 6.3027344 L 6.5527344 9.6660156 A 1 1 0 0 0 6 9.5 L 6 6.7695312 L 7.6035156 5.3789062 L 7.1679688 4.5117188 z M 1 7 L 5 7 L 5 10 L 1 10 L 1 7 z "
+        />
+
+</svg>


### PR DESCRIPTION
Adds a toll booth symbol. Based on the icon of @MaestroGlanz, but without the right bollard (because at 14×14, with the bollard it looks to me a little bit like a dripping oil can). Some small geometry adjustments.

Resolves #958 

To discuss:
- Zoom level: 16?
- barrier=toll_booth on areas? JOSM and iD have a preset for both, points and areas. The wiki allows it on points and areas (right box on the wiki page), but at the same time, the wiki description says _“The node should be on the highway the toll applies to, in order to support routing decisions.”_ and doesn’t describe a correct mapping on areas. Actually about 5% of the toll booth objects in the database are areas – most of them have also a `building=*` tag.
- Between ¼ and ⅓ of the toll booth objects have a name. Should this be rendered?

![screenshot 1](https://user-images.githubusercontent.com/6830724/34638977-c6f3e99c-f2ce-11e7-9310-d05a66b7c96c.png)
![screenshot 3](https://user-images.githubusercontent.com/6830724/34638978-c72012e2-f2ce-11e7-9a21-99e922e5a54c.png)
![screenshot 4](https://user-images.githubusercontent.com/6830724/34638979-c740d1da-f2ce-11e7-9670-4cb1a4095a1b.png)

  