### PR TITLE
Adding rendering for amenity=police and amenity=fire_station areas

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -543,6 +543,21 @@
     }
   }
 
+  [feature = 'amenity_fire_station'][zoom >= 8][way_pixels > 900],
+  [feature = 'amenity_police'][zoom >= 8][way_pixels > 900],
+  [feature = 'amenity_fire_station'][zoom >= 13],
+  [feature = 'amenity_police'][zoom >= 13] {
+    polygon-fill: #F3E3DD;
+    line-color: @military; 
+    line-opacity: 0.24;
+    line-width: 1.0; 
+    line-offset: -0.5;
+    [zoom >= 15] {
+      line-width: 2; 
+      line-offset: -1.0;
+    }
+  }
+
   [feature = 'amenity_parking'][zoom >= 10],
   [feature = 'amenity_bicycle_parking'][zoom >= 10],
   [feature = 'amenity_motorcycle_parking'][zoom >= 10],

--- a/project.mml
+++ b/project.mml
@@ -119,8 +119,8 @@ Layer:
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
-                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space', 'bus_station')
-                                                    THEN amenity ELSE NULL END)) AS amenity,
+                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space', 'bus_station', 
+                                                    'fire_station', 'police') THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
                                                     'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial',
@@ -144,7 +144,7 @@ Layer:
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'taxi', 'university', 'college', 'school', 'hospital', 'kindergarten',
                              'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
-                             'arts_centre', 'parking_space', 'bus_station')
+                             'arts_centre', 'parking_space', 'bus_station', 'fire_station', 'police')
               OR man_made IN ('works')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')


### PR DESCRIPTION
Related to #3045.
Resolves #848.

Rendering police and fire station areas with the same hatching as new military area style, as discussed before. It will make uniformed services areas to use similar look.

Examples:
[Police](https://www.openstreetmap.org/way/556906228#map=18/52.24606/20.99851)
![fyhfx56t](https://user-images.githubusercontent.com/5439713/36321779-4ea007e4-134b-11e8-9a95-72a210051696.png)

[Fire services](https://www.openstreetmap.org/way/35017939#map=19/52.18410/21.00388)
![acj3finn](https://user-images.githubusercontent.com/5439713/36321778-4b26c5c6-134b-11e8-8dee-29bcea90582c.png)

[Comparison with military area rendering](https://www.openstreetmap.org/#map=18/52.21053/21.01156)
![wua6dgpj](https://user-images.githubusercontent.com/5439713/36321770-45bad4ce-134b-11e8-9df6-627b7cc0b3a1.png)