### PR TITLE
Added text-repeat-distance for highway names

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -286,8 +286,8 @@
 @shield-font: @book-fonts;
 @shield-clip: false;
 
-@major-highway-text-repeat-distance: 500;
-@minor-highway-text-repeat-distance: 100;
+@major-highway-text-repeat-distance: 50;
+@minor-highway-text-repeat-distance: 10;
 
 @railway-text-repeat-distance: 200;
 

--- a/roads.mss
+++ b/roads.mss
@@ -286,8 +286,8 @@
 @shield-font: @book-fonts;
 @shield-clip: false;
 
-@major-highways-text-repeat-distance: 50;
-@minor-highways-text-repeat-distance: 200;
+@major-highways-text-repeat-distance: 500;
+@minor-highways-text-repeat-distance: 100;
 
 @railway-text-repeat-distance: 200;
 
@@ -2945,6 +2945,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-fill: @residential-fill;
       text-face-name: @book-fonts;
       text-repeat-distance: @minor-highways-text-repeat-distance;
+      [highway = 'unclassified'] { text-repeat-distance: @major-highways-text-repeat-distance;}
     }
     [zoom >= 16] {
       text-size: 9;
@@ -2974,7 +2975,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'raceway'] { text-halo-fill: @raceway-fill; }
       [highway = 'service'] { text-halo-fill: @service-fill; }
       text-face-name: @book-fonts;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
+      text-repeat-distance: @major-highways-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2993,7 +2994,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-halo-radius: @standard-halo-radius;
-      [highway = 'living_street'] { text-halo-fill: @living-street-fill; }
+      [highway = 'living_street'] { text-halo-fill: @living-street-fill; text-repeat-distance: @major-highways-text-repeat-distance;}
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
       text-repeat-distance: @minor-highways-text-repeat-distance;
@@ -3036,7 +3037,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 5;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
+      text-repeat-distance: @major-highways-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3065,7 +3066,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 7;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
+      text-repeat-distance: @major-highways-text-repeat-distance;
+      [highway = 'steps'] { text-repeat-distance: @minor-highways-text-repeat-distance; }
     }
     [zoom >= 17] {
       text-size: 11;

--- a/roads.mss
+++ b/roads.mss
@@ -2798,11 +2798,11 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
       text-fill: #000;
       text-face-name: @book-fonts;
+      text-min-distance: 40;
       text-halo-radius: 2;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 760;
       text-clip: false;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
   }
 

--- a/roads.mss
+++ b/roads.mss
@@ -286,6 +286,9 @@
 @shield-font: @book-fonts;
 @shield-clip: false;
 
+@major-highways-text-repeat-distance: 50;
+@minor-highways-text-repeat-distance: 200;
+
 #roads-casing, #bridges, #tunnels {
   ::casing {
     [zoom >= 12] {
@@ -2793,11 +2796,11 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
       text-fill: #000;
       text-face-name: @book-fonts;
-      text-min-distance: 40;
       text-halo-radius: 2;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 760;
       text-clip: false;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
   }
 
@@ -2810,10 +2813,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 750;
       text-clip: false;
       text-placement: line;
-      text-min-distance: 18;
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
   }
 }
@@ -2833,6 +2836,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
+      text-repeat-distance: @major-highways-text-repeat-distance;
       [tunnel = 'no'] {
         text-halo-radius: @standard-halo-radius;
         [highway = 'motorway'] { text-halo-fill: @motorway-fill; }
@@ -2865,6 +2869,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @secondary-fill;
+      text-repeat-distance: @major-highways-text-repeat-distance;
     }
     [zoom >= 14] {
       text-size: 9;
@@ -2891,6 +2896,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @tertiary-fill;
+      text-repeat-distance: @major-highways-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2909,6 +2915,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-face-name: @book-fonts;
+    text-repeat-distance: @major-highways-text-repeat-distance;
 
     [zoom >= 17] {
       text-size: 11;
@@ -2935,6 +2942,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @residential-fill;
       text-face-name: @book-fonts;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -2964,6 +2972,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'raceway'] { text-halo-fill: @raceway-fill; }
       [highway = 'service'] { text-halo-fill: @service-fill; }
       text-face-name: @book-fonts;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2985,6 +2994,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'living_street'] { text-halo-fill: @living-street-fill; }
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3024,6 +3034,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 5;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3052,6 +3063,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 7;
+      text-repeat-distance: @minor-highways-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;

--- a/roads.mss
+++ b/roads.mss
@@ -286,8 +286,8 @@
 @shield-font: @book-fonts;
 @shield-clip: false;
 
-@major-highways-text-repeat-distance: 500;
-@minor-highways-text-repeat-distance: 100;
+@major-highway-text-repeat-distance: 500;
+@minor-highway-text-repeat-distance: 100;
 
 @railway-text-repeat-distance: 200;
 
@@ -2818,7 +2818,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
+      text-repeat-distance: @minor-highway-text-repeat-distance;
     }
   }
 }
