### PR TITLE
WIP: Indoor rendering

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2864,6 +2864,24 @@
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;
   }
+
+  [feature = 'indoor_corridor'][zoom >= 18][way_area >= 150],
+  [feature = 'indoor_room'][zoom >= 18][way_area >= 150],
+  [feature = 'indoor_area'][zoom >= 18][way_area >= 150],
+  [feature = 'indoor_corridor'][zoom >= 19][way_area >= 50],
+  [feature = 'indoor_room'][zoom >= 19][way_area >= 50],
+  [feature = 'indoor_area'][zoom >= 19][way_area >= 50] {
+    text-name: "[name]";
+    text-size: 9;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: @indoor-text;
+    text-dy: 0;
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+  }
 }
 
 #amenity-line {

--- a/buildings.mss
+++ b/buildings.mss
@@ -5,6 +5,8 @@
 @building-major-fill: darken(@building-fill, 20%);
 @building-major-line: darken(@building-major-fill, 25%);
 
+@indoor-text: darken(@building-fill, 40%);
+
 @entrance-permissive: darken(@building-line, 15%);
 @entrance-normal: @building-line;
 
@@ -35,6 +37,30 @@
         line-clip: false;
         line-color: @building-major-line;
       }
+    }
+  }
+}
+
+#indoor-areas {
+  [zoom >= 17] {
+    [indoor = 'room'] {
+      polygon-fill: lighten(@building-fill, 3%);
+      polygon-clip: false;
+      line-width: 0.5;
+      line-clip: false;
+      line-color: @building-line;
+    }
+    [indoor = 'corridor'] {
+      polygon-fill: lighten(@building-fill, 6%);
+      polygon-clip: false;
+      line-width: 0.5;
+      line-clip: false;
+      line-color: @building-line;
+    }
+    [indoor = 'area'] {
+      line-width: 0.5;
+      line-clip: false;
+      line-color: @building-line;
     }
   }
 }

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -15,6 +15,7 @@ local polygon_keys = {
     'building:part',
     'harbour',
     'historic',
+    'indoor',
     'landuse',
     'leisure',
     'man_made',

--- a/project.mml
+++ b/project.mml
@@ -465,6 +465,25 @@ Layer:
         AS buildings_major
     properties:
       minzoom: 13
+  - id: indoor-areas
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            tags->'level' AS level,
+            tags->'indoor' AS indoor 
+          FROM planet_osm_polygon
+          WHERE tags->'indoor' IN ('corridor', 'room', 'area')
+            AND (tags->'level' IS NULL OR tags->'level' = '0')
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          ORDER BY COALESCE(layer,0), way_area DESC)
+        AS indoor_areas
+    properties:
+      minzoom: 17
   - id: tunnels
     class: access
     geometry: linestring
@@ -1519,6 +1538,7 @@ Layer:
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
             tags->'information' as information,
+
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1961,6 +1981,7 @@ Layer:
             name
           FROM planet_osm_line
           WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')
+            OR (highway IN ('corridor') AND (tags->'level' = '0' OR tags->'level' IS NULL))
             AND name IS NOT NULL
         ) AS paths_text_name
     properties:
@@ -2086,6 +2107,7 @@ Layer:
               'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
               'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
               'waterway_' || CASE WHEN waterway IN ('dam', 'dock') THEN waterway ELSE NULL END,
+              'indoor_' || CASE WHEN tags->'indoor' IN ('corridor', 'room', 'area') THEN tags->'indoor' ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END
             ) AS feature,
             access,
@@ -2113,6 +2135,8 @@ Layer:
             tags->'recycling_type' as recycling_type,
             tags->'castle_type' as castle_type,
             tags->'information' as information,
+            tags->'indoor' as indoor,
+            tags->'level' as level,
             ref,
             way_area,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
@@ -2134,6 +2158,7 @@ Layer:
               OR military IN ('danger_area', 'bunker')
               OR historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
               OR tags->'memorial' IN ('plaque')
