### PR TITLE
Update kosmtik, db, import Dockerfiles for Ubuntu 18.04 and nodejs 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # Style dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    unzip curl ca-certificates gnupg python postgresql-client \
-    fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted ttf-unifont \
-    mapnik-utils \
-    && rm -rf /var/lib/apt/lists/*
+    ca-certificates curl gnupg postgresql-client python fonts-hanazono \
+    fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted mapnik-utils \
+    nodejs npm ttf-unifont unzip && rm -rf /var/lib/apt/lists/*
 
-# Node.js 6.x LTS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash \
-    && apt-get install --no-install-recommends -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-# Kosmtik with plugins
-RUN npm install -g kosmtik
+# Kosmtik with plugins, forcing prefix to /usr because bionic sets
+# npm prefix to /usr/local, which breaks the install
+RUN npm set prefix /usr && npm install -g kosmtik
 
 WORKDIR /usr/lib/node_modules/kosmtik/ 
 RUN kosmtik plugins --install kosmtik-overpass-layer \

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM mdillon/postgis:9.6
+FROM mdillon/postgis:10
 
 ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,15 +1,17 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
-RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu xenial main\n\
-deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu xenial main' > \
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates curl gnupg && rm -rf /var/lib/apt/lists/*
+
+RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main\n\
+deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main' > \
     /etc/apt/sources.list.d/osmadmins-ppa.list
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com \
     --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    curl ca-certificates osm2pgsql postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+    osm2pgsql postgresql-client && rm -rf /var/lib/apt/lists/*
 
 ADD openstreetmap-carto.style /
 


### PR DESCRIPTION
Fixes #3308 
Changes proposed in this pull request:
* Postgresql 10 (as is the default is in Ubuntu 18.04, Bionic Beaver)
* Nodejs 8.x (also its default)
* Addition of `fonts-hanazono` fonts package which was never included in Dockerfile but is mentioned in the install guide
* Sets the prefix of npm installation to /usr, which is what kosmtik expects (Default in Ubuntu 18.04 npm package is /usr/local, which confused its installation scripts). Kosmtik **is** expected to be node 8 compatible. See https://github.com/kosmtik/kosmtik/commit/aed8789c6d11e53f03b151f2817b08a659d20c99 .

Testing performed:
docker-compose up import (against a data.osm.pbf file)
docker-compose up kosmtik