### PR TITLE
Add rendering for waterway=waterfall [WIP]

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -379,10 +379,10 @@ Layer:
         (SELECT
             way, waterway
           FROM planet_osm_point
-          WHERE waterway IN ('dam', 'weir', 'lock_gate')
+          WHERE waterway IN ('dam', 'weir', 'lock_gate', 'waterfall')
         ) AS water_barriers_points
     properties:
-      minzoom: 17
+      minzoom: 13
   - id: bridge
     geometry: polygon
     <<: *extents
@@ -1613,6 +1613,7 @@ Layer:
             OR barrier IN ('toll_booth')
             OR man_made IN ('mast', 'tower', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk')
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
+            OR waterway IN ('waterfall')
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine')
             OR tags->'memorial' IN ('plaque')
             OR military IN ('bunker')
@@ -2151,6 +2152,7 @@ Layer:
                   'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring',
                                                         'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree')
                                                         THEN "natural" ELSE NULL END,
+                  'waterway_' || CASE WHEN waterway IN ('waterfall') THEN waterway ELSE NULL END,
                   'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                   'barrier_' || CASE WHEN barrier IN ('toll_booth') THEN barrier ELSE NULL END,
                   'military_' || CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,

--- a/symbols/waterfall.svg
+++ b/symbols/waterfall.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 14 14"
+   height="14px"
+   width="14px"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.0">
+  <metadata
+     id="metadata7242">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7240" />
+  <path
+     id="path7235"
+     d="m 1,11 c 0.641,0 1.829,1 2.4,1 0.535,0 1.795,-1 2.4,-1 0.605,0 1.866,1 2.4,1 0.642,0 1.825,-1 2.399,-1 0.641,-0.029 1.902,1 2.4,1 v 2 c -0.604,0 -1.83,-1 -2.4,-1 C 10.03,13 8.804,14 8.2,14 7.626,14 6.405,13 5.8,13 5.191,13 3.971,14 3.4,14 2.76,14 1.606,13 1,13 Z M 1,3 C 2.094,3 3.001,3.3 3.001,4.75 L 3,7.25 c 0,2 2,3 3,3 0,0 -1,-1 -1,-3 V 4.75 C 5,3.835 4.351,3.442 3.999,3 5.093,3 6,3.3 6,4.75 v 2.5 c 0,2 2,3 3,3 0,0 -1,-1 -1,-3 L 8.1,4.75 C 8.1365708,3.8357311 7.351,3.442 7,3 8.093,3 9,3.3 9,4.75 v 2.5 c 0,2 2,3 3,3 0,0 -1,-1 -1,-3 V 4.75 C 11,1.75 8,1 7,1 H 0 l 5e-4,2 z" />
+</svg>

--- a/water-features.mss
+++ b/water-features.mss
@@ -62,6 +62,13 @@
       marker-ignore-placement: true;
     }
   }
+
+  [waterway = 'waterfall'][zoom >= 13] {
+    marker-file: url('symbols/waterfall.svg');
+    marker-fill: @water-text;
+    marker-placement: interior;
+    marker-clip: false;
+  }
 }
 
 #piers-poly, #piers-line {
@@ -161,5 +168,18 @@
         text-spacing: 400;
       }
     }
+  }
+
+  [feature = 'waterway_waterfall'][zoom >= 14] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-dy: 10;
+    text-fill: @water-text;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+    text-face-name: @standard-font;
   }
 }


### PR DESCRIPTION
Fixes #336

Adds icon and name rendering for waterway=waterfall.

Before

![waterfall_before_15](https://user-images.githubusercontent.com/14190496/38182551-11b2ac08-35ef-11e8-8e70-b9809b547917.png)

After

![waterfall_after_15](https://user-images.githubusercontent.com/14190496/38182556-1c6a392c-35ef-11e8-8e0d-898a2a3c4737.png)

Various zoom levels:

![waterfalls_after_17](https://user-images.githubusercontent.com/14190496/38182630-a5872670-35ef-11e8-8d94-d9b1eea2f22a.png)
![waterfall_after_14](https://user-images.githubusercontent.com/14190496/38182772-8c5f3a06-35f0-11e8-9cdf-5b50688edb60.png)
![waterfall_after_13](https://user-images.githubusercontent.com/14190496/38182792-b787a682-35f0-11e8-9517-e0f69cbd88b1.png)

This uses the waterfall v3 icon from @gpsvisualizer (I did some slight pixel alignment) with both icon and text using the standard water text color.

I'm not sure why cliffs/highways are rendering on top of the waterfall icon. Can anyone offer some advice here? Is this just kosmtik?

I'm also not too happy with the low zoom. I think waterfalls are prominant features that primarily occur in rural areas and deserve to be rendered fairly low, but I'd like to try rendering only those with names at lower zooms.