### PR TITLE
[DO NOT MERGE] Treat barrier=toll_booth as area

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -43,6 +43,7 @@ local linestring_values = {
 
 -- Objects with any of the following key/value combinations will be treated as polygon
 local polygon_values = {
+    barrier = {toll_booth = true},
     highway = {services = true, rest_area = true},
     junction = {yes = true}
 }


### PR DESCRIPTION
Fixes part of #3244

Currently, we treat `barrier=toll_booth` as _line_ geometry, just like all other `barrier`.

Resolving #3244 needs `barrier=toll_booth` as _area_ geometry.

We could make a geometry transformation to get an area in the SQL query with `ST_BuildArea(way)` even on line geometries. But #2510 has proven that there are pitfalls that can make serious performance problems. So I think it’s better to avoid this.

Without judging here weather it is a good idea or not to _render_ `barrier=toll_booth` on areas in our style, I think in any case it would be more correct to treat `barrier=toll_booth` as area geometry in our database tables.

This PR changes the lua file to make this happen. This would mean a database reload. I think this change is not important enough for a database reload. But maybe we can collect somewhere changes like this to the database tables, just to have them ready for a later database reload…