### PR TITLE
Mapnik non-strict mode

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,10 +130,10 @@ For deployment, CartoCSS and Mapnik are required.
 * [CartoCSS](https://github.com/mapbox/carto) >= 0.18.0 (we're using YAML)
 * [Mapnik](https://github.com/mapnik/mapnik/wiki/Mapnik-Installation) >= 3.0
 
-Remember to run CartoCSS with proper API version to avoid errors (at least 3.0.0: `carto -a "3.0.0"`).
+With CartoCSS you compile these sources into a Mapnik compatible XML file. When running CartoCSS, specify the Mapnik API version you are using (at least 3.0.0: `carto -a "3.0.0"`).
 
-With CartoCSS you can compile these sources into a Mapnik compatible XML file. If you're calling Mapnik in your own program, remember to load the XML file in non strict mode, as some fonts are declared with alternative names. This way, you only get a warning instead of an error when Mapnik does not find a font name.
+If you're calling Mapnik in your own program, remember to load the XML file in non strict mode. This way, fonts declared with alternative names will only generate warnings, not errors. For instance, using the Python bindings, this becomes:
 
-For instance, using the Python bindings, this becomes:
-
-    mapnik.load_map(mapnik.Map(width, height), xml_filename, False)  # False for non-strict mode
+```python
+mapnik.load_map(mapnik.Map(width, height), xml_filename, False)  # False for non-strict mode
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,7 +132,7 @@ For deployment, CartoCSS and Mapnik are required.
 
 Remember to run CartoCSS with proper API version to avoid errors (at least 3.0.0: `carto -a "3.0.0"`).
 
-With CartoCSS you can compile These sources into a Mapnik compatible XML file. If you're calling Mapnik in your own program, remember to load the XML file in non strict mode, as some fonts are declared with alternative names. This way, you only get a warning instead of an error when Mapnik does not find a font name.
+With CartoCSS you can compile these sources into a Mapnik compatible XML file. If you're calling Mapnik in your own program, remember to load the XML file in non strict mode, as some fonts are declared with alternative names. This way, you only get a warning instead of an error when Mapnik does not find a font name.
 
 For instance, using the Python bindings, this becomes:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -131,3 +131,9 @@ For deployment, CartoCSS and Mapnik are required.
 * [Mapnik](https://github.com/mapnik/mapnik/wiki/Mapnik-Installation) >= 3.0
 
 Remember to run CartoCSS with proper API version to avoid errors (at least 3.0.0: `carto -a "3.0.0"`).
+
+With CartoCSS you can compile These sources into a Mapnik compatible XML file. If you're calling Mapnik in your own program, remember to load the XML file in non strict mode, as some fonts are declared with alternative names. This way, you only get a warning instead of an error when Mapnik does not find a font name.
+
+For instance, using the Python bindings, this becomes:
+
+    mapnik.load_map(mapnik.Map(width, height), xml_filename, False)  # False for non-strict mode


### PR DESCRIPTION
Mention that, if Mapnik is being used programmatically, the map should be loaded in non-strict mode.