### PR TITLE
Fix duplicate key in linestring_values table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [Unreleased](https://github.com/gravitystorm/openstreetmap-carto/compare/v4.8.0...master)
+### Major Changes
+- A bug where closed ways with natural=cliff or natural=tree_row were not
+  rendering has been fixed. This required fixing a transform bug. The fix
+  will apply to all objects when they are created in OSM, but there is no
+  migration for existing databases. Deployments will have to decide if the
+  effects are serious enough to require them to reload the database.
 
 ## [v4.8.0](https://github.com/gravitystorm/openstreetmap-carto/compare/v4.7.0...v4.8.0) - 2018-02-23
 ### Changes

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -35,11 +35,10 @@ local polygon_keys = {
 local linestring_values = {
     leisure = {track = true, slipway = true},
     man_made = {embankment = true, breakwater = true, groyne = true},
-    natural = {cliff = true, tree_row = true},
+    natural = {cliff = true, tree_row = true, ridge = true, arete = true},
     historic = {citywalls = true},
     waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, wadi = true, weir = true},
-    power = {line = true, minor_line = true},
-    natural = {ridge = true, arete = true}
+    power = {line = true, minor_line = true}
 }
 
 -- Objects with any of the following key/value combinations will be treated as polygon

--- a/scripts/lua/test.lua
+++ b/scripts/lua/test.lua
@@ -49,6 +49,7 @@ assert(isarea({area = "yes", leisure = "track"}) == 1, "test failed: leisure=tra
 assert(isarea({waterway = "river"}) == 0, "test failed: river")
 assert(isarea({waterway = "riverbank"}) == 1, "test failed: river")
 assert(isarea({highway = "services"}) == 1, "test failed: river")
+assert(isarea({natural="cliff"}) == 0, "test failed: cliff") -- issue #3084
 
 print("TESTING: filter_tags_generic")
 assert(({filter_tags_generic({})})[1] == 1, "Untagged filter")


### PR DESCRIPTION
This was causing objects with natural=cliff or natural=tree_row to be incorrectly processed.

Fixes #3084

This does not require a MAJOR release and can go into the next 4.x release. It could even go into a patch release since it's a bugfix. The schema hasn't changed, previous code wasn't producing output that matched the target schema.

Should we attempt to add some SQL for a migration? It's likely to be reasonably long because the column lists are very long.
I'd probably write something along the lines of

```sql
WITH areas_deleted AS (
  DELETE FROM planet_osm_polygon
  WHERE "natural" IN ('cliff', 'tree_row')
    AND NOT (tags ? 'area')
    AND osm_id > 0
  RETURNING * )
INSERT INTO planet_osm_line
  SELECT
      osm_id, access, "addr:housename", ..., 
      tags,
      (ST_Dump(way)).geom AS way;
```

Given the minor impact I'm fine not including a migration.