### PR TITLE
Fix operator precedence for hstore queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,11 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 * Add indentation after `SELECT`s until the end of the sub-select.
 * Add indentation for contents of `FROM`, `WHERE`, `ORDER BY` and other clauses
 * Put content with WHERE, etc if it's short
-* Add indentation if necessary for complex function calls, WHERE parenthesis, and CASE statements
+* Add indentation if necessary for complex function calls, WHERE parentheses, and CASE statements
 * One space before and after = etc
 * Name SQL subqueries after the layer name (but use underscores)
-* When extracting tags from hstore, use `tags->'foo'`, not `tags -> 'foo'`, and only add parenthesis if needed for order of operations
+* When extracting tags from hstore, use `tags->'foo'`, not `tags -> 'foo'`, and only add parentheses if needed for order of operations
+* Hstore queries tested for NULL should be enclosed in parentheses, e.g. `(tags->'foo') IS NULL`.
 * To check if a tag is in the tags hstore, use `tags @> 'foo=>bar'`, relying on automatic conversion from `text` to `hstore`.
 
 ## Map icon guidelines

--- a/project.mml
+++ b/project.mml
@@ -412,7 +412,7 @@ Layer:
             AND (amenity IS NULL OR amenity != 'place_of_worship')
             AND building != 'train_station'
             AND (aerialway IS NULL OR aerialway != 'station')
-            AND (tags->'public_transport' IS NULL OR tags->'public_transport' != 'station')
+            AND ((tags->'public_transport') IS NULL OR tags->'public_transport' != 'station')
             AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS buildings
@@ -1099,9 +1099,9 @@ Layer:
             tags->'entrance' AS entrance,
             access
           FROM planet_osm_point
-          WHERE tags->'entrance' IS NOT NULL AND
+          WHERE (tags->'entrance') IS NOT NULL AND
             (tags->'indoor' = 'no'
-            OR tags->'indoor' IS NULL))
+            OR (tags->'indoor') IS NULL))
         AS entrances
     properties:
       minzoom: 18


### PR DESCRIPTION
Fixes #3077.

See [the precedence table](https://www.postgresql.org/docs/9.3/static/sql-syntax-lexical.html#SQL-PRECEDENCE-TABLE): `IS` is higher than `(any other)`, which includes `->`.