### PR TITLE
Use UTF8 in createdb

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,10 +9,12 @@ Start by creating a database
 
 ```
 sudo -u postgres createuser -s $USER
-createdb gis
+createdb -E UTF8 -l en_GB.UTF8 gis
 ```
 
-Enable PostGIS and hstore extensions with
+The character encoding scheme to be used in the database is *UTF8* and the adopted collation is *en_GB.UTF8*.
+
+Enable *PostGIS* and *hstore* extensions with
 
 ```
 psql -d gis -c 'CREATE EXTENSION postgis; CREATE EXTENSION hstore;'


### PR DESCRIPTION
**Use UTF8 in createdb**

Minor hint within the documentation.

Mention that the character encoding scheme to be used in the *gis* database shall be UTF8 (e.g., useful when using [Ubuntu for Windows](https://www.microsoft.com/en-us/store/p/ubuntu/9nblggh4msv6) within  [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), where also `template template0` is needed).