### PR TITLE
Render place=square name for nodes

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -395,5 +395,14 @@
       text-halo-fill: white;
     }
   }
+  [place = 'square'] {
+    [zoom >= 17] {
+      text-name: "[name]";
+      text-size: 11;
+      text-face-name: @book-fonts;
+      text-wrap-width: 30; // 2.7 em
+      text-line-spacing: -1.7; // -0.15 em
+    }
+  }
 }
 

--- a/project.mml
+++ b/project.mml
@@ -1357,13 +1357,16 @@ Layer:
         (SELECT
             way,
             place,
+            leisure,
             name
           FROM planet_osm_point
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
-             OR place IN ('suburb', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
-             AND name IS NOT NULL
+             OR (place IN ('suburb', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
+                 OR (place IN ('square')
+                     AND (leisure is NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
+             ) AND name IS NOT NULL
           ORDER BY CASE
               WHEN place = 'suburb' THEN 3
               WHEN place = 'village' THEN 4
@@ -1372,6 +1375,7 @@ Layer:
               WHEN place = 'locality' THEN 7
               WHEN place = 'isolated_dwelling' THEN 8
               WHEN place = 'farm' THEN 9
+              WHEN place = 'square' THEN 10
             END ASC, length(name) DESC, name
         ) AS placenames_small
     properties:


### PR DESCRIPTION
See #2673

Changes proposed in this pull request:
Rendering place=square name for nodes too

z17
![square-z17](https://user-images.githubusercontent.com/9254305/38457999-86714682-3a98-11e8-9a08-096b02ea0311.png)
z18
![square-z18](https://user-images.githubusercontent.com/9254305/38457997-86550134-3a98-11e8-838e-7b873ae8c698.png)
z19
![square-z19](https://user-images.githubusercontent.com/9254305/38457996-8638adfe-3a98-11e8-883f-a4f8041c43b3.png)

Data (4 objects with place=square, original place is [here](https://www.openstreetmap.org/node/4917621976)):
![square-data](https://user-images.githubusercontent.com/9254305/38457995-86097660-3a98-11e8-88dc-0afeb22f275a.PNG)
