### PR TITLE
add barrier=log like block

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1114,7 +1114,8 @@
   }
 
   [feature = 'barrier_bollard'],
-  [feature = 'barrier_block'] {
+  [feature = 'barrier_block'],
+  [feature = 'barrier_log'] {
     [zoom >= 16] {
       marker-width: 3;
       marker-line-width: 0;

--- a/project.mml
+++ b/project.mml
@@ -2320,7 +2320,7 @@ Layer:
                             'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log') THEN barrier ELSE NULL END
             )  AS feature,
             access,
             CASE WHEN amenity IN ('waste_basket', 'waste_disposal') THEN 2 ELSE 1 END AS prio
@@ -2330,7 +2330,7 @@ Layer:
              OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket', 'waste_disposal')
              OR historic IN ('wayside_cross')
              OR man_made IN ('cross')
-             OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')
+             OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log')
           ORDER BY prio
           ) AS amenity_low_priority
     properties:
@@ -2346,12 +2346,12 @@ Layer:
             way,
             COALESCE(
               'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block') THEN barrier ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log') THEN barrier ELSE NULL END
             )  AS feature,
             access
           FROM planet_osm_polygon p
           WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')
-             OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block')
+             OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log')
           ) AS amenity_low_priority_poly
     properties:
       minzoom: 14


### PR DESCRIPTION
Resolves #3052 
Add barrier=log to the non-opening barrier types 'bollard' and 'block'.
z19 before/after (Kosmtik):
![z19_log_before](https://user-images.githubusercontent.com/8266355/35777641-bfef3dfa-09b1-11e8-8a7b-23c721e0b29a.png) ![z19_log_after](https://user-images.githubusercontent.com/8266355/35777593-0314f2f6-09b1-11e8-8846-15376edd3151.png)

