### PR TITLE
Adding rendering for amenity=parking_space

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -30,6 +30,7 @@
 @apron: #e9d1ff;
 @garages: #dfddce;
 @parking: #eeeeee;
+@parking-outline: saturate(darken(@parking, 40%), 20%);
 @railway: @industrial;
 @railway-line: @industrial-line;
 @rest_area: #efc8c8; // also services
@@ -548,10 +549,15 @@
     polygon-fill: @parking;
     [zoom >= 15] {
       line-width: 0.3;
-      line-color: saturate(darken(@parking, 40%), 20%);
+      line-color: @parking-outline;
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  
+  [feature = 'amenity_parking_space'][zoom >= 18] {
+    line-width: 0.3;
+    line-color: mix(@parking-outline, @parking, 50%);
   }
 
   [feature = 'aeroway_apron'][zoom >= 10] {

--- a/project.mml
+++ b/project.mml
@@ -119,7 +119,7 @@ Layer:
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
-                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'shower', 'bbq')
+                                                    'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'shower', 'bbq', 'parking_space')
                                                     THEN amenity ELSE NULL END)) AS amenity,
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
@@ -144,7 +144,7 @@ Layer:
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten',
                              'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
-                             'arts_centre', 'shower', 'bbq')
+                             'arts_centre', 'shower', 'bbq', 'parking_space')
               OR man_made IN ('works')
               OR military IN ('danger_area')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')


### PR DESCRIPTION
Resolves #428.

It adds visual clues for bigger parking areas. It's rendered the same as parking, but without "P" letter and probably without name, I think z18+ is good enough. This tagging scheme is used [118 468 times](https://taginfo.openstreetmap.org/tags/?key=amenity&value=parking_space).

[Example 1](https://www.openstreetmap.org/#map=19/52.30362/21.05551)
Before
![fx6ommbk](https://user-images.githubusercontent.com/5439713/36705558-227d6364-1b66-11e8-8fda-d23c9653e450.png)
After
![k e66o4x](https://user-images.githubusercontent.com/5439713/36705559-23e53dda-1b66-11e8-90cd-55c51ad75f43.png)

[Example 2](https://www.openstreetmap.org/#map=19/52.25835/20.99361)
Before
![3q_dolsn](https://user-images.githubusercontent.com/5439713/36705574-38708340-1b66-11e8-8eb0-d2b76dfaa223.png)
After
![ancvyrzq](https://user-images.githubusercontent.com/5439713/36705580-3c0ff7ce-1b66-11e8-9dd2-2a79ddb30fd4.png)
