### PR TITLE
Make military=danger_area font dark pink and slanted

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1580,8 +1580,8 @@
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
       }
-      text-fill: darken(@military, 40%);
-      text-face-name: @bold-fonts;
+      text-fill: darken(@military, 20%);
+      text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: interior;


### PR DESCRIPTION
Follow up to #3057.

Small fix to make label rendering of [danger area without landuse=military](https://www.openstreetmap.org/way/173480188) still easy to recognize (hence dark pink again) and compatible with area labels rule (hence slanted):

z11
Before
![aez5ysl](https://user-images.githubusercontent.com/5439713/36100028-1581de18-1005-11e8-8e8f-f81f391bdb62.png)

Current master
![kkj6e 6](https://user-images.githubusercontent.com/5439713/36100033-19ff2e78-1005-11e8-96de-af89a67f29d3.png) 

After
![iqdw2do_](https://user-images.githubusercontent.com/5439713/36164142-c2611630-10eb-11e8-8a81-0640e1627558.png)