### PR TITLE
Add curl option

### DIFF
--- a/scripts/get-shapefiles.py
+++ b/scripts/get-shapefiles.py
@@ -124,13 +124,13 @@ def download_file(
             sys.stdout.flush()
             if os.path.exists(file_name) and not option_force_update:
                 if subprocess.call(
-                    ["curl", "-z", file_name, "-L", "-o", file_name, url],
+                    ["curl", "-R", "-z", file_name, "-L", "-o", file_name, url],
                         stderr=subprocess.STDOUT) != 0:
                     sys.exit("\n\n   'curl' error: download failed.\n")
                 curl_used = 2
             else:
                 if subprocess.call(
-                    ["curl", "-L", "-o", file_name, url],
+                    ["curl", "-R", "-L", "-o", file_name, url],
                         stderr=subprocess.STDOUT) != 0:
                     sys.exit("\n\n   'curl' error: download failed.\n")
             sys.stdout.flush()


### PR DESCRIPTION
When downloading files it is a good idea to set the timestamp of the remote file for the downloaded file which is better for subsequent updates than the download time.