### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://EditorConfig.org
+
+root = true
+
+# Defaults apply to all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# 4 space indentation for Lua and Python
+[*.{lua,py}]
+indent_size = 4
+
+# Leave SVG files alone, we have a mix of tabs and spaces
+[*.svg]
+indent_style = undef
+indent_size = undef

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
Fixes #3209 

This should configure editors to follow the indentation and whitespace behaviour the existing code has, using http://editorconfig.org/
