### PR TITLE
Adding rendering for historic=fort

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -590,6 +590,13 @@
     marker-clip: false;
   }
 
+  [feature = 'historic_fort'][zoom >= 16] {
+    marker-file: url('symbols/fort.svg');
+    marker-fill: @memorials;
+    marker-placement: interior;
+    marker-clip: false;
+  }
+
   [feature = 'historic_archaeological_site'][zoom >= 16] {
     marker-file: url('symbols/archaeological_site.svg');
     marker-fill: @culture;
@@ -1389,7 +1396,8 @@
   [feature = 'historic_memorial'][zoom >= 17],
   [feature = 'historic_memorial_plaque'][zoom >= 19],
   [feature = 'man_made_obelisk'][zoom >= 16],
-  [feature = 'historic_monument'][zoom >= 16] {
+  [feature = 'historic_monument'][zoom >= 16],
+  [feature = 'historic_fort'][zoom >= 16] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;

--- a/project.mml
+++ b/project.mml
@@ -1443,7 +1443,7 @@ Layer:
                                                   'fitness_centre', 'fitness_station', 'firepit') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('spring') THEN "natural" ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
               'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,                             
@@ -1480,7 +1480,7 @@ Layer:
                            'fitness_station', 'firepit')
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk')
             OR "natural" IN ('spring')
-            OR historic IN ('memorial', 'monument', 'archaeological_site')
+            OR historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
             OR tags->'memorial' IN ('plaque')
             OR military IN ('bunker')
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
@@ -1535,7 +1535,7 @@ Layer:
                                                   'dog_park', 'fitness_centre', 'fitness_station', 'firepit') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN "natural" ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
               'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,
@@ -1583,7 +1583,7 @@ Layer:
                            'dog_park', 'fitness_centre', 'fitness_station', 'firepit')
             OR man_made IN ('mast', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
-            OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
+            OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort')
             OR tags->'memorial' IN ('plaque')
             OR military IN ('bunker')
             OR tags @> 'emergency=>phone'
@@ -1971,7 +1971,7 @@ Layer:
                                                     'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
-              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
+              'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
               'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
@@ -2009,7 +2009,7 @@ Layer:
               OR "natural" IS NOT NULL
               OR place IN ('island', 'islet')
               OR military IN ('danger_area', 'bunker')
-              OR historic IN ('memorial', 'monument', 'archaeological_site')
+              OR historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
               OR tags->'memorial' IN ('plaque')
               OR highway IN ('services', 'rest_area', 'bus_stop', 'elevator')
               OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
@@ -2115,7 +2115,7 @@ Layer:
                                                         THEN "natural" ELSE NULL END,
                   'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                   'military_' || CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
-                  'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site')
+                  'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
                                  THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                                  ELSE NULL END,
                   'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
@@ -2158,7 +2158,7 @@ Layer:
                   OR "natural" IS NOT NULL
                   OR place IN ('island', 'islet')
                   OR military IN ('danger_area', 'bunker')
-                  OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross')
+                  OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort')
                   OR tags->'memorial' IN ('plaque')
                   OR highway IN ('bus_stop', 'services', 'rest_area', 'elevator')
                   OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')

--- a/symbols/fort.svg
+++ b/symbols/fort.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 14 14"
+   id="svg2">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     id="fort"
+     d="M 1 1 L 1 3 L 6 3 L 6 1 L 5 1 L 5 2 L 4 2 L 4 1 L 3 1 L 3 2 L 2 2 L 2 1 L 1 1 z M 8 1 L 8 3 L 13 3 L 13 1 L 12 1 L 12 2 L 11 2 L 11 1 L 10 1 L 10 2 L 9 2 L 9 1 L 8 1 z M 1 4 L 1 10 L 13 10 L 13 4 L 8 4 L 8 6 L 6 6 L 6 4 L 1 4 z M 3 6 L 4 6 L 4 7 L 3.5 8 L 3 7 L 3 6 z M 10 6 L 11 6 L 11 7 L 10.5 8 L 10 7 L 10 6 z M 1 11 L 0 14 L 14 14 L 13 11 L 1 11 z "
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
Resolves #2871.

Icon design is kind of a blend of https://github.com/gmgeo/osmic/blob/master/tourism/castle-fortress-14.svg and https://github.com/gmgeo/osmic/blob/master/tourism/fort-14.svg, which makes sense, since fort is similar to castle (newer form), but its icon in Osmic is not clear for me at 14 px (![fort osmic](https://user-images.githubusercontent.com/25656654/35795068-4133b0a2-0a58-11e8-89a0-87530f7ee8dd.png) ).

Rendering from z16 like monuments for example, because they are rather alone by design so it shouldn't clash with other objects on the map. It also takes lower priority than museum icon (like [here](https://www.openstreetmap.org/way/37014114#map=16/52.4155/16.8728)), which is good in my opinion.

[Example on the node](https://www.openstreetmap.org/node/710620121):
![2ceta9dy](https://user-images.githubusercontent.com/5439713/35872681-baf18ff8-0b67-11e8-87a2-e6bc79d504f7.png)

[Example on the way+building](https://www.openstreetmap.org/way/27951036#map=17/52.40590/16.85907):
![7ldvybzj](https://user-images.githubusercontent.com/5439713/35872688-c0cddc2e-0b67-11e8-8360-c8192eb7420c.png)
