### PR TITLE
Moving manors to higher zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -803,9 +803,10 @@
     marker-clip: false;
   }
 
-  [feature = 'historic_castle'][castle_type != 'stately'][zoom >= 15],
+  [feature = 'historic_castle'][castle_type != 'stately'][castle_type != 'manor'][zoom >= 15],
   [feature = 'historic_castle'][castle_type = 'stately'][zoom >= 16],
-  [feature = 'historic_manor'][zoom >= 15] {
+  [feature = 'historic_castle'][castle_type = 'manor'][zoom >= 16],
+  [feature = 'historic_manor'][zoom >= 16] {
     marker-file: url('symbols/historic/castle.svg');
     marker-fill: @memorials;
     marker-placement: interior;


### PR DESCRIPTION
Fixes #3325

Changes proposed in this pull request:
- Moving manors icon rendering to higher zoom level without touching any other castles

[Poznań at z15](https://www.openstreetmap.org/#map=15/52.4074/16.9290)

Before
![ckgh dl8](https://user-images.githubusercontent.com/5439713/44306090-cc66c600-a387-11e8-9ebe-385e294f69af.png)

After
![tgbavxzg](https://user-images.githubusercontent.com/5439713/44306070-72fe9700-a387-11e8-82a4-92b175310127.png)
