### PR TITLE
Make amenity=shelter brown

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -47,6 +47,9 @@
     [feature = 'tourism_alpine_hut'] {
       marker-file: url('symbols/alpinehut.svg');
     }
+    [feature = 'amenity_shelter'] {
+      marker-fill: @amenity-brown;
+    }
     marker-fill: @accommodation-icon;
     marker-placement: interior;
     marker-clip: false;
@@ -2118,6 +2121,9 @@
     [feature = 'tourism_camp_site'],
     [feature = 'tourism_caravan_site'] {
       text-dy: 15;
+    }
+    [feature = 'amenity_shelter'] {
+      text-fill: @amenity-brown;
     }
   }
 


### PR DESCRIPTION
Observed in the German style.

Changes proposed in this pull request:
- Make amenity=shelter brown, as it is not a transport nor accommodation utility, rather generic amenity

It looks more like other amenities [on platforms](https://www.openstreetmap.org/#map=19/52.23285/20.99709) and doesn't take away attention from real transport-related objects:

Before
![8wn9n_af](https://user-images.githubusercontent.com/5439713/39961184-7c918988-5631-11e8-9757-7ddb41f35cc0.png)

After
![tswelai8](https://user-images.githubusercontent.com/5439713/39961189-8e9e904e-5631-11e8-828f-a6a68f06cd52.png)


It blends better with other amenities [at the picnic site](https://www.openstreetmap.org/#map=18/52.30240/20.87196) and with buildings:

Before
![jojkzgyo](https://user-images.githubusercontent.com/5439713/39961211-de08edaa-5631-11e8-9cd2-f99976477020.png)

After
![uazgkp m](https://user-images.githubusercontent.com/5439713/39961212-e044bf18-5631-11e8-913a-2bba1bf56d2a.png)


It's also easier to spot [in the forest](https://www.openstreetmap.org/node/2881682202#map=16/52.3026/20.3666):

Before
![ze86_f8n](https://user-images.githubusercontent.com/5439713/39961276-10240364-5633-11e8-9ac7-89376b9f2c74.png)

After
![5 6r5fof](https://user-images.githubusercontent.com/5439713/39961285-152cc030-5633-11e8-8f82-35a6ed525664.png)
