### PR TITLE
Issue #2224 Construction steps

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1154,7 +1154,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [construction = 'cycleway'],
         [construction = 'bridleway'],
         [construction = 'path'],
-        [construction = 'track'] {
+        [construction = 'track'], 
+        [construction = 'steps']{
           [zoom < 14] {
             line-width: 0;
             b/line-width: 0;


### PR DESCRIPTION
Fixes #2224
before:
![image](https://user-images.githubusercontent.com/498547/37565996-77701de4-2a89-11e8-8b49-7e54c7c00ac3.png)
and added to the construction tags gives this:
![image](https://user-images.githubusercontent.com/498547/37566005-8f3de2f8-2a89-11e8-83b5-e1fc55f5f8eb.png)