### PR TITLE
Bugfix primary road casing

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -359,7 +359,7 @@
         [zoom >= 17] { line-width: @primary-width-z17; }
         [zoom >= 18] { line-width: @primary-width-z18; }
         [zoom >= 19] { line-width: @primary-width-z19; }
-        #roads {
+        #roads-casing {
           line-join: round;
           line-cap: round;
         }


### PR DESCRIPTION
Before:
![screenshot 1](https://user-images.githubusercontent.com/6830724/39373943-c2c5895e-4a38-11e8-8d73-5e24e1f874f5.png)
The road casing for primary roads is wrong (not round like motorway, trunk, secondary…). This is because of a small bug (in a layer name) in `roads.mss`.

After:
![screenshot 2](https://user-images.githubusercontent.com/6830724/39373945-c4ed1170-4a38-11e8-8cc6-475fd19cbc5f.png)