### PR TITLE
Making gardens to use grass color with plant nursery pattern

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -1,10 +1,10 @@
 // --- Parks, woods, other green things ---
 
-@grass: #cdebb0; // also grassland, meadow, common, village_green
+@grass: #cdebb0; // also grassland, meadow, common, village_green, garden
 @scrub: #b5e3b5;
 @forest: #add19e;       // Lch(80,30,135)
 @forest-text: #46673b;  // Lch(40,30,135)
-@park: #c8facc;         // Lch(94,30,145) also garden
+@park: #c8facc;         // Lch(94,30,145)
 @orchard: #aedfa3; // also vineyard, plant_nursery
 
 // --- "Base" landuses ---
@@ -159,6 +159,21 @@
     }
   }
 
+  [feature = 'leisure_garden'] {
+    [zoom >= 10] {
+      polygon-fill: @grass;
+      [way_pixels >= 4]  { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.3;  }
+    }
+    [zoom >= 14] {
+      polygon-pattern-file: url('symbols/plant_nursery.png');
+      polygon-pattern-opacity: 0.6;
+      polygon-pattern-alignment: global;
+      [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
+    }
+  }
+
   [feature = 'landuse_plant_nursery'] {
     [zoom >= 10] {
       polygon-fill: @orchard;
@@ -244,8 +259,7 @@
     line-opacity: 0.2;
   }
 
-  [feature = 'leisure_park'],
-  [feature = 'leisure_garden'] {
+  [feature = 'leisure_park'] {
     [zoom >= 10] {
       polygon-fill: @park;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }


### PR DESCRIPTION
Resolves #3022.

Green areas redesign (#2964) didn't work too well for gardens. It seems that garden is a very wide concept, so it can be a small residential green area, something like farm, something like park (including public botanical gardens), also a more precise version of village green.

Therefore a more subtle change would be better - something like grass (general mild green) but with a pattern that shows that there's usually something more growing and it's human curated (hence regular pattern from plant nursery). I also opt for 60% opacity for the pattern, since I don't like the home gardens to stand up too much and also because the original pattern color has lower contrast because the background is darker.

Examples:
![allv y1p](https://user-images.githubusercontent.com/5439713/36703080-4b5f3b10-1b5a-11e8-854b-25692712f8e0.png)
![tphwddxr](https://user-images.githubusercontent.com/5439713/36869951-ba88e9f6-1d9d-11e8-935b-eb457ef2962c.png)
![8uzejybb](https://user-images.githubusercontent.com/5439713/36869953-bc1eeb12-1d9d-11e8-9cba-fb5aaf0d9555.png)
![qnd3od_y](https://user-images.githubusercontent.com/5439713/36869955-be9cd1ce-1d9d-11e8-882c-2dd7de090830.png)
