### PR TITLE
Fixing SVG icons artifacts

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -104,7 +104,7 @@
   [feature = 'amenity_bus_station'][zoom >= 16] {
     marker-file: url('symbols/bus_station.svg');
     // use colors from SVG to allow for white background
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -182,7 +182,7 @@
   [feature = 'tourism_chalet'][zoom >= 17] {
     marker-file: url('symbols/chalet.svg');
     marker-fill: @accommodation-icon;
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -258,14 +258,14 @@
   [feature = 'tourism_guest_house'][zoom >= 17] {
     marker-file: url('symbols/guest_house.svg');
     marker-fill: @accommodation-icon;
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_apartment'][zoom >= 18] {
     marker-file: url('symbols/apartment.svg');
     marker-fill: @accommodation-icon;
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -936,14 +936,14 @@
   [feature = 'leisure_miniature_golf'][zoom >= 17] {
     marker-file: url('symbols/miniature_golf.svg');
     marker-fill: @leisure-green;
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'leisure_golf_course'][zoom >= 15] {
     marker-file: url('symbols/golf.svg');
     marker-fill: @leisure-green;
-    point-placement: interior;
+    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1112,10 +1112,10 @@
 
   [feature = 'railway_level_crossing'][zoom >= 14]::railway,
   [feature = 'railway_crossing'][zoom >= 15]::railway{
-    point-file: url('symbols/level_crossing.svg');
-    point-placement: interior;
+    marker-file: url('symbols/level_crossing.svg');
+    marker-placement: interior;
     [zoom >= 16] {
-      point-file: url('symbols/level_crossing2.svg');
+      marker-file: url('symbols/level_crossing2.svg');
     }
   }
 


### PR DESCRIPTION
Resolves #2787.
Resolves #3081.

Fixing code to avoid rendering artifacts. Some types haven't been reported, but when the problem is known, it was easy to spot examples. Railway crossings added to make the code more consistent.

[Mini golf, guest house](https://www.openstreetmap.org/#map=18/54.43010/-2.96525)
![_g 8dgbb](https://user-images.githubusercontent.com/5439713/36725101-8391187c-1bb5-11e8-9c8b-7de1ca06c00f.png)
![geohqeza](https://user-images.githubusercontent.com/5439713/36725104-8520a4dc-1bb5-11e8-8b34-029a36c69f54.png)

[Golf](https://www.openstreetmap.org/#map=15/45.5906/-122.6432)
![iqv__yi1](https://user-images.githubusercontent.com/5439713/36725315-33bddabe-1bb6-11e8-8527-33f1f8da0019.png)
![64tawyhv](https://user-images.githubusercontent.com/5439713/36725317-363cf64e-1bb6-11e8-87a6-438895659623.png)

[Apartment](https://www.openstreetmap.org/#map=19/52.26586/20.99200)
![izimychs](https://user-images.githubusercontent.com/5439713/36725590-0b28d1c0-1bb7-11e8-831f-e92e22982490.png)
![29hhwq0q](https://user-images.githubusercontent.com/5439713/36725593-0cc50e36-1bb7-11e8-861c-d3a3d92f3e61.png)

[Bus station](https://www.openstreetmap.org/way/485181612#map=18/51.39249/21.15921)
![3gw26xwk](https://user-images.githubusercontent.com/5439713/36726003-86086b2a-1bb8-11e8-88be-29bf749542fc.png)
![8et8uu8t](https://user-images.githubusercontent.com/5439713/36726010-88e70cac-1bb8-11e8-8820-c8fac0149e60.png)

[Chalet](https://www.openstreetmap.org/way/537467185#map=18/49.36841/22.43469)
![paiqli h](https://user-images.githubusercontent.com/5439713/36726182-35b3c074-1bb9-11e8-9d71-c830bff66987.png)
![0ckek9af](https://user-images.githubusercontent.com/5439713/36726185-373c4308-1bb9-11e8-999e-fda0527f6285.png)
