### PR TITLE
Travis test for unsupported hstore operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,5 @@ script:
   - osm2pgsql -G --hstore --style openstreetmap-carto.style -U postgres -d gis -r libxml2 <(echo '<osm version="0.6"/>')
   # Apply the custom indexes
   - psql -1Xq -v ON_ERROR_STOP=1 -d gis -f indexes.sql
+  # Test for hstore operation not supported in PostgreSQL 9.3
+  - '! grep "tags->''[^'']\+'' IS" project.mml > /dev/null'


### PR DESCRIPTION
This should make Travis CI check for that unsupported hstore operation, that needs brackets. I'm not an expert, so a test is needed.

See #3245 and #3078.