### PR TITLE
Check all YAML files are valid YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
     - lua5.1
     - libxml2-utils
+    - python-yaml
 env:
   - CARTO=0.18.0 MAPNIK='3.0.0 3.0.12'
 install:
@@ -17,6 +18,9 @@ install:
 script:
   # We're using pipes in the checks, so fail if any part fails
   - set -o pipefail
+  # Check all tye YAML files are valid YAML
+  - find . -not \( -path ./node_modules -prune \) \( -type f -name '*.yaml' -o -name '*.yml' -o -name '*.mml' \)
+     -exec python -c "from yaml import safe_load; safe_load(file('{}'))" \;
   # Validate the MML against multiple Mapnik versions, and report its lines for debugging purposes
   - for m in $MAPNIK; do ./node_modules/carto/bin/carto -a $m project.mml | xmllint - | wc -l; done
   # Validate that the SVGs are valid XML


### PR DESCRIPTION
This checks with find rather than an explicit list, because any .yml or .yaml files should be YAML, and should be valid.
