### PR TITLE
Water slide

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2901,6 +2901,26 @@
     marker-file: url('symbols/transport_slipway.p.20.svg');
     marker-fill: @transportation-icon;
   }
+
+  [feature = 'attraction_water_slide'] {
+    [zoom >= 16] {
+      [zoom >= 17] {
+        bridgecasing/line-color: black;
+        bridgecasing/line-join: round;
+        bridgecasing/line-smooth: 1;
+        bridgecasing/line-width: 1.25;
+        [zoom >= 18] { bridgecasing/line-width: 2.5; }
+        [zoom >= 19] { bridgecasing/line-width: 5; }
+      }
+      line-color: @pitch;
+      line-join: round;
+      line-cap: round;
+      line-smooth: 1;
+      line-width: 1;
+      [zoom >= 18] { line-width: 2; }
+      [zoom >= 19] { line-width: 4; }
+    }
+  }
 }
 
 #trees [zoom >= 16] {

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2919,6 +2919,19 @@
       line-width: 1;
       [zoom >= 18] { line-width: 2; }
       [zoom >= 19] { line-width: 4; }
+
+      [zoom >= 19] {
+        text-name: "[name]";
+        text-size: 10;
+        text-face-name: @oblique-fonts;
+        text-fill: darken(@pitch, 40%);
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: @standard-halo-fill;
+        text-placement: line;
+        text-vertical-alignment: middle;
+        text-repeat-distance: @waterway-text-repeat-distance;
+        text-dy: 8;
+      }
     }
   }
 }

--- a/project.mml
+++ b/project.mml
@@ -1563,14 +1563,17 @@ Layer:
       table: |-
         (SELECT
           way,
+          name,
           COALESCE(
            'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' ELSE NULL END,
-           'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure ELSE NULL END
+           'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure ELSE NULL END,
+           'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' ELSE NULL END
             ) AS feature
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
           WHERE tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
             OR leisure IN ('slipway')
+            OR tags @> 'attraction=>water_slide'
         ) AS amenity_line
     properties:
       minzoom: 16


### PR DESCRIPTION
Fixes #3335 

Changes proposed in this pull request:
- Render attraction=water_slide similar to a (water) stream
- Render a marker for water slide
- Render the name of the water slide

This is more a proof of goodwill, probably both the rendering and the code have to be further improved, as I'm a complete newbie to this.
In particular, the marker is hidden unter the slide, how can I fix that?  However, I'm not so sure the marker makes sense, anyway.


Test rendering with links to the example places:
https://www.openstreetmap.org/way/353735844

Before
![waterslide_before](https://user-images.githubusercontent.com/3518185/44153441-8fffcd56-a0a8-11e8-8ac4-8081b2b7d263.png)


After
![waterslide19](https://user-images.githubusercontent.com/3518185/44153330-44a8f468-a0a8-11e8-8236-f4c787869eb4.png)
![waterslide18](https://user-images.githubusercontent.com/3518185/44153336-4a9195c4-a0a8-11e8-8f45-9f305bd5e4d0.png)
![waterslide17](https://user-images.githubusercontent.com/3518185/44153342-4cb95008-a0a8-11e8-948e-8427a8e8e8d5.png)
![waterslide16](https://user-images.githubusercontent.com/3518185/44153346-4edf6188-a0a8-11e8-958b-45c405741478.png)
![waterslide15](https://user-images.githubusercontent.com/3518185/44153348-50e85566-a0a8-11e8-8958-375314815464.png)

