### PR TITLE
Hide railway=platform with location=underground, tunnels and covered=yes

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -543,7 +543,7 @@ Layer:
                 z_order
               FROM planet_osm_line
               WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
-                AND railway IS NOT NULL -- end of rail select
+                AND (railway NOT IN ('platform') AND railway IS NOT NULL) -- end of rail select
             ) AS features
           ORDER BY
             layernotnull,
@@ -692,11 +692,18 @@ Layer:
             way,
             COALESCE((
               'highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'track', 'path', 'platform') THEN highway ELSE NULL END)),
-              ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END))
+              ('railway_' || (CASE WHEN (railway IN ('platform') 
+                              AND (tags->'location' NOT IN ('underground') OR tags->'location' IS NULL)
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              THEN railway ELSE NULL END))
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'track', 'path', 'platform')
-            OR railway IN ('platform')
+            OR (railway IN ('platform') 
+                AND (tags->'location' NOT IN ('underground') OR tags->'location' IS NULL)
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                AND (covered NOT IN ('yes') OR covered IS NULL))
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS highway_area_casing
     properties:
@@ -803,12 +810,19 @@ Layer:
             COALESCE(
               ('highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street',
                                                     'track', 'path', 'platform', 'services') THEN highway ELSE NULL END)),
-              ('railway_' || (CASE WHEN railway IN ('platform') THEN railway ELSE NULL END)),
+              ('railway_' || (CASE WHEN (railway IN ('platform') 
+                              AND (tags->'location' NOT IN ('underground') OR tags->'location' IS NULL)
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              THEN railway ELSE NULL END)),
               (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'living_street', 'track', 'path', 'platform', 'services')
-            OR railway IN ('platform')
+            OR (railway IN ('platform') 
+                AND (tags->'location' NOT IN ('underground') OR tags->'location' IS NULL)
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                AND (covered NOT IN ('yes') OR covered IS NULL))
             OR aeroway IN ('runway', 'taxiway', 'helipad')
           ORDER BY COALESCE(layer,0), way_area desc
         ) AS highway_area_fill
@@ -1858,7 +1872,10 @@ Layer:
             name
           FROM planet_osm_polygon
           WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
-            OR railway IN ('platform')
+            OR (railway IN ('platform') 
+                AND (tags->'location' NOT IN ('underground') OR tags->'location' IS NULL)
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                AND (covered NOT IN ('yes') OR covered IS NULL))
             OR (place IN ('square')
                 AND (leisure IS NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
             AND name IS NOT NULL


### PR DESCRIPTION
Related to #2504, #2037 and #1659.

Changes proposed in this pull request:
- Hide railway platforms which are located underground, because they eclipse station buildings too much and this is rather indoor feature (see https://www.openstationmap.org )

Test rendering with links to the example places:

[Warsaw](https://www.openstreetmap.org/#map=17/52.22925/21.00564)
Before
![zw4rvxvq](https://user-images.githubusercontent.com/5439713/38213949-55279f8c-36c3-11e8-87c9-9c69fc4d788e.png)
After
![qw3ocor3](https://user-images.githubusercontent.com/5439713/38213943-51b328b2-36c3-11e8-9476-79aac8e6324f.png)

[Berlin](https://www.openstreetmap.org/#map=17/52.52497/13.37020)
Before
![xecy6jgv](https://user-images.githubusercontent.com/5439713/38214223-42cf7034-36c4-11e8-9f60-6153bf171a0f.png)
After
![qjfugaih](https://user-images.githubusercontent.com/5439713/38214240-52b2d6bc-36c4-11e8-84b6-1fc41138cb29.png)

