### PR TITLE
Move barriers to higher zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1224,15 +1224,15 @@
   }
 
   [feature = 'barrier_gate']::barrier {
-    [zoom >= 16] {
+    [zoom >= 17] {
       marker-file: url('symbols/gate.svg');
       marker-placement: interior;
       marker-clip: false;
     }
   }
 
-  [feature = 'barrier_lift_gate'][zoom >= 16]::barrier,
-  [feature = 'barrier_swing_gate'][zoom >= 16]::barrier {
+  [feature = 'barrier_lift_gate'][zoom >= 17]::barrier,
+  [feature = 'barrier_swing_gate'][zoom >= 17]::barrier {
     marker-file: url('symbols/liftgate.svg');
     marker-fill: #3f3f3f;
     marker-placement: interior;
@@ -1242,7 +1242,7 @@
   [feature = 'barrier_bollard'],
   [feature = 'barrier_block'],
   [feature = 'barrier_log'] {
-    [zoom >= 16] {
+    [zoom >= 17] {
       marker-width: 3;
       marker-line-width: 0;
       marker-fill: #7d7c7c;


### PR DESCRIPTION
Fixes #323

Changes proposed in this pull request:
- moving barriers from z16+ to z17+:
  - gate
  - lift_gate
  - swing_gate
  - bollard
  - block
  - log

Test rendering with links to the example places:

[Example place with gates, z16](https://www.openstreetmap.org/#map=16/52.2223/20.9062)
Before
![nfawmamh](https://user-images.githubusercontent.com/5439713/38168405-323dbed0-354b-11e8-8fcd-b335f4bfee9b.png)

After
![i_bplp2q](https://user-images.githubusercontent.com/5439713/38168404-2fb668d8-354b-11e8-969c-a2f68308f37c.png)

[Example place with bollards, z16](https://www.openstreetmap.org/#map=16/52.2560/20.9835)
Before
![ndz77k9j](https://user-images.githubusercontent.com/5439713/38168430-f3132776-354b-11e8-8c5d-a14e96630416.png)

After
![blsw9wd_](https://user-images.githubusercontent.com/5439713/38168431-f68bc926-354b-11e8-83fa-259a8f554ada.png)

[Example place with gates and lift gates, z16](https://www.openstreetmap.org/#map=16/46.3637/11.0327)
Before
![qtc tyij](https://user-images.githubusercontent.com/5439713/38168462-d4795320-354c-11e8-986b-92eca527aaa9.png)

After
![sew4co2j](https://user-images.githubusercontent.com/5439713/38168461-d0691efa-354c-11e8-9bb6-48b21013d0b9.png)
