### PR TITLE
Increased text and shield distances on waterways, railways and roads

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -281,7 +281,7 @@
 @shield-size-z18: 12;
 @shield-line-spacing-z18: -1.80; // -0.15 em
 @shield-spacing: 760;
-@shield-min-distance: 40;
+@shield-repeat-distance: 600;
 @shield-font: @book-fonts;
 @shield-clip: false;
 
@@ -2665,7 +2665,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     shield-line-spacing: @shield-line-spacing;
     shield-placement: line;
     shield-spacing: @shield-spacing;
-    shield-min-distance: @shield-min-distance;
+    shield-repeat-distance: @shield-repeat-distance;
     shield-face-name: @shield-font;
     shield-clip: @shield-clip;
 
@@ -2713,7 +2713,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
       shield-placement: line;
       shield-spacing: @shield-spacing;
-      shield-min-distance: @shield-min-distance;
+      shield-repeat-distance: @shield-repeat-distance;
       shield-face-name: @shield-font;
       shield-clip: @shield-clip;
 

--- a/roads.mss
+++ b/roads.mss
@@ -283,7 +283,8 @@
 @shield-size-z18: 12;
 @shield-line-spacing-z18: -1.80; // -0.15 em
 @shield-spacing: 760;
-@shield-repeat-distance: 600;
+@shield-repeat-distance: 400;
+@shield-margin: 40;
 @shield-font: @book-fonts;
 @shield-clip: false;
 
@@ -2668,6 +2669,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     shield-placement: line;
     shield-spacing: @shield-spacing;
     shield-repeat-distance: @shield-repeat-distance;
+    shield-margin: @shield-margin;
     shield-face-name: @shield-font;
     shield-clip: @shield-clip;
 
@@ -2716,6 +2718,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       shield-placement: line;
       shield-spacing: @shield-spacing;
       shield-repeat-distance: @shield-repeat-distance;
+      shield-margin: @shield-margin;
       shield-face-name: @shield-font;
       shield-clip: @shield-clip;
 

--- a/roads.mss
+++ b/roads.mss
@@ -272,6 +272,8 @@
 @track-oneway-arrow-color:        darken(@track-fill, 15%);
 @bridleway-oneway-arrow-color:    darken(@track-fill, 10%);
 
+@text-repeat-distance: 600;
+
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.
 @shield-size: 10;
@@ -2830,6 +2832,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
+      text-repeat-distance: @text-repeat-distance;
       [tunnel = 'no'] {
         text-halo-radius: @standard-halo-radius;
         [highway = 'motorway'] { text-halo-fill: @motorway-fill; }
@@ -2862,6 +2865,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @secondary-fill;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 14] {
       text-size: 9;
@@ -2888,6 +2892,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @tertiary-fill;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2906,6 +2911,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-face-name: @book-fonts;
+    text-repeat-distance: @text-repeat-distance;
 
     [zoom >= 17] {
       text-size: 11;
@@ -2932,6 +2938,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @residential-fill;
       text-face-name: @book-fonts;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -2961,6 +2968,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'raceway'] { text-halo-fill: @raceway-fill; }
       [highway = 'service'] { text-halo-fill: @service-fill; }
       text-face-name: @book-fonts;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2982,6 +2990,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'living_street'] { text-halo-fill: @living-street-fill; }
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3021,6 +3030,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 5;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3049,6 +3059,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 7;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -3173,10 +3184,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 900;
       text-clip: false;
       text-placement: line;
-      text-min-distance: 18;
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 19] {
       text-size: 11;
@@ -3195,10 +3206,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         text-spacing: 300;
         text-clip: false;
         text-placement: line;
-        text-min-distance: 18;
         text-face-name: @book-fonts;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
+        text-repeat-distance: @text-repeat-distance;
       }
       [zoom >= 13] {
         text-dy: 6;
@@ -3224,10 +3235,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         text-spacing: 300;
         text-clip: false;
         text-placement: line;
-        text-min-distance: 18;
         text-face-name: @book-fonts;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
+        text-repeat-distance: @text-repeat-distance;
       }
       [zoom >= 17] {
         text-spacing: 600;
@@ -3254,10 +3265,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 900;
       text-clip: false;
       text-placement: line;
-      text-min-distance: 18;
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 19] {
       text-size: 11;

--- a/roads.mss
+++ b/roads.mss
@@ -272,7 +272,7 @@
 @track-oneway-arrow-color:        darken(@track-fill, 15%);
 @bridleway-oneway-arrow-color:    darken(@track-fill, 10%);
 
-@text-repeat-distance: 600;
+@text-repeat-distance: 50;
 
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.
@@ -2941,7 +2941,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @residential-fill;
       text-face-name: @book-fonts;
-      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -2993,7 +2992,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'living_street'] { text-halo-fill: @living-street-fill; }
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
-      text-repeat-distance: @text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;

--- a/water.mss
+++ b/water.mss
@@ -2,6 +2,8 @@
 @glacier: #ddecec;
 @glacier-line: #9cf;
 
+@text-repeat-distance: 600;
+
 #water-areas {
   [natural = 'glacier']::natural {
     [zoom >= 8] {
@@ -266,6 +268,7 @@
       text-halo-fill: @standard-halo-fill;
       text-spacing: 400;
       text-placement: line;
+      text-repeat-distance: @text-repeat-distance;
       [zoom >= 14] { text-size: 12; }
       [int_tunnel = 'yes'] { text-min-distance: 200; }
     }
@@ -278,6 +281,7 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: line;
+      text-repeat-distance: @text-repeat-distance;
     }
 
     [waterway = 'stream'][zoom >= 15] {
@@ -288,7 +292,7 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 600;
-      text-repeat-distance: 400;
+      text-repeat-distance: @text-repeat-distance;
       text-placement: line;
       text-vertical-alignment: middle;
       text-dy: 8;
@@ -304,7 +308,7 @@
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
         text-spacing: 600;
-        text-repeat-distance: 400;
+        text-repeat-distance: @text-repeat-distance;
         text-placement: line;
         text-vertical-alignment: middle;
         text-dy: 8;

--- a/water.mss
+++ b/water.mss
@@ -288,6 +288,7 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 600;
+      text-repeat-distance: 400;
       text-placement: line;
       text-vertical-alignment: middle;
       text-dy: 8;
@@ -303,6 +304,7 @@
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
         text-spacing: 600;
+        text-repeat-distance: 400;
         text-placement: line;
         text-vertical-alignment: middle;
         text-dy: 8;


### PR DESCRIPTION
This PR fixes #3111: it limits redundant shields and stream labels by using `shield-repeat-distance` and `text-repeat-distance`. The `*-min-distance` versions of these attributes were not used, because they didn't change rendering, even with very large values (i.e. about 1000); besides, this PR drops `shield-min-distance`, because Mapnik complained about using this `deprecated option minimum-distance with new options margin and repeat-distance.`

I wandered around to see if the new version does not remove too much labels and shields, but there are still one or two at each view I took, so I assume these values are OK, but I can test on other places if requested, as long as the Geofabrik dump is not too big.

* Before
![image](https://user-images.githubusercontent.com/13777824/42383760-83bd629a-8138-11e8-9677-b2cf5422d115.png)
![image](https://user-images.githubusercontent.com/13777824/42383790-98b18e60-8138-11e8-8644-291fe4a4e9b0.png)
* After
![image](https://user-images.githubusercontent.com/13777824/42383772-8c337b30-8138-11e8-849c-e68410d31a28.png)
![image](https://user-images.githubusercontent.com/13777824/42383797-a5446d00-8138-11e8-8ea6-e38868e7d6b1.png)
