### PR TITLE
Added text-repeat-distance for railways (part of #3295)

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -285,6 +285,8 @@
 @shield-font: @book-fonts;
 @shield-clip: false;
 
+@railway-text-repeat-distance: 600;
+
 #roads-casing, #bridges, #tunnels {
   ::casing {
     [zoom >= 12] {
@@ -3173,10 +3175,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 900;
       text-clip: false;
       text-placement: line;
-      text-min-distance: 18;
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @railway-text-repeat-distance;
     }
     [zoom >= 19] {
       text-size: 11;
@@ -3195,10 +3197,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         text-spacing: 300;
         text-clip: false;
         text-placement: line;
-        text-min-distance: 18;
         text-face-name: @book-fonts;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
+        text-repeat-distance: @railway-text-repeat-distance;
       }
       [zoom >= 13] {
         text-dy: 6;
@@ -3224,10 +3226,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         text-spacing: 300;
         text-clip: false;
         text-placement: line;
-        text-min-distance: 18;
         text-face-name: @book-fonts;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
+        text-repeat-distance: @railway-text-repeat-distance;
       }
       [zoom >= 17] {
         text-spacing: 600;
@@ -3254,10 +3256,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 900;
       text-clip: false;
       text-placement: line;
-      text-min-distance: 18;
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @railway-text-repeat-distance;
     }
     [zoom >= 19] {
       text-size: 11;


### PR DESCRIPTION
This PR adds `text-repeat-distance` on railways texts, to avoid uselessly cluttering the map by repeating the labels to close of one another; this partly supersedes #3295 which was to be split in several PRs. This includes the removing of the conflicting, deprecated `text-min-distance`.

Test renderings, before/after:
![01704473417392_old_railway](https://user-images.githubusercontent.com/13777824/43078718-9248f364-8e8b-11e8-839c-571fef9d562e.png)
![01704473417392_new_railway](https://user-images.githubusercontent.com/13777824/43078716-922e1422-8e8b-11e8-9508-c45148b9ffbf.png)

![02008434052688_old_railway](https://user-images.githubusercontent.com/13777824/43078720-927bf494-8e8b-11e8-84cc-34a58f917c42.png)
![02008434052688_new_railway](https://user-images.githubusercontent.com/13777824/43078719-92617e8e-8e8b-11e8-9559-ca3ca6c5cb85.png)

![102575255415005_old_railway](https://user-images.githubusercontent.com/13777824/43078722-92aafc58-8e8b-11e8-919d-0a39e7aa3847.png)
![102575255415005_new_railway](https://user-images.githubusercontent.com/13777824/43078721-929446a2-8e8b-11e8-97dd-c1dde81c7b2d.png)