### PR TITLE
Finer man_made=pier width

### DIFF
--- a/water-features.mss
+++ b/water-features.mss
@@ -70,10 +70,12 @@
       polygon-fill: @land-color;
     }
     #piers-line {
-      line-width: 1.5;
+      line-width: 0.5;
       line-color: @land-color;
-      [zoom >= 13] { line-width: 3; }
-      [zoom >= 16] { line-width: 7; }
+      line-cap: square;
+      [zoom >= 13] { line-width: 1; }
+      [zoom >= 15] { line-width: 2; }
+      [zoom >= 17] { line-width: 4; }
     }
   }
 


### PR DESCRIPTION
Fixes #2652

- Lowers the stroke width of man_made=pier
- Adds square line-cap to remove rendering artifacts
- Does not effect piers mapped as an area

From the discussion in #2652, there was some disagreement on whether piers should represent real world geometries or abstract lines. My opinion is that it doesn't matter which camp you're in, piers are currently much wider in the map than they are in the real world, and as an abstract line, they are still too wide (they are wider than residential roads at zooms 12, 13 and 14).

At [this sample area.](https://www.openstreetmap.org/#map=14/45.6079/-122.6679)

Before
![before_12](https://user-images.githubusercontent.com/14190496/41503582-d3289be4-718c-11e8-91ff-9b0ac0eafbe1.png)
After
![after_12](https://user-images.githubusercontent.com/14190496/41503584-d56d4224-718c-11e8-88e4-a071e12a4af0.png)

Before
![before_13](https://user-images.githubusercontent.com/14190496/41503595-0173d680-718d-11e8-9027-38651eff7640.png)
After
![after_13](https://user-images.githubusercontent.com/14190496/41503598-0522e00a-718d-11e8-9a24-957f9824ce55.png)

Before
![before_14](https://user-images.githubusercontent.com/14190496/41503600-0b619862-718d-11e8-874f-a02a0b2c327e.png)
After
![after_14](https://user-images.githubusercontent.com/14190496/41503601-0d63a27c-718d-11e8-874d-41d6c0ed4014.png)

Before
![before_15](https://user-images.githubusercontent.com/14190496/41503602-1524e7d2-718d-11e8-8aef-eee16d2258d4.png)
After
![after_15](https://user-images.githubusercontent.com/14190496/41503603-17e61392-718d-11e8-8e78-bf2b805207af.png)

Before
![before_16](https://user-images.githubusercontent.com/14190496/41503604-1ad970da-718d-11e8-94b5-e07582c81cef.png)
After
![after_16](https://user-images.githubusercontent.com/14190496/41503605-1dc35f9a-718d-11e8-96ac-9aae01edcf85.png)

Before
![before_17](https://user-images.githubusercontent.com/14190496/41503606-20af3026-718d-11e8-9c98-a4d1c2b18e65.png)
After
![after_17](https://user-images.githubusercontent.com/14190496/41503607-24c7aef4-718d-11e8-9bcf-d8018c42e744.png)

Before
![before_18](https://user-images.githubusercontent.com/14190496/41503609-2758aa38-718d-11e8-9ef8-bb9827522508.png)
Notice the gaps in the line rendering.
After
![after_18](https://user-images.githubusercontent.com/14190496/41503610-2a5328d0-718d-11e8-8a75-70b1d814eb16.png)

Before
![before_19](https://user-images.githubusercontent.com/14190496/41503611-2d2e2f82-718d-11e8-8be4-b9720fb42809.png)
After
![after_19](https://user-images.githubusercontent.com/14190496/41503613-30171ad8-718d-11e8-8c48-c75a17915a05.png)
