### PR TITLE
Update import Docker container to use OSMF PPA packages

### DIFF
--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,5 +1,12 @@
 FROM ubuntu:xenial
 
+RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu xenial main\n\
+deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu xenial main' > \
+    /etc/apt/sources.list.d/osmadmins-ppa.list
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com \
+    --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
     curl ca-certificates osm2pgsql postgresql-client \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes # (id of the issue to be closed)
N/A
Changes proposed in this pull request:
Adds build arguments to the 'import' Docker container so that a custom osm2pgsql library can be built if the user so chooses, and explains the arguments to do this in the DOCKER.md file.

(I have run into a potential bug in osm2pgsql, and being able to specify an arbitrary version or branch for the version I wish to test against, to see how the osm2pgsql program imports it to display in openstreetmap-carto, is very useful in this scenario.)

Test rendering with links to the example places:
N/A