### PR TITLE
Pixel align the shop=deli icon

### DIFF
--- a/symbols/shop/deli.svg
+++ b/symbols/shop/deli.svg
@@ -1,46 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   height="14"
-   width="14"
-   version="1.0"
-   viewBox="0 0 14 14"
-   id="svg2">
-  <defs
-     id="defs58" />
-  <metadata
-     id="metadata54">
-    <rdf:RDF>
-      <cc:Work>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <rect
-     width="14"
-     height="14"
-     x="0"
-     y="0"
-     id="canvas"
-     style="fill:none;stroke:none;visibility:hidden" />
-  <path
-     d="M 5.9999999,0 8,0 c 2,0 3,0 3,1.0000001 l 0,1 -8.0000003,0 0,-1 C 2.9999997,-4.0395351e-8 3.9999998,0 5.9999999,0 Z M 4,3 c -10e-8,1.9999997 -1.5124998,1.0000396 -1.5,3 l 0.03125,5 C 2.5374999,11.999981 3.0000004,14 5,14 l 4,0 c 2,0 2.5,-2 2.5,-3 l 0,-5 C 11.5,4.0000006 10,4.9999997 10,3 L 4,3 Z m 3,4 c 1.0424134,0 3.126953,0.6074219 3.126953,0.6074219 l 0,1.3925781 0,1.392578 C 10.126953,10.392578 8.0424135,11 7,11 5.9575867,11 3.8730469,10.392578 3.8730469,10.392578 l 0,-1.392578 0,-1.3925781 C 3.8730469,7.6074219 5.9575867,7 7,7 Z"
-     style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-opacity:1"
-     id="path4173" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14" height="14" version="1.0" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+    <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+   </cc:Work>
+   <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+    <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+   </cc:License>
+  </rdf:RDF>
+ </metadata>
+ <rect id="canvas" width="14" height="14" fill="none" visibility="hidden"/>
+ <path d="m6 0h2c2 0 3 0 3 1v1h-8v-1c0-1 1-1 3-1zm-2 3c-1e-7 2-2.0219 1-2.0156 3l0.015625 5c0.00312 1 1 3 3 3h4c2 0 3-2 3-3v-5c0-2-2-1-2-3zm6 4v3h-6v-3z" fill-rule="evenodd"/>
 </svg>


### PR DESCRIPTION
The current shop=deli icon looks pretty fuzzy to me. This PR pixel aligns the icon to the pixel grid.

Icon before:
![deli_grid_before](https://user-images.githubusercontent.com/14190496/39675220-b7f3a760-510c-11e8-8173-92a04ccb7248.png)

Icon after:
![deli_grid_after](https://user-images.githubusercontent.com/14190496/39675221-b9976dae-510c-11e8-81df-4c1bf42478ee.png)

The edges of the jar are snapped outward to the pixel grid and the curve on the label is removed (the curve is not really visible at 14x14 anyway).

Before:
https://www.openstreetmap.org/#map=18/45.51760/-122.97312&layers=N
![deli_before](https://user-images.githubusercontent.com/14190496/39675243-25882ed6-510d-11e8-878f-1efbc327411c.png)

After:
![deli_after](https://user-images.githubusercontent.com/14190496/39675244-2a719d88-510d-11e8-89a4-ece6bce2451b.png)
