### PR TITLE
Added landcover=grass as grass

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -327,7 +327,8 @@
   [feature = 'natural_grassland'],
   [feature = 'landuse_grass'],
   [feature = 'landuse_village_green'],
-  [feature = 'leisure_common'] {
+  [feature = 'leisure_common'],
+  [feature = 'landcover_grass'] {
     [zoom >= 10] {
       polygon-fill: @grass;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }


### PR DESCRIPTION
For the moment, landcover=grass does not render as grass. As this is subtly different then landuse=grass, this is a valuable addition.

For example, [here](https://www.openstreetmap.org/way/311784342) we would like to map the grass within a residential area. By using 'landcover', we can correctly use this within a residential area.

Rendering won't change visibly here:
![screenshot from 2018-02-21 15-59-34](https://user-images.githubusercontent.com/1466478/36487054-45e01a30-1720-11e8-9c89-5cb3ff9e3685.png)
