### PR TITLE
Adding rendering for big natural=bay

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1939,7 +1939,8 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
-              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water') THEN "natural" ELSE NULL END,
+              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
+                                                    'water', 'bay') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
@@ -1948,7 +1949,7 @@ Layer:
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')
-              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay')
               OR "place" IN ('island')
               OR boundary IN ('national_park')
               OR leisure IN ('nature_reserve'))

--- a/water.mss
+++ b/water.mss
@@ -330,6 +330,7 @@
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
   [feature = 'natural_water'],
+  [feature = 'natural_bay'],
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {


### PR DESCRIPTION
Rendering big bay labels is currently missing, notable example is [Port Phillip Bay](https://www.openstreetmap.org/relation/1221199#map=9/-37.9962/145.0923) in Australia:

Using Mapnik 3.0.15 (currently in Kosmtik):

z8
![rik1uo8i](https://user-images.githubusercontent.com/5439713/37866835-6b6cd602-2f90-11e8-8e1c-e458d0f8f82e.png)

z9 (probably eclipsed by a town name)
![p3rcx_d4](https://user-images.githubusercontent.com/5439713/37866849-92e862d2-2f90-11e8-8fe8-8dc51085b65b.png)

Mapnik 3.0.19 (latest release):

z8
![cdc4iu6v](https://user-images.githubusercontent.com/5439713/37866875-bee237aa-2f90-11e8-9dfc-ae23b1d4a65e.png)

z9 
![hxf tbsq](https://user-images.githubusercontent.com/5439713/37866876-c27754c2-2f90-11e8-8ba6-95ac959f3d5b.png)

Related to #2068.