### PR TITLE
playground=sandpit with sand as background-color

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -482,6 +482,12 @@
     }
   }
 
+  [feature = 'sandpit'][zoom >= 17] {
+    polygon-fill: @sand;
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+
   [feature = 'natural_sand'][zoom >= 8] {
     polygon-fill: @sand;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }


### PR DESCRIPTION
# Changes proposed in this pull request:

A sandpit is always made of sand and therefore can and should be displayed with the color of sand. However, in contrast to the general sand rendering, the playground should only be rendered in higher zoom levels since the size of the sandpit is most likely small and will only clutter the map when zoomed out.

- Details about at `playground=sandpit` at https://wiki.openstreetmap.org/wiki/Key:playground#playground-values
- Details about the tag usage https://taginfo.openstreetmap.org/tags/playground=sandpit

# Testcase 1 Karl-Marx-Platz
https://www.openstreetmap.org/#map=19/52.47447/13.44328

## Before
<img width="612" alt="bildschirmfoto 2018-05-12 um 08 33 35" src="https://user-images.githubusercontent.com/111561/39954406-33021110-55bf-11e8-94fa-0c34cca8e4a7.png">

## After

(I dont know yet how to create test renderings)

# Testcase 2 Kirchgasse
https://www.openstreetmap.org/#map=19/52.47799/13.44190

## Before
<img width="415" alt="bildschirmfoto 2018-05-12 um 08 33 20" src="https://user-images.githubusercontent.com/111561/39954407-3325540e-55bf-11e8-9034-d9ca117863d5.png">

## After

(I dont know yet how to create test renderings)
