### PR TITLE
Brighten built-up areas on z12

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -9,8 +9,9 @@
 
 // --- "Base" landuses ---
 
-@built-up-upper-lowzoom: #c0c0c0;
-@built-up-lower-lowzoom: #aaaaaa;
+@built-up-lowzoom: #aaaaaa;
+@built-up-z11: #c0c0c0;
+@built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
 @retail: #ffd6d1;           // Lch(89,16,30)
@@ -231,8 +232,9 @@
   }
 
   [feature = 'landuse_residential'][zoom >= 8] {
-    polygon-fill: @built-up-lower-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+    polygon-fill: @built-up-lowzoom;
+    [zoom >= 11] { polygon-fill: @built-up-z11; }
+    [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @residential; }
     [zoom >= 16] {
       line-width: .5;
@@ -351,8 +353,9 @@
   [feature = 'landuse_retail'],
   [feature = 'amenity_marketplace'] {
     [zoom >= 8] {
-      polygon-fill: @built-up-lower-lowzoom;
-      [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+      polygon-fill: @built-up-lowzoom;
+      [zoom >= 11] { polygon-fill: @built-up-z11; }
+      [zoom >= 12] { polygon-fill: @built-up-z12; }
       [zoom >= 13] { polygon-fill: @retail; }
       [zoom >= 16] {
         line-width: 0.5;
@@ -367,8 +370,9 @@
   }
 
   [feature = 'landuse_industrial'][zoom >= 8] {
-    polygon-fill: @built-up-lower-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+    polygon-fill: @built-up-lowzoom;
+    [zoom >= 11] { polygon-fill: @built-up-z11; }
+    [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @industrial; }
     [zoom >= 16] {
       line-width: .5;
@@ -419,8 +423,9 @@
   }
 
   [feature = 'landuse_commercial'][zoom >= 8] {
-    polygon-fill: @built-up-lower-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-upper-lowzoom; }
+    polygon-fill: @built-up-lowzoom;
+    [zoom >= 11] { polygon-fill: @built-up-z11; }
+    [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @commercial; }
     [zoom >= 16] {
       line-width: 0.5;


### PR DESCRIPTION
This resolves #2777

The brightness sequence from z10 up used to be 212-216-211-223, now it is 212-216-221-223.

Test rendering with links to the example places:

Before
<img width="331" alt="screen shot 2018-05-09 at 00 31 19" src="https://user-images.githubusercontent.com/5251909/39786434-e40b9cde-5320-11e8-97d2-3f0a279e2349.png">

After
<img width="331" alt="screen shot 2018-05-09 at 00 31 11" src="https://user-images.githubusercontent.com/5251909/39786451-ee4fd4bc-5320-11e8-9ab4-fba59aca65f2.png">