### PR TITLE
Select overground power=cable like power=line

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1234,7 +1234,7 @@ Layer:
             way
           FROM planet_osm_line
           WHERE power = 'line'
-            OR (power = 'cable' AND tags->'location' IS NOT NULL AND tags->'location' NOT IN ('underground', 'underwater'))
+            OR (power = 'cable' AND tags->'location' IN ('overground', 'overhead', 'surface', 'outdoor', 'platform'))
         ) AS power_line
     properties:
       minzoom: 14

--- a/project.mml
+++ b/project.mml
@@ -1234,6 +1234,7 @@ Layer:
             way
           FROM planet_osm_line
           WHERE power = 'line'
+            OR (power = 'cable' AND tags->'location' IS NOT NULL AND tags->'location' NOT IN ('underground', 'underwater'))
         ) AS power_line
     properties:
       minzoom: 14


### PR DESCRIPTION
Power cables with a location tag that says they are overground, are now selected and rendered just like power lines, to improve the look of substations that use gas insulated cables. Since those cables are insulated, they have to be mapped with power=cable instead of power=line, but this left undesirable gaps in the connections.

[According to the wiki](https://wiki.openstreetmap.org/wiki/Tag:power%3Dcable) cables without a location tag default to 'either underground or underwater', so they are treated as such.

Closes #3217.

#### Before
Location: [a substation in Zeebrugge, Belgium](https://www.openstreetmap.org/#map=18/51.32588/3.18409)
![before](https://user-images.githubusercontent.com/4283376/39677761-0934fa30-5170-11e8-9e30-8dd79ca53975.png)
![before-zoom-out](https://user-images.githubusercontent.com/4283376/39846001-b5811394-53e8-11e8-89e2-8c783cb1151d.png)

#### After
![after](https://user-images.githubusercontent.com/4283376/39845914-2051077a-53e8-11e8-8251-c2174a904d5b.png)
![after-zoom-out](https://user-images.githubusercontent.com/4283376/39845994-ae466020-53e8-11e8-919d-7cae92baea94.png)

~~I tried to set up Kosmtik but the installation failed horribly. I don't feel like installing even more versions of Node.js (which I don't like) on my system to see which one might possibly work, to test such a small change. If you can give me some pointers about which versions to use, I would give it another go.~~

~~TileMill's install script thinks that all Linux is Debian so TileMill didn't work either.~~