### PR TITLE
Fixed office/amenity conflict

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1026,7 +1026,7 @@
   }
 
   // office points
-  [office != null][zoom >= 17] {
+  [feature = 'office'][zoom >= 17] {
     marker-width: 4;
     [zoom >= 18] {
       marker-width: 6;
@@ -2328,25 +2328,79 @@
     }
   }
 
-  // potentially larger offices
-  [zoom >= 17] {
-    [feature = 'office_administrative'],
-    [feature = 'office_adoption_agency'],
-    [feature = 'office_educational_institution'],
-    [feature = 'office_employment_agency'],
-    [feature = 'office_energy_supplier'],
-    [feature = 'office_financial'],
-    [feature = 'office_government'],
-    [feature = 'office_newspaper'],
-    [feature = 'office_ngo'],
-    [feature = 'office_political_party'],
-    [feature = 'office_quango'],
-    [feature = 'office_religion'],
-    [feature = 'office_research'],
-    [feature = 'office_tax'],
-    [feature = 'office_telecommunication'],
-    [feature = 'office_water_utility'],
-    {
+  [feature = 'office'] {
+    // potentially larger offices
+    [zoom >= 17] {
+      [office = 'administrative'],
+      [office = 'adoption_agency'],
+      [office = 'educational_institution'],
+      [office = 'employment_agency'],
+      [office = 'energy_supplier'],
+      [office = 'financial'],
+      [office = 'government'],
+      [office = 'newspaper'],
+      [office = 'ngo'],
+      [office = 'political_party'],
+      [office = 'quango'],
+      [office = 'religion'],
+      [office = 'research'],
+      [office = 'tax'],
+      [office = 'telecommunication'],
+      [office = 'water_utility'],
+      {
+        text-name: "[name]";
+        text-size: @standard-font-size;
+        text-wrap-width: @standard-wrap-width;
+        text-line-spacing: @standard-line-spacing-size;
+        text-dy: 8;
+        text-fill: @office;
+        text-face-name: @standard-font;
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: rgba(255, 255, 255, 0.6);
+        text-placement: interior;
+      }
+    }
+
+    // other documented office types
+    [zoom >= 18] {
+      [office = 'accountant'],
+      [office = 'advertising_agency'],
+      [office = 'architect'],
+      [office = 'association'],
+      [office = 'charity'],
+      [office = 'company'],
+      [office = 'estate_agent'],
+      [office = 'forestry'],
+      [office = 'foundation'],
+      [office = 'guide'],
+      [office = 'insurance'],
+      [office = 'it'],
+      [office = 'lawyer'],
+      [office = 'logistics'],
+      [office = 'moving_company'],
+      [office = 'notary'],
+      [office = 'physician'],
+      [office = 'private_investigator'],
+      [office = 'property_management'],
+      [office = 'surveyor'],
+      [office = 'tax_advisor'],
+      [office = 'therapist'],
+      [office = 'travel_agent'] {
+        text-name: "[name]";
+        text-size: @standard-font-size;
+        text-wrap-width: @standard-wrap-width;
+        text-line-spacing: @standard-line-spacing-size;
+        text-dy: 8;
+        text-fill: @office;
+        text-face-name: @standard-font;
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: rgba(255, 255, 255, 0.6);
+        text-placement: interior;
+      }
+    }
+
+    // all other offices
+    [zoom >= 19] {
       text-name: "[name]";
       text-size: @standard-font-size;
       text-wrap-width: @standard-wrap-width;
@@ -2358,58 +2412,6 @@
       text-halo-fill: rgba(255, 255, 255, 0.6);
       text-placement: interior;
     }
-  }
-
-  // other documented office types
-  [zoom >= 18] {
-    [feature = 'office_accountant'],
-    [feature = 'office_advertising_agency'],
-    [feature = 'office_architect'],
-    [feature = 'office_association'],
-    [feature = 'office_charity'],
-    [feature = 'office_company'],
-    [feature = 'office_estate_agent'],
-    [feature = 'office_forestry'],
-    [feature = 'office_foundation'],
-    [feature = 'office_guide'],
-    [feature = 'office_insurance'],
-    [feature = 'office_it'],
-    [feature = 'office_lawyer'],
-    [feature = 'office_logistics'],
-    [feature = 'office_moving_company'],
-    [feature = 'office_notary'],
-    [feature = 'office_physician'],
-    [feature = 'office_private_investigator'],
-    [feature = 'office_property_management'],
-    [feature = 'office_surveyor'],
-    [feature = 'office_tax_advisor'],
-    [feature = 'office_therapist'],
-    [feature = 'office_travel_agent'] {
-      text-name: "[name]";
-      text-size: @standard-font-size;
-      text-wrap-width: @standard-wrap-width;
-      text-line-spacing: @standard-line-spacing-size;
-      text-dy: 8;
-      text-fill: @office;
-      text-face-name: @standard-font;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: rgba(255, 255, 255, 0.6);
-      text-placement: interior;
-    }
-  }
-
-  // all other offices
-  [office != null][zoom >= 19] {
-    text-name: "[name]";
-    text-size: @standard-font-size;
-    text-wrap-width: @standard-wrap-width;
-    text-line-spacing: @standard-line-spacing-size;
-    text-dy: 8;
-    text-fill: @office;
-    text-face-name: @standard-font;
-    text-halo-radius: @standard-halo-radius;
-    text-halo-fill: rgba(255, 255, 255, 0.6);
-    text-placement: interior;
   }
 
   [feature = 'shop_supermarket'],

--- a/project.mml
+++ b/project.mml
@@ -1449,7 +1449,7 @@ Layer:
                                                   'charging_station', 'arts_centre', 'ferry_terminal', 'marketplace', 'waste_disposal', 'shower', 'bbq') THEN amenity ELSE NULL END,
               'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,                                                  
               'shop' || CASE WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
-              'office_' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE tags->'office' END,
+              'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE '' END,
               'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table',
                                                   'fitness_centre', 'fitness_station', 'firepit', 'sauna', 'beach_resort') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'tower', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
@@ -1559,7 +1559,7 @@ Layer:
               'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,
               'emergency_' || CASE WHEN tags->'emergency' IN ('phone') THEN tags->'emergency' ELSE NULL END,
               'shop' || CASE WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
-              'office_' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE tags->'office' END,
+              'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE '' END,
               'leisure_' || CASE WHEN leisure IN ('water_park', 'playground', 'miniature_golf', 'golf_course', 'picnic_table', 'slipway',
                                                   'dog_park', 'fitness_centre', 'fitness_station', 'firepit', 'sauna', 'beach_resort') THEN leisure ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('mast', 'tower', 'water_tower', 'lighthouse', 'windmill', 'obelisk') THEN man_made ELSE NULL END,
@@ -2017,7 +2017,7 @@ Layer:
                                             'perfumery', 'cosmetics', 'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea',
                                             'coffee', 'tyres', 'pastry', 'chocolate', 'music', 'medical_supply', 'dairy', 'video_games') THEN shop
                               WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,
