### PR TITLE
Move amenity=toilets to higher zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -533,11 +533,14 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_toilets'][zoom >= 17] {
-    marker-file: url('symbols/toilets.svg');
-    marker-fill: @amenity-brown;
-    marker-placement: interior;
-    marker-clip: false;
+  [feature = 'amenity_toilets'] {
+    [access = 'yes'][zoom >= 18],
+    [zoom >= 19] {
+      marker-file: url('symbols/toilets.svg');
+      marker-fill: @amenity-brown;
+      marker-placement: interior;
+      marker-clip: false;
+    }
   }
 
   [feature = 'amenity_drinking_water'][zoom >= 17] {


### PR DESCRIPTION
Related to #1745.

This change moves the toilets to higher zoom levels, because in well mapped areas they compete with other amenities like shop or cafe. Also this is rather a short-distance amenity, so lower zoom levels are not relevant here.

The problem is that we don't even know if they are standalone amenities or just a part of some other amenity. So I guess that toilets with access for everyone ("yes") or paid ("customers'" or "destination") are more important and most probably standalone, but status of the rest (including "permissive" and lack of the access tags) is not clear and they are probably less important. 

[Louvre example](https://www.openstreetmap.org/#map=17/48.86141/2.33593) (click the images to view full size)):
z17
Before
![nzhd7g_9](https://user-images.githubusercontent.com/5439713/35811580-1c6c00bc-0a8f-11e8-8b2f-b8660400238e.png)
After
![ijkxw4ux](https://user-images.githubusercontent.com/5439713/35811549-09c52f1a-0a8f-11e8-99b5-505243b01e76.png)

z18
Before
![zfvswuzo](https://user-images.githubusercontent.com/5439713/35811589-2161ef14-0a8f-11e8-8a55-5f77f0c82b29.png)
After
![ncv4xhfa](https://user-images.githubusercontent.com/5439713/35811555-0d56cbca-0a8f-11e8-8da5-57d9241da3fc.png)
