### PR TITLE
Add rendering of zip line

### DIFF
--- a/aerialways.mss
+++ b/aerialways.mss
@@ -71,7 +71,8 @@
   [aerialway = 't-bar'],
   [aerialway = 'j-bar'],
   [aerialway = 'platter'],
-  [aerialway = 'rope_tow'] {
+  [aerialway = 'rope_tow'],
+  [aerialway = 'zip_line'] {
     [zoom >= 12] {
       line/line-width: 1;
       line/line-join: round;


### PR DESCRIPTION
Fixes #3156 

Changes proposed in this pull request:
Display `aerialway=zip_line` as other aerialways (e.g. chair_lift)

Test rendering with links to the example places:
Fantasticable [1](https://www.openstreetmap.org/way/132119392) and [2](https://www.openstreetmap.org/way/132119393)
Before
![zipline_before](https://user-images.githubusercontent.com/9897203/38579235-aac1869e-3d06-11e8-9434-2c8c583f6011.png)

After
![zipline_after](https://user-images.githubusercontent.com/9897203/38579242-ae92657c-3d06-11e8-890f-2993ffb0d927.png)
