### PR TITLE
Run osm2pgsql in slim mode

### DIFF
--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -45,6 +45,8 @@ EOF
   --hstore \
   --multi-geometry \
   --database gis \
+  --slim \
+  --drop \
   --style openstreetmap-carto.style \
   --tag-transform-script openstreetmap-carto.lua \
   $OSM2PGSQL_DATAFILE


### PR DESCRIPTION
Slim mode uses temporary tables, so running the process takes more disk
space, while less memory is used.

This resolves #2911.