+              OR (tags->'indoor' IN ('corridor', 'room', 'area') AND (tags->'level' = '0' OR tags->'level' IS NULL))
               OR highway IN ('services', 'rest_area', 'bus_stop', 'elevator')
               OR power IN ('plant', 'station', 'generator', 'sub_station', 'substation')
               OR boundary IN ('national_park')

--- a/roads.mss
+++ b/roads.mss
@@ -3060,6 +3060,20 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-dy: 9;
     }
   }
+
+  [highway = 'corridor'] {
+    [zoom >= 18] {
+      text-name: "[name]";
+      text-size: 9;
+      text-face-name: @book-fonts;
+      text-fill: @indoor-text;  
+      text-spacing: 300;
+      text-clip: false;
+      text-placement: line;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+    }
+  }
 }
 
 .directions::directions {


### PR DESCRIPTION
First off, this is not a (completely) serious PR. This is just me messing around and I got some cool results that I decided to share. 

The first obvious issue with indoor rendering is that there is no way select different floors. I solved this by only displaying the main floor, e.g. `tags->'level' IS NULL OR tags->'level' = '0'`.

The results:

https://www.openstreetmap.org/#map=17/45.52838/-122.66303
![orconv_17](https://user-images.githubusercontent.com/14190496/44630027-72787a00-a90c-11e8-8ff6-1ad728703158.png)
![orconv_18](https://user-images.githubusercontent.com/14190496/44630028-76a49780-a90c-11e8-94b0-2e93ad9ca199.png)

https://www.openstreetmap.org/#map=18/45.62839/-122.66863
![library_17](https://user-images.githubusercontent.com/14190496/44630036-a784cc80-a90c-11e8-8450-99ca8e48283e.png)
![library_18](https://user-images.githubusercontent.com/14190496/44630037-a8b5f980-a90c-11e8-94a6-7d9d7cc7c22c.png)
![library_19](https://user-images.githubusercontent.com/14190496/44630038-aa7fbd00-a90c-11e8-80d9-58c0ffb06414.png)
And zoom 20, just for fun.
![library_20](https://user-images.githubusercontent.com/14190496/44630041-ace21700-a90c-11e8-9437-9f732e6c0ae5.png)

Lost the link to this one (somewhere in Taiwan):
![taiwan_17](https://user-images.githubusercontent.com/14190496/44630083-32fe5d80-a90d-11e8-8e24-3c05d46a8a35.png)
![taiwan_18](https://user-images.githubusercontent.com/14190496/44630086-398cd500-a90d-11e8-8554-65f4011194c3.png)
![taiwan_19](https://user-images.githubusercontent.com/14190496/44630087-3abe0200-a90d-11e8-925c-e443edca7ff8.png)


Here's what I learned:

### Pros

- The results were surprisingly good. It almost seems useful.
- Something like this would encourage proper indoor tagging instead of tagging rooms as separate buildings and corridors are pedestrian areas (this happens a lot).
- Currently, properly tagged indoor areas look terrible in this style, all POIs from all floors are collapsed and displayed on the same layer. Merely filtering them is an improvement. For example, this is actually a very neatly mapped mall (with three levels of POIs ):
![current_indoor](https://user-images.githubusercontent.com/14190496/44629981-d9496380-a90b-11e8-8dff-ebf33249565f.png)
Same mall (try to imagine with only POIs from one level):
![westfield](https://user-images.githubusercontent.com/14190496/44630541-2df0dc80-a914-11e8-982a-a8da0ff957ca.png)

### Cons

- Bad user interface (people will be searching for the floor selector widget, but will never be able to find it).
- The major building color is way too dark and it looks terrible with this rendering. (although POIs in major buildings already look terrible IMO):
![major_pois](https://user-images.githubusercontent.com/14190496/44629932-31cc3100-a90b-11e8-87d7-67bede41b4e5.png)
- This does not parse the level tag properly (it should support values like `0-3`, `0;2;3`).
- There are some notable examples where the "main" floor is not `level=0`.
    - The tagging scheme is currently missing a way to identify the "default" floor. It would be nice if that was contained entirely in the `level` tag as big nasty relations are both hard to map and hard to query.

This is a 50% solution. The question I'm trying to push is this: could something like this work as a starting point to build up to a 100% solution, or do we hold out for the 100% solution.