### PR TITLE
Fix rendering bug (#3043) with access=yes|permissive tags.

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -59,7 +59,7 @@
       marker-file: url('symbols/square.svg');
     }
   }
-  [zoom >= 19] {
+  [zoom >= 19]["entrance" != null] {
     ["entrance" = "yes"],
     ["entrance" = "main"],
     ["entrance" = "home"],

--- a/project.mml
+++ b/project.mml
@@ -1099,8 +1099,9 @@ Layer:
             tags->'entrance' AS entrance,
             access
           FROM planet_osm_point
-          WHERE tags->'indoor' = 'no'
-            OR tags->'indoor' IS NULL)
+          WHERE tags->'entrance' IS NOT NULL AND
+            (tags->'indoor' = 'no'
+            OR tags->'indoor' IS NULL))
         AS entrances
     properties:
       minzoom: 18


### PR DESCRIPTION
Nodes with access=yes|permissive were rendered as brown circles at z=19
due to overly general entrance rendering rules. Tighten the entrances
layer code to apply only to entrance nodes. Fixes #3043.