### PR TITLE
Adding rendering of lock_name

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2498,6 +2498,7 @@ Layer:
             waterway,
             lock,
             name,
+            tags-> 'lock_name' AS lock_name,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,

--- a/water.mss
+++ b/water.mss
@@ -245,6 +245,17 @@
 }
 
 #water-lines-text {
+  [lock = 'yes'][zoom >= 17] {
+      text-name: "[lock_name]";
+      text-face-name: @oblique-fonts;
+      text-placement: line;
+      text-fill: @water-text;
+      text-spacing: 400;
+      text-size: 10;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill; 
+  }
+
   [lock != 'yes'][int_tunnel != 'yes'] {
     [waterway = 'river'][zoom >= 13] {
       text-name: "[name]";


### PR DESCRIPTION
Fixes #157

Changes proposed in this pull request:
Render lock_name

Test rendering with links to the example places:
https://www.openstreetmap.org/way/231720575
Before
![lock_name_before](https://user-images.githubusercontent.com/9897203/40047032-a834addc-582e-11e8-8dd0-18811cb642ef.png)

After
![lock_name_after](https://user-images.githubusercontent.com/9897203/40047041-abbb3606-582e-11e8-8ee7-e83c535b0af7.png)
