### PR TITLE
Explicitly state that PostgreSQL at least 9.5 is required

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,7 +110,7 @@ For development, a style design studio is needed.
 
 To display any map a database containing OpenStreetMap data and some utilities are required
 
-* [PostgreSQL](http://www.postgresql.org/)
+* [PostgreSQL](http://www.postgresql.org/) 9.5+
 * [PostGIS](http://postgis.org/)
 * [osm2pgsql](https://github.com/openstreetmap/osm2pgsql#installing) to [import your data](https://switch2osm.org/loading-osm-data/) into a PostGIS database
 * `curl` and `unzip` for downloading and decompressing files


### PR DESCRIPTION
SQL queries fail on PostgreSQL 9.3 with `operator does not exist: hstore -> boolean`. Turns out 9.5 is required. Let's state this in the documentation explicitly, for people upgrading their styles from earlier versions.