-              'office_' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE tags->'office' END,
+              'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE '' END,
               'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'fitness_centre', 'sports_centre', 'stadium', 'track',
                                                   'pitch', 'playground', 'park', 'recreation_ground', 'common', 'garden', 'nature_reserve', 'marina',
                                                   'picnic_table', 'dog_park', 'fitness_station', 'firepit', 'sauna', 'beach_resort') THEN leisure ELSE NULL END,
@@ -2179,7 +2179,7 @@ Layer:
                                                 'variety_store', 'wine', 'outdoor', 'copyshop', 'sports', 'deli', 'tobacco', 'art', 'tea', 'coffee', 'tyres', 
                                                 'pastry', 'chocolate', 'music', 'medical_supply','dairy', 'video_games') THEN shop
                                   WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE 'other' END,
-                  'office_' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE tags->'office' END,
+                  'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR tags->'office' IS NULL THEN NULL ELSE '' END,
                   'leisure_' || CASE WHEN leisure IN ('swimming_pool', 'water_park', 'miniature_golf', 'golf_course', 'fitness_centre', 'sports_centre', 'stadium', 'track',
                                                       'pitch','playground', 'park', 'recreation_ground', 'common', 'garden', 'nature_reserve', 'marina',
                                                       'slipway', 'picnic_table', 'dog_park', 'fitness_station', 'firepit', 'sauna', 'beach_resort') THEN leisure ELSE NULL END,
@@ -2283,6 +2283,7 @@ Layer:
           WHERE building IS NOT NULL
             AND building NOT IN ('no')
             AND name IS NOT NULL
+            AND amenity IS NULL AND shop IS NULL AND tags->'office' IS NULL
           ORDER BY way_area DESC
         ) AS building_text
     properties:
@@ -2314,7 +2315,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
           WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
-            AND building IS NOT NULL
+            AND (building IS NOT NULL) AND (amenity IS NULL) AND (shop IS NULL) AND (tags->'office' IS NULL)
         UNION ALL
         SELECT
             way,
@@ -2323,7 +2324,8 @@ Layer:
             tags->'addr:unit' AS addr_unit,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
+          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
+            AND (amenity IS NULL) AND (shop IS NULL) AND (tags->'office' IS NULL)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:

--- a/project.mml
+++ b/project.mml
@@ -2283,7 +2283,6 @@ Layer:
           WHERE building IS NOT NULL
             AND building NOT IN ('no')
             AND name IS NOT NULL
-            AND amenity IS NULL AND shop IS NULL AND tags->'office' IS NULL
           ORDER BY way_area DESC
         ) AS building_text
     properties:
@@ -2315,7 +2314,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
           FROM planet_osm_polygon
           WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
-            AND (building IS NOT NULL) AND (amenity IS NULL) AND (shop IS NULL) AND (tags->'office' IS NULL)
+            AND building IS NOT NULL
         UNION ALL
         SELECT
             way,
@@ -2324,8 +2323,7 @@ Layer:
             tags->'addr:unit' AS addr_unit,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
-            AND (amenity IS NULL) AND (shop IS NULL) AND (tags->'office' IS NULL)
+          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:


### PR DESCRIPTION
RE: https://github.com/gravitystorm/openstreetmap-carto/issues/3159#issuecomment-383376498
Fixes #3195

POIs with both `amenity` and `office` tags triggered both code paths, resulting in points that shared some visual effects of both of these points.

Refactored the code to use `feature` field instead, as the coalesce() function guarantees it is unique. In the above example, `amenity` takes precedence over the `office` tag.

I've also, added extra checks in `addresses` and `building_text` layers so that they don't render labels when amenity/shop/office tags are defined.
In most (but not all) cases these labels were already hidden by Mapnik because they would have overlapped POI icons otherwise. However, even if not rendered, these labels would still be processed by Carto and Mapnik, increasing rendering time.