### PR TITLE
Adding rendering for place=quarter

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -369,6 +369,38 @@
   }
 }
 
+#placenames-small::quarter {
+  [place = 'quarter'] {
+    [zoom >= 14][zoom < 17] {
+      text-name: "[name]";
+      text-fill: @placenames;
+      text-face-name: @book-fonts;
+      text-halo-fill: @standard-halo-fill;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      [zoom >= 14] {
+        text-halo-fill: white;
+        text-size: 11;
+        text-wrap-width: 55; // 5.0 em
+        text-line-spacing: -0.55; // -0.05 em
+        text-margin: 7.7; // 0.7 em
+      }
+      [zoom >= 15] {
+        text-fill: @placenames-light;
+        text-size: 12;
+        text-wrap-width: 60; // 5.0 em
+        text-line-spacing: -0.60; // -0.05 em
+        text-margin: 8.4; // 0.7 em
+      }
+      [zoom >= 16] {
+        text-size: 14;
+        text-wrap-width: 70; // 5.0 em
+        text-line-spacing: -0.70; // -0.05 em
+        text-margin: 9.8; // 0.7 em
+      }
+    }
+  }
+}
+
 #placenames-small::hamlet {
   [place = 'hamlet'],
   [place = 'locality'],

--- a/project.mml
+++ b/project.mml
@@ -1395,7 +1395,7 @@ Layer:
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
-             OR (place IN ('suburb', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
+             OR (place IN ('suburb', 'quarter', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
                  OR (place IN ('square')
                      AND (leisure is NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
              ) AND name IS NOT NULL
@@ -1403,11 +1403,12 @@ Layer:
               WHEN place = 'suburb' THEN 3
               WHEN place = 'village' THEN 4
               WHEN place = 'hamlet' THEN 5
-              WHEN place = 'neighbourhood' THEN 6
-              WHEN place = 'locality' THEN 7
-              WHEN place = 'isolated_dwelling' THEN 8
-              WHEN place = 'farm' THEN 9
-              WHEN place = 'square' THEN 10
+              WHEN place = 'quarter' THEN 6
+              WHEN place = 'neighbourhood' THEN 7
+              WHEN place = 'locality' THEN 8
+              WHEN place = 'isolated_dwelling' THEN 9
+              WHEN place = 'farm' THEN 10
+              WHEN place = 'square' THEN 11
             END ASC, length(name) DESC, name
         ) AS placenames_small
     properties:


### PR DESCRIPTION
Fixes #798

Changes proposed in this pull request:
- adding rendering for place=quarter as a name label on z14-z16

Rendering test:
- [Example place](https://www.openstreetmap.org/node/334557199#map=16/52.1973/21.0438) (_Sielce_), compared to place=suburb (_Mokotów_) and place=neighbourhood (_Marcelin_):

z14
![ochpaaw9](https://user-images.githubusercontent.com/5439713/39722851-310679f6-5244-11e8-935c-179f8e865574.png)

z15
![qu2ttl37](https://user-images.githubusercontent.com/5439713/39722856-34ef3d5a-5244-11e8-969a-a706e8873f91.png)

z16
![tlqypxz0](https://user-images.githubusercontent.com/5439713/39722865-39daa11a-5244-11e8-83b2-784423fd870d.png)
