### PR TITLE
Standard text halo for fitness_centre and fitness_station

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2160,9 +2160,10 @@
       [feature = 'leisure_stadium'] {
         text-fill: darken(@stadium, 70%);
       }
-      [feature = 'leisure_dog_park'],
       [feature = 'leisure_fitness_centre'],
-      [feature = 'leisure_fitness_station'],
+      [feature = 'leisure_fitness_station'] {
+        text-fill: @leisure-green;
+      }
       [feature = 'leisure_dog_park'] {
         text-fill: @leisure-green;
         text-halo-radius: @standard-halo-radius * 1.5; /* Extra halo needed to stand out from paw pattern. */


### PR DESCRIPTION
`leisure=fitness_centre` and `leisure=fitness_station` have a larger than standard text halo. The screenshot posted for the recent bowling icons looked odd to me (comparing the bowling text to the fitness text):

![fitness_bowling](https://user-images.githubusercontent.com/14190496/43237992-1f751acc-9041-11e8-9a26-8c02e85d5a71.png)

It turns out that a larger halo was added to dog park text to make it more visible over the paw pattern. fitness_centre and fitness_station matched the same CSS block. This PR splits dog_park from fitness_centre and fitness_station like so:

```
        [feature = 'leisure_fitness_centre'],
        [feature = 'leisure_fitness_station'] {
          text-fill: @leisure-green;
        }
        [feature = 'leisure_dog_park'] {
          text-fill: @leisure-green;
          text-halo-radius: @standard-halo-radius * 1.5; /* Extra halo needed to stand out from paw pattern. */
          text-halo-fill: @standard-halo-fill;
        }
```

Before
https://www.openstreetmap.org/#map=18/45.70804/-122.70853
![fitness_before](https://user-images.githubusercontent.com/14190496/43238164-e1e7665a-9041-11e8-9fe9-e46e55094fc1.png)

After
![fitness_after](https://user-images.githubusercontent.com/14190496/43238180-f2858776-9041-11e8-8b43-d82098a7a4c6.png)

Before
https://www.openstreetmap.org/#map=18/47.66518/-122.12174
![fitness_station_before](https://user-images.githubusercontent.com/14190496/43238197-0847e324-9042-11e8-8595-08904ff887c6.png)

After
![fitness_station_after](https://user-images.githubusercontent.com/14190496/43238199-0c08bb46-9042-11e8-9801-92dbeaa84714.png)
