### PR TITLE
add office column to text-poly-low-zoom layer to avoid SQL errors

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1969,6 +1969,7 @@ Layer:
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
             ) AS feature,
             name,
+            NULL as office,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')


### PR DESCRIPTION
I was getting the following SQL error when running the style:

```
kosmtik_1  | Postgis Plugin: ERROR:  column "office" does not exist
kosmtik_1  | LINE 1: ...ELECT ST_AsBinary("way") AS geom,"feature","name","office","...
kosmtik_1  |                                                              ^
kosmtik_1  | in executeQuery Full sql was: 'SELECT ST_AsBinary("way") AS geom,"feature","name","office","way_pixels" FROM (SELECT
kosmtik_1  |     way,
kosmtik_1  |     way_area/NULLIF(9783.94::real*9783.94::real,0) AS way_pixels,
kosmtik_1  |     COALESCE(
kosmtik_1  |       'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
kosmtik_1  |       'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
kosmtik_1  |                                             'water', 'bay') THEN "natural" ELSE NULL END,
kosmtik_1  |       'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
kosmtik_1  |       'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
kosmtik_1  |       'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure ELSE NULL END
kosmtik_1  |     ) AS feature,
kosmtik_1  |     name,
kosmtik_1  |     CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
kosmtik_1  |   FROM planet_osm_polygon
kosmtik_1  |   WHERE (landuse IN ('forest', 'military', 'farmland')
kosmtik_1  |       OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay')
kosmtik_1  |       OR "place" IN ('island')
kosmtik_1  |       OR boundary IN ('national_park')
kosmtik_1  |       OR leisure IN ('nature_reserve'))
kosmtik_1  |     AND building IS NULL
kosmtik_1  |     AND name IS NOT NULL
kosmtik_1  |   ORDER BY way_area DESC
kosmtik_1  | ) AS text_poly_low_zoom WHERE "way" && ST_SetSRID('BOX3D(-2504688.542848659 -2504688.542848658,7514065.628545969 7514065.62854597)'::box3d, 3857)'
```

I addded a `NULL as office` column to the `text-poly-low-zoom` layer as it is also used in the selector where a `[office != null]`filter is used.