### PR TITLE
Fix repetition of high-zoom admin/nature reserve labels

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -172,7 +172,8 @@ overlapping borders correctly.
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
   text-placement: line;
-  text-clip: true;
+  text-clip: false;
+  text-spacing: 600;
   text-vertical-alignment: middle;
   text-dy: -10;
 }
@@ -184,7 +185,8 @@ overlapping borders correctly.
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
   text-placement: line;
-  text-clip: true;
+  text-clip: false;
+  text-spacing: 600;
   text-vertical-alignment: middle;
   text-dy: -10;
 }


### PR DESCRIPTION
The code that renders admin and nature reserve labels along borders
(on z16 and higher) was broken: it only rendered one label per
metatile. With the new code, labels are rendered every 600px.