### PR TITLE
[WIP] Render maritime borders differently

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -1,4 +1,5 @@
 @admin-boundaries: #ac46ac;
+@admin-boundaries-maritime: darken(@water-color,30%);
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
@@ -16,6 +17,9 @@ overlapping borders correctly.
       background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 1.2;
     }
     [zoom >= 5] {
@@ -43,6 +47,9 @@ overlapping borders correctly.
       background/line-width: 0.6;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 0.6;
     }
     [zoom >= 7] {
@@ -63,6 +70,9 @@ overlapping borders correctly.
       background/line-color: white;
       background/line-width: 0.4;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-join: bevel;
       line-width: 0.4;
       line-clip: false;
@@ -116,6 +126,9 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
+    [maritime = 'yes'] {
+      line-color: @admin-boundaries-maritime;
+    }
     line-width: 2;
     line-dasharray: 6,3,2,3,2,3;
     line-clip: false;
@@ -126,6 +139,9 @@ overlapping borders correctly.
     background/line-width: 2;
     line-join: bevel;
     line-color: @admin-boundaries;
+    [maritime = 'yes'] {
+      line-color: @admin-boundaries-maritime;
+    }
     line-width: 2;
     line-dasharray: 6,3,2,3;
     line-clip: false;
@@ -138,6 +154,9 @@ overlapping borders correctly.
       background/line-width: 1.5;
       line-join: bevel;
       line-color: @admin-boundaries;
+      [maritime = 'yes'] {
+        line-color: @admin-boundaries-maritime;
+      }
       line-width: 1.5;
       line-dasharray: 5,2;
       line-clip: false;

--- a/project.mml
+++ b/project.mml
@@ -178,10 +178,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, 
-            waterway, 
+            way,
+            waterway,
             CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
@@ -199,7 +199,7 @@ Layer:
             way,
             waterway,
             CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent
           FROM planet_osm_line
           WHERE waterway = 'river'
@@ -283,12 +283,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, 
-            waterway, 
-            name, 
+            way,
+            waterway,
+            name,
             CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
-              THEN 'yes' ELSE 'no' END AS int_intermittent,            
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'no' AS bridge
           FROM planet_osm_line
@@ -869,7 +869,7 @@ Layer:
                   ELSE NULL
                 END AS access,
                 construction,
-                CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text 
+                CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text
                   ELSE 'INT-normal'::text END AS service,
                 'no' AS link,
                 COALESCE(layer,0) AS layernotnull,
@@ -975,8 +975,8 @@ Layer:
             waterway,
             name,
             CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
-              THEN 'yes' ELSE 'no' END AS int_intermittent,            
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'yes' AS bridge
           FROM planet_osm_line
@@ -1130,11 +1130,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            tags->'maritime' AS maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level DESC
         ) AS admin_low_zoom
     properties:
@@ -1148,11 +1149,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            tags->'maritime' AS maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
@@ -1166,11 +1168,12 @@ Layer:
       table: |-
         (SELECT
             way,
-            admin_level
+            admin_level,
+            tags->'maritime' AS maritime
           FROM planet_osm_roads
           WHERE boundary = 'administrative'
             AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
-            AND osm_id < 0
+            AND osm_id > 0
           ORDER BY admin_level::integer DESC -- With 10 as a valid value, we need to do a numeric ordering, not a text ordering
         ) AS admin_high_zoom
     properties:
@@ -1446,7 +1449,7 @@ Layer:
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort')
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
-              'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,                             
+              'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,
               'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END
@@ -1539,7 +1542,7 @@ Layer:
                              THEN concat_ws('_', historic, CASE WHEN tags->'memorial' IN ('plaque') THEN tags->'memorial' ELSE NULL END)
                              ELSE NULL END,
               'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,
-              'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway 
+              'highway_'|| CASE WHEN highway IN ('bus_stop', 'elevator', 'traffic_signals') THEN highway
                                 WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' ELSE NULL END,
               'power_' || CASE WHEN power IN ('generator') THEN power ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint') THEN tourism ELSE NULL END,
@@ -2098,7 +2101,7 @@ Layer:
                                                 'seafood', 'shoes', 'alcohol', 'gift', 'furniture', 'kiosk', 'mobile_phone', 'motorcycle', 'musical_instrument',
                                                 'newsagent', 'optician', 'jewelry', 'jewellery', 'electronics', 'chemist', 'toys', 'travel_agency', 'car_parts',
                                                 'greengrocer', 'farm', 'stationery', 'laundry', 'dry_cleaning', 'beverages', 'perfumery', 'cosmetics',
-                                                'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea', 'coffee', 'tyres', 
+                                                'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea', 'coffee', 'tyres',
                                                 'pastry', 'chocolate') THEN shop
                                   WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,
                   'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'fitness_centre', 'sports_centre', 'stadium', 'track',
@@ -2244,7 +2247,7 @@ Layer:
             lock,
             name,
             CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season') 
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
@@ -2316,7 +2319,7 @@ Layer:
             COALESCE(
               'highway_' || CASE WHEN highway IN ('mini_roundabout') THEN highway ELSE NULL END,
               'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') THEN railway ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench', 
+              'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'bench',
                             'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,


### PR DESCRIPTION
This renders maritime borders less prominently (blue instead of purple).

In order to implement this, we render admin boundaries from lines
instead of from polygons. This has the additional advantage that
it becomes possible in the future to render admin boundaries
thinner than currently.

Before:
<img width="399" alt="screen shot 2018-03-05 at 01 28 34" src="https://user-images.githubusercontent.com/5251909/36952786-95e2583e-2014-11e8-928b-27be80331c18.png">


After:
<img width="400" alt="screen shot 2018-03-05 at 01 27 30" src="https://user-images.githubusercontent.com/5251909/36952778-80d40a50-2014-11e8-9ada-952f3b754009.png">

This fixes #621.