### PR TITLE
Fix invisible barriers on tourism_boundary - step 1

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -551,6 +551,23 @@ Layer:
         ) AS landuse_overlay
     properties:
       minzoom: 7
+  - id: tourism-boundary
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            name,
+            tourism
+          FROM planet_osm_polygon
+          WHERE tourism = 'theme_park'
+            OR tourism = 'zoo'
+        ) AS tourism_boundary
+    properties:
+      minzoom: 10
   - id: line-barriers
     class: barriers
     geometry: linestring
@@ -1201,23 +1218,6 @@ Layer:
         ) AS national_park_boundaries
     properties:
       minzoom: 8
-  - id: tourism-boundary
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
-            name,
-            tourism
-          FROM planet_osm_polygon
-          WHERE tourism = 'theme_park'
-            OR tourism = 'zoo'
-        ) AS tourism_boundary
-    properties:
-      minzoom: 10
   - id: trees
     geometry: polygon
     <<: *extents


### PR DESCRIPTION
This PR moves rendering the tourism-boundary layer under the barrier layer.

### Rationale:
Barriers on tourism-boundaries (currently zoo, theme_park) are not visible. Here is a mixture of fenced and unfenced boundary - try to figure out.  Hint: bride is unfenced, SW and NE corners are fenced. 
![z19_zoo_fenced-unfenced-mix](https://user-images.githubusercontent.com/8266355/35420916-797982d6-0240-11e8-953e-566f65b127f8.png)

There are two reasons:
1. tourism-boundary is rendered in a higher layer than barriers
2. the current outer line of the tourism outline (a/line) is relatively dark brown. As it uses opacity=0.5 the barrier shines weakly through, but this is barely noticeable since barrier uses a very thin (width=0.4) grey (```#444```) line. 

This PR only fixes reason 1. The effects are currently marginal, however the fix is a prerequisite of working further on outlines while keeping barriers visible, see drafts in #2290, #2704, #3035. The actual colour of the zoo+theme_park outline can be addressed separately.

### Details:
The ```tourism-boundaries``` layer was sitting between ```nature-reserve-boundaries``` and ```trees```. It is now moved up in the project.mml to sit between ```landuse-overlay``` (current use military hatching) and the ```barriers``` class.

### Side effects:
As it is moved next to military, the effects are comparable to the military outline. It is now rendered under several unrelated features, the only notable is that the boundary renders under _roads_. I see this as beneficial, as it improves the visibility of gates; and if an ungated road runs over the boundary this is now clearer.

### Before/after
As said, with the current brown boundary the visible effects are marginal, the darkness of the outer line is slightly strengthened (but that depends on the underlying landuse because of the opacity):
Before
![prz19_current_fenced](https://user-images.githubusercontent.com/8266355/35421454-941c5714-0243-11e8-8221-fc32726cc4b5.png)
After
![prz19_after_fenced](https://user-images.githubusercontent.com/8266355/35421463-9f8ad3a0-0243-11e8-8e69-57abfdacfcf9.png)

Here is a proof with a bright colour on a wider, non-transparant line (**the colour is not part of this PR**) to make clear that the barrier was invisible before and becomes now visible:
Before, solid bright line over barrier:
![z19_proof_current_barrier_under_boundary](https://user-images.githubusercontent.com/8266355/35421536-0fe48bb4-0244-11e8-99e3-8b17a007fcbe.png)
After, same line under barrier:
![z19_proof_barrier_over_tourism_boundary](https://user-images.githubusercontent.com/8266355/35421557-2f2d5a00-0244-11e8-8f92-92815a956cbb.png)

### Future Work
The PR enables to continue working on other outlines, where the presence of fences is well visible, example (not part of this PR):
![z19_transport-light_barrier_over_outline](https://user-images.githubusercontent.com/8266355/35421601-5c6d397c-0244-11e8-8472-4b7c9ad02578.png)
