### PR TITLE
Living street tunnels different from residential

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -60,7 +60,7 @@
 @secondary-tunnel-fill: lighten(@secondary-fill, 5%);
 @tertiary-tunnel-fill: lighten(@tertiary-fill, 5%);
 @residential-tunnel-fill: darken(@residential-fill, 5%);
-@living-street-tunnel-fill: lighten(@living-street-fill, 10%);
+@living-street-tunnel-fill: lighten(@living-street-fill, 3%);
 
 @motorway-width-z6:               0.4;
 @trunk-width-z6:                  0.4;


### PR DESCRIPTION
Fixes #3258 

Changes proposed in this pull request:
- Lighten living street tunnels less (respective to normal living street colour)

Test rendering with links to the example places:

Before/After

![screenshot 1](https://user-images.githubusercontent.com/6830724/40964600-0ee56f5e-689b-11e8-90e6-8fb3fab10524.png)
https://www.openstreetmap.org/way/424282172#map=19/41.80501/12.62467
