### PR TITLE
Revert "Fix repetition of high-zoom admin/nature reserve labels"

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -203,8 +203,7 @@ overlapping borders correctly.
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
   text-placement: line;
-  text-clip: false;
-  text-spacing: 600;
+  text-clip: true;
   text-vertical-alignment: middle;
   text-dy: -10;
 }
@@ -216,8 +215,7 @@ overlapping borders correctly.
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
   text-placement: line;
-  text-clip: false;
-  text-spacing: 600;
+  text-clip: true;
   text-vertical-alignment: middle;
   text-dy: -10;
 }


### PR DESCRIPTION
Reverts #3101 because of the performance problem. See https://github.com/gravitystorm/openstreetmap-carto/issues/3159#issuecomment-382932958 for details.