### PR TITLE
do not show castle/manor/fort symbols when ruins tag is set

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -684,16 +684,16 @@
     marker-clip: false;
   }
 
-  [feature = 'historic_fort'][zoom >= 16] {
+  [feature = 'historic_fort'][ruins = null][zoom >= 16] {
     marker-file: url('symbols/fort.svg');
     marker-fill: @memorials;
     marker-placement: interior;
     marker-clip: false;
   }
 
-  [feature = 'historic_castle'][castle_type != 'stately'][zoom >= 15],
-  [feature = 'historic_castle'][castle_type = 'stately'][zoom >= 16],
-  [feature = 'historic_manor'][zoom >= 15] {
+  [feature = 'historic_castle'][ruins = null][castle_type != 'stately'][zoom >= 15],
+  [feature = 'historic_castle'][ruins = null][castle_type = 'stately'][zoom >= 16],
+  [feature = 'historic_manor'][ruins = null][zoom >= 15] {
     marker-file: url('symbols/castle.svg');
     marker-fill: @memorials;
     marker-placement: interior;
@@ -1632,9 +1632,9 @@
   [feature = 'historic_memorial_plaque'][zoom >= 19],
   [feature = 'man_made_obelisk'][zoom >= 16],
   [feature = 'historic_monument'][zoom >= 16],
-  [feature = 'historic_fort'][zoom >= 16],
-  [feature = 'historic_castle'][zoom >= 16],
-  [feature = 'historic_manor'][zoom >= 16] {
+  [feature = 'historic_fort'][ruins = null][zoom >= 16],
+  [feature = 'historic_castle'][ruins = null][zoom >= 16],
+  [feature = 'historic_manor'][ruins = null][zoom >= 16] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;

--- a/project.mml
+++ b/project.mml
@@ -1482,6 +1482,7 @@ Layer:
             tags->'tower:construction' as "tower:construction",
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
+            CASE WHEN tags->'ruins' = 'yes' THEN tags->'ruins' ELSE NULL END as ruins,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1610,6 +1611,7 @@ Layer:
             tags->'tower:construction' as "tower:construction",
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
+            CASE WHEN tags->'ruins' = 'yes' THEN tags->'ruins' ELSE NULL END as ruins,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -2063,6 +2065,7 @@ Layer:
             tags->'office' as office,
             tags->'recycling_type' as recycling_type,
             tags->'castle_type' as castle_type,
+            CASE WHEN tags->'ruins' = 'yes' THEN tags->'ruins' ELSE NULL END as ruins,
             ref,
             way_area,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2150,6 +2153,7 @@ Layer:
             office,
             recycling_type,
             castle_type,
+            ruins,
             ref,
             way_area,
             is_building
@@ -2232,6 +2236,7 @@ Layer:
                 tags->'office' as office,
                 tags->'recycling_type' as recycling_type,
                 tags->'castle_type' as castle_type,
+                CASE WHEN tags->'ruins' = 'yes' THEN tags->'ruins' ELSE NULL END as ruins,
                 ref,
                 NULL AS way_area,
                 CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building


### PR DESCRIPTION
Changes proposed in this pull request:
Do not show castle/manor/fort symbols when the ruins tag is set. The symbols convey that the feature is in a good shape. But the `ruins` tag has a very wide definition. It could be that there are just some stones left or that still most of the building is there. I think it is better to not show symbols and text for ruins until there is a ruins symbol.

Those two not-in-very-good-shape castles (one more in the "some stones left" category) in the preview started appearing after the symbols were rendered.

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=16/46.9613/13.5035

Before
![z16_before](https://user-images.githubusercontent.com/3531092/39381706-5659a536-4a63-11e8-9a9a-dbbae28cea9c.png)

After
![z16_after](https://user-images.githubusercontent.com/3531092/39381713-5a144654-4a63-11e8-9bd3-59abf806919e.png)
