### PR TITLE
Move natural=grassland and landuse=meadow earlier

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -323,16 +323,14 @@
     }
   }
 
-  [feature = 'landuse_meadow'],
-  [feature = 'natural_grassland'],
-  [feature = 'landuse_grass'],
-  [feature = 'landuse_village_green'],
-  [feature = 'leisure_common'] {
-    [zoom >= 10] {
-      polygon-fill: @grass;
-      [way_pixels >= 4]  { polygon-gamma: 0.75; }
-      [way_pixels >= 64] { polygon-gamma: 0.3;  }
-    }
+  [feature = 'natural_grassland'][zoom >= 8],
+  [feature = 'landuse_meadow'][zoom >= 10],
+  [feature = 'landuse_grass'][zoom >= 10],
+  [feature = 'landuse_village_green'][zoom >= 10],
+  [feature = 'leisure_common'][zoom >= 10] {
+    polygon-fill: @grass;
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
   [feature = 'landuse_retail'],

--- a/landcover.mss
+++ b/landcover.mss
@@ -324,7 +324,7 @@
   }
 
   [feature = 'natural_grassland'][zoom >= 8],
-  [feature = 'landuse_meadow'][zoom >= 10],
+  [feature = 'landuse_meadow'][zoom >= 8],
   [feature = 'landuse_grass'][zoom >= 10],
   [feature = 'landuse_village_green'][zoom >= 10],
   [feature = 'leisure_common'][zoom >= 10] {

--- a/project.mml
+++ b/project.mml
@@ -90,12 +90,12 @@ Layer:
             COALESCE(wetland, landuse, "natural") AS feature
           FROM (SELECT
               way, COALESCE(name, '') AS name, religion,
-              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial') THEN landuse ELSE NULL END)) AS landuse,
+              ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
-            WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial')
+            WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL

--- a/project.mml
+++ b/project.mml
@@ -91,12 +91,12 @@ Layer:
           FROM (SELECT
               way, COALESCE(name, '') AS name, religion,
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial') THEN landuse ELSE NULL END)) AS landuse,
-              ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath') THEN "natural" ELSE NULL END)) AS "natural",
+              ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
             FROM planet_osm_polygon
             WHERE (landuse IN ('forest', 'military', 'farmland', 'residential', 'commercial', 'retail', 'industrial')
-              OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath'))
+              OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL
             ORDER BY way_area DESC


### PR DESCRIPTION
[Example of natural=grassland](https://www.openstreetmap.org/#map=9/51.3906/67.5536) shown from z8 (instead of z10+, as it is currently). Maybe also meadows could be visible there, but not the natural=grass, since it is intended for smaller grass areas.

z8
![feal18_u](https://user-images.githubusercontent.com/5439713/37067103-9e9106d4-21a8-11e8-8320-7d67103bcb38.png)

z9
![fkxvk8_k](https://user-images.githubusercontent.com/5439713/37067104-a005f768-21a8-11e8-9101-114cd12cde7f.png)
