### PR TITLE
Docker: enable access to the postgresql database from the host and restrict port sharing to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - db
     ports:
-      - "6789:6789"
+      - "127.0.0.1:6789:6789"
     environment:
       - PGHOST=db
       - PGUSER=postgres
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.db
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - PG_WORK_MEM
       - PG_MAINTENANCE_WORK_MEM


### PR DESCRIPTION
Changes proposed in this pull request:
- This exposes the port of PostgreSQL to the host to enable access to the database from there with management tools.
- Limit port sharing to localhost only. I have seen on a production server that Docker is able to punch a hole in the firewall if you are not careful. While this is not the main scenario for our Docker setup it does not hurt to be careful.