### PR TITLE
Changing farmland and societal amenities colors

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -20,8 +20,8 @@
 @commercial-line: #d1b2b0;  // Lch(75,12,25)
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line)
-@farmland: #fbecd7;         // Lch(94,12,80)
-@farmland-line: #d6c4ab;    // Lch(80,15,80)
+@farmland: #eef0d5;         // Lch(94,14,112)
+@farmland-line: #c7c9ae;    // Lch(80,14,112)
 @farmyard: #f5dcba;         // Lch(89,20,80)
 @farmyard-line: #d1b48c;    // Lch(75,25,80)
 
@@ -51,7 +51,7 @@
 @power: darken(@industrial, 5%);
 @power-line: darken(@industrial-line, 5%);
 @sand: #f5e9c6;
-@societal_amenities: #f0f0d8;
+@societal_amenities: #fbecd7;   // Lch(94,12,80)
 @tourism: #734a08;
 @quarry: #c5c3c3;
 @military: #f55;


### PR DESCRIPTION
Closes #2821

Changes proposed in this pull request:
- Changing the colors of farmland and societal amenities taken from @imagico fork (https://github.com/imagico/osm-carto-alternative-colors, changes described in details in http://blog.imagico.de/more-new-colors/ )

In short, this makes basically a color swap between farmland and societal amenities, in effect:
- farmlands are greenish, which is coherent with other vegetation areas
- farmlands are lighter, which is better than going back to dark, since they tend to be quite big
- societal amenities are reddish, which is more coherent with some other landuses 
- societal amenities are darker, which makes them easier to spot, since they tend to be not too big and eclipsed with some other landcovers (like grass for example)

Farmland color comparison between different forks:
![ac_farmland](https://user-images.githubusercontent.com/5439713/43654014-26ef3aca-974a-11e8-99de-799c325e0be4.png)


Test rendering with links to the example places (click images to see the full scale):

[Poland](https://www.openstreetmap.org/#map=8/52.736/19.355)

Before
![uotnvcnv](https://user-images.githubusercontent.com/5439713/43653409-42a52286-9748-11e8-882c-99d81f1a238e.png)

After
![kn8gjoy](https://user-images.githubusercontent.com/5439713/43653412-4478886e-9748-11e8-9f5c-90ae6b330420.png)


[Comparison with some other green areas](https://www.openstreetmap.org/#map=15/52.1051/21.2017)

Before
![k kwnwdp](https://user-images.githubusercontent.com/5439713/43653518-9aa5e4a2-9748-11e8-8336-433f941939b7.png)

After
![ldzsnmnp](https://user-images.githubusercontent.com/5439713/43653513-9796bc96-9748-11e8-933e-f00da0391c3f.png)


[Color change for schools and hospitals](https://www.openstreetmap.org/#map=16/52.2863/20.9559)

Before
![rlibezwh](https://user-images.githubusercontent.com/5439713/43653641-f5283dc6-9748-11e8-8908-b5ee8d554973.png)

After
![5kur7zui](https://user-images.githubusercontent.com/5439713/43653668-04b226da-9749-11e8-80a3-481bf8c38a0b.png)

[Color switch between social facility and farmlands ](https://www.openstreetmap.org/#map=16/52.2989/20.8403)

Before
![vupsxxit](https://user-images.githubusercontent.com/5439713/43653793-6fceb6ae-9749-11e8-8dba-eb811e2b8580.png)

After
![yxiys3ro](https://user-images.githubusercontent.com/5439713/43653788-69f14e2c-9749-11e8-8656-810b586acd28.png)