### PR TITLE
Remove hidden icon of dog_park

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1093,13 +1093,6 @@
     marker-clip: false;
   }
 
-  [feature = 'leisure_dog_park'][zoom >= 17] {
-    marker-file: url('symbols/shop/pet.svg');
-    marker-placement: interior;
-    marker-fill: @leisure-green;
-    marker-clip: false;
-  }
-
   [feature = 'leisure_playground'][zoom >= 17] {
     marker-file: url('symbols/playground.svg');
     marker-fill: @leisure-green;
@@ -1769,7 +1762,6 @@
   }
 
   [feature = 'leisure_playground'],
-  [feature = 'leisure_dog_park'],
   [feature = 'leisure_fitness_centre'],
   [feature = 'leisure_fitness_station'] {
     [way_area >= 150000][zoom >= 14],
@@ -2052,8 +2044,7 @@
       }
       [feature = 'leisure_dog_park'],
       [feature = 'leisure_fitness_centre'],
-      [feature = 'leisure_fitness_station'],
-      [feature = 'leisure_dog_park'] {
+      [feature = 'leisure_fitness_station'] {
         text-fill: @leisure-green;
         text-halo-radius: @standard-halo-radius * 1.5; /* Extra halo needed to stand out from paw pattern. */
         text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
Changes proposed in this pull request:
`leisure=dog_park` should display an icon which is hidden and this shifts the label which is not centered. The following PR removes unnecessary code to show icon and redundancy.

Test rendering with links to the example places:
https://www.openstreetmap.org/way/554648250

Before
![dog_park_before](https://user-images.githubusercontent.com/9897203/40889663-33f5f4ac-676b-11e8-9df4-57db45400675.png)

After
![dog_park_after](https://user-images.githubusercontent.com/9897203/40889665-37c763a4-676b-11e8-9846-fd5ee986cfa5.png)
