### PR TITLE
differentiate guidepost from general tourism=information display

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -313,11 +313,17 @@
     marker-clip: false;
   }
 
-  [feature = 'tourism_information'][zoom >= 17] {
-    marker-file: url('symbols/information.12.svg');
-    marker-placement: interior;
-    marker-fill: @amenity-brown;
-    marker-clip: false;
+  [feature = 'tourism_information'] {
+    [information != 'guidepost'][zoom >= 17],
+    [information = 'guidepost'][zoom >= 19] {
+      marker-file: url('symbols/information.12.svg');
+      [information = 'guidepost'] {
+        marker-file: url('symbols/guidepost.svg');
+      }
+      marker-placement: interior;
+      marker-fill: @amenity-brown;
+      marker-clip: false;
+    }
   }
 
   [feature = 'amenity_embassy'][zoom >= 17] {
@@ -1573,6 +1579,19 @@
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;
+  }
+
+  [feature = 'tourism_information'][information = 'guidepost'][zoom >= 19] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: darken(@landform-color, 30%);
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+    text-dy: 11;
   }
 
   [feature = 'waterway_waterfall'] {

--- a/project.mml
+++ b/project.mml
@@ -1500,6 +1500,7 @@ Layer:
             tags->'tower:construction' as "tower:construction",
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
+            tags->'information' as information,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1628,6 +1629,7 @@ Layer:
             tags->'tower:construction' as "tower:construction",
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
+            tags->'information' as information,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -2081,6 +2083,7 @@ Layer:
             tags->'office' as office,
             tags->'recycling_type' as recycling_type,
             tags->'castle_type' as castle_type,
+            tags->'information' as information,
             ref,
             way_area,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2168,6 +2171,7 @@ Layer:
             office,
             recycling_type,
             castle_type,
+            information,
             ref,
             way_area,
             is_building
@@ -2227,7 +2231,9 @@ Layer:
                 access,
                 name,
                 CASE
-                  WHEN "natural" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter' THEN
+                  WHEN "natural" IN ('peak', 'volcano', 'saddle')
+                    OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
+                    OR amenity = 'shelter' THEN
                     CASE
                       WHEN tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$' THEN (tags->'ele')::NUMERIC
                       ELSE NULL
@@ -2250,6 +2256,7 @@ Layer:
                 tags->'office' as office,
                 tags->'recycling_type' as recycling_type,
                 tags->'castle_type' as castle_type,
+                tags->'information' as information,
                 ref,
                 NULL AS way_area,
                 CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2279,7 +2286,10 @@ Layer:
                   OR boundary IN ('national_park')
                   OR waterway IN ('dam', 'weir', 'dock'))
                 AND (name IS NOT NULL
-                     OR (tags?'ele' AND ("natural" IN ('peak', 'volcano', 'saddle') OR tourism = 'alpine_hut' OR amenity = 'shelter'))
+                     OR (tags?'ele' AND ("natural" IN ('peak', 'volcano', 'saddle')
+                         OR tourism = 'alpine_hut'
+                         OR (tourism = 'information' AND tags->'information' = 'guidepost')
+                         OR amenity = 'shelter'))
                      OR (ref IS NOT NULL AND aeroway IN ('gate'))
                     )
               ) AS p

--- a/symbols/guidepost.svg
+++ b/symbols/guidepost.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 14 14"
+   id="svg2">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="M 7,0.25 C 6.625,0.25 6.25,0.5 6.25,1 l 0,13 1.5,0 0,-13 C 7.75,0.5 7.375,0.25 7,0.25 z M 2,1 0,2.5 2,4 6,4 6,1 2,1 z M 8,4 8,7 12,7 14,5.5 12,4 8,4 z"
+     id="guidepost"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
Ref #1978, #3105.

Adds a guidepost icon on z19 and drops rendering of guidepost nodes before z19.

before z18
![z18_before](https://user-images.githubusercontent.com/3531092/39330373-b5764eba-49a1-11e8-8e06-d676f33d3078.png)

after z18
![z18_after](https://user-images.githubusercontent.com/3531092/39330376-b8eb6350-49a1-11e8-9046-be2388d32f50.png)

before z19
![z19_before](https://user-images.githubusercontent.com/3531092/39330380-bb920410-49a1-11e8-8be4-aac678d022d3.png)

after z19
![z19_after](https://user-images.githubusercontent.com/3531092/39330387-c3e8e50c-49a1-11e8-8d91-4e955f0003ae.png)