### PR TITLE
Move highway=mini_roundabout rendering to higher zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1217,7 +1217,7 @@
     }
   }
 
-  [feature = 'highway_mini_roundabout'][zoom >= 16]::highway {
+  [feature = 'highway_mini_roundabout'][zoom >= 17]::highway {
     marker-file: url('symbols/mini_roundabout.svg');
     marker-placement: interior;
     marker-clip: false;


### PR DESCRIPTION
Resolves #2020.

I think moving from z16+ to z17+ should be enough:

[Standard example](https://www.openstreetmap.org/node/3404845697#map=16/52.2216/21.0927):
z16, before
![jplu8dsj](https://user-images.githubusercontent.com/5439713/37908845-a31dd37e-3109-11e8-8676-cbfe2f085987.png)

z16, after
![d3ptsq r](https://user-images.githubusercontent.com/5439713/37908849-a615ba6a-3109-11e8-9873-3f0232e0fa5e.png)

z17
![1d_nr78p](https://user-images.githubusercontent.com/5439713/37908856-a83f6a3e-3109-11e8-93ed-818ce197ae72.png)

[Extended example](https://www.openstreetmap.org/node/2730785546#map=16/52.1516/21.0551):
z16, before
![g6ctuvyh](https://user-images.githubusercontent.com/5439713/37909003-0c67993c-310a-11e8-979d-3486e8b35bb4.png)

z16, after
![2nqv3gpl](https://user-images.githubusercontent.com/5439713/37909089-440db240-310a-11e8-9992-659337510e47.png)

z17
![hpx4w q](https://user-images.githubusercontent.com/5439713/37909009-0eb424c6-310a-11e8-9b4b-e4ed0c8080d3.png)