@@ -2838,7 +2838,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-face-name: @book-fonts;
-      text-repeat-distance: @major-highways-text-repeat-distance;
+      text-repeat-distance: @major-highway-text-repeat-distance;
       [tunnel = 'no'] {
         text-halo-radius: @standard-halo-radius;
         [highway = 'motorway'] { text-halo-fill: @motorway-fill; }
@@ -2871,7 +2871,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @secondary-fill;
-      text-repeat-distance: @major-highways-text-repeat-distance;
+      text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 14] {
       text-size: 9;
@@ -2898,7 +2898,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @tertiary-fill;
-      text-repeat-distance: @major-highways-text-repeat-distance;
+      text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2917,7 +2917,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-face-name: @book-fonts;
-    text-repeat-distance: @major-highways-text-repeat-distance;
+    text-repeat-distance: @major-highway-text-repeat-distance;
 
     [zoom >= 17] {
       text-size: 11;
@@ -2944,8 +2944,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @residential-fill;
       text-face-name: @book-fonts;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
-      [highway = 'unclassified'] { text-repeat-distance: @major-highways-text-repeat-distance;}
+      text-repeat-distance: @minor-highway-text-repeat-distance;
+      [highway = 'unclassified'] { text-repeat-distance: @major-highway-text-repeat-distance;}
     }
     [zoom >= 16] {
       text-size: 9;
@@ -2975,7 +2975,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [highway = 'raceway'] { text-halo-fill: @raceway-fill; }
       [highway = 'service'] { text-halo-fill: @service-fill; }
       text-face-name: @book-fonts;
-      text-repeat-distance: @major-highways-text-repeat-distance;
+      text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 17] {
       text-size: 11;
@@ -2994,10 +2994,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-halo-radius: @standard-halo-radius;
-      [highway = 'living_street'] { text-halo-fill: @living-street-fill; text-repeat-distance: @major-highways-text-repeat-distance;}
+      [highway = 'living_street'] { text-halo-fill: @living-street-fill; text-repeat-distance: @major-highway-text-repeat-distance;}
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
-      text-repeat-distance: @minor-highways-text-repeat-distance;
+      text-repeat-distance: @minor-highway-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3037,7 +3037,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 5;
-      text-repeat-distance: @major-highways-text-repeat-distance;
+      text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
@@ -3066,8 +3066,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 7;
-      text-repeat-distance: @major-highways-text-repeat-distance;
-      [highway = 'steps'] { text-repeat-distance: @minor-highways-text-repeat-distance; }
+      text-repeat-distance: @major-highway-text-repeat-distance;
+      [highway = 'steps'] { text-repeat-distance: @minor-highway-text-repeat-distance; }
     }
     [zoom >= 17] {
       text-size: 11;

--- a/roads.mss
+++ b/roads.mss
@@ -2994,7 +2994,10 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-clip: false;
       text-placement: line;
       text-halo-radius: @standard-halo-radius;
-      [highway = 'living_street'] { text-halo-fill: @living-street-fill; text-repeat-distance: @major-highway-text-repeat-distance;}
+      [highway = 'living_street'] { 
+        text-halo-fill: @living-street-fill;
+        text-repeat-distance: @major-highway-text-repeat-distance;
+      }
       [highway = 'pedestrian'] { text-halo-fill: @pedestrian-fill; }
       text-face-name: @book-fonts;
       text-repeat-distance: @minor-highway-text-repeat-distance;


### PR DESCRIPTION
This PR adds `text-repeat-distance` for highways, which currently unnecessarily clutter the map on dense areas. It uses a smaller value of 50 for `highway=unclassified` and lower-importance highways, and 200 for higher-importance highways. This also achieves the split of #3295 in smaller PR as requested by @kocio-pl, and consequently closes #3111.

Before/after examples:
![66666216877235_old_highway](https://user-images.githubusercontent.com/13777824/43082279-fd983fc8-8e93-11e8-9db8-20b221b62f40.png)
![66666216877235_new_highway](https://user-images.githubusercontent.com/13777824/43082277-fd7cbe2e-8e93-11e8-9170-cafb7f0382e1.png)
https://www.openstreetmap.org/#map=17/48.66397/6.17061

![68452214932439_old_highway](https://user-images.githubusercontent.com/13777824/43082281-fdda7082-8e93-11e8-8778-e034cdd46883.png)
![68452214932439_new_highway](https://user-images.githubusercontent.com/13777824/43082280-fdc155fc-8e93-11e8-92f2-552106ad8fbd.png)
https://www.openstreetmap.org/#map=17/48.68110/6.14494

![70195095380471_old_highway](https://user-images.githubusercontent.com/13777824/43082285-fe0ba6c0-8e93-11e8-9b4b-3317cff35dba.png)
![70195095380471_new_highway](https://user-images.githubusercontent.com/13777824/43082283-fdf46762-8e93-11e8-9f89-32876977c76d.png)
https://www.openstreetmap.org/#map=17/48.69825/6.18554

![197890463702336_old_highway](https://user-images.githubusercontent.com/13777824/43082287-fe3ee21a-8e93-11e8-9feb-3c82281926bc.png)
![197890463702336_new_highway](https://user-images.githubusercontent.com/13777824/43082286-fe24e19e-8e93-11e8-8147-e6ea74c6c78d.png)
https://www.openstreetmap.org/#map=16/48.1898/6.4266

Edit: added links to test locations.