### PR TITLE
Add area rendering of taxi

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -545,7 +545,8 @@
 
   [feature = 'amenity_parking'][zoom >= 10],
   [feature = 'amenity_bicycle_parking'][zoom >= 10],
-  [feature = 'amenity_motorcycle_parking'][zoom >= 10] {
+  [feature = 'amenity_motorcycle_parking'][zoom >= 10],
+  [feature = 'amenity_taxi'][zoom >= 10] {
     polygon-fill: @parking;
     [zoom >= 15] {
       line-width: 0.3;

--- a/project.mml
+++ b/project.mml
@@ -117,7 +117,7 @@ Layer:
           FROM (SELECT
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
-              ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school',
+              ('amenity_' || (CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
                                                     'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space')
                                                     THEN amenity ELSE NULL END)) AS amenity,
@@ -142,7 +142,7 @@ Layer:
             WHERE (landuse IS NOT NULL
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
-              OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'hospital', 'kindergarten',
+              OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'taxi', 'university', 'college', 'school', 'hospital', 'kindergarten',
                              'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
                              'arts_centre', 'parking_space')
               OR man_made IN ('works')


### PR DESCRIPTION
Fixes #3110

Changes proposed in this pull request:
Add rendering of `amenity=taxi` in a similar way than other parking amenities

Test rendering with links to the example places:
https://www.openstreetmap.org/way/284714637

Before
![taxi_before](https://user-images.githubusercontent.com/9897203/39628237-b09cd6c2-4fa8-11e8-8004-1adf0bf9d8d0.png)

After
![taxi_after](https://user-images.githubusercontent.com/9897203/39628240-b4820c94-4fa8-11e8-8a53-e28a136147eb.png)

I noticed that `amenity=parking` is also included into `amenity-low-priority` in the project file. Should I put also taxi in this section ?