### PR TITLE
Moving amenity=atm to z19+

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -56,7 +56,7 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_atm'][zoom >= 17] {
+  [feature = 'amenity_atm'][zoom >= 19] {
     marker-file: url('symbols/amenity/atm.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;
@@ -2277,7 +2277,7 @@
     }
   }
 
-  [feature = 'amenity_atm'][zoom >= 17] {
+  [feature = 'amenity_atm'][zoom >= 19] {
     text-name: "[operator]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;


### PR DESCRIPTION
Changes proposed in this pull request:
- Render amenity=atm on z19+ instead of z17+

ATMs are small facilities which make clutter on the map on z17 and z18 when located near some other POIs, which is common case in cities. ATM is smaller than bank, where it can be usually placed, so it should be rendered later, and since their size is smaller than all the shops, I think they should be rendered from z19.

Just two examples out of many:

[Bank is eclipsed by ATM at z17:](https://www.openstreetmap.org/#map=17/52.27057/20.97482)
Before
![ht3d59_z](https://user-images.githubusercontent.com/5439713/44880878-0734fc00-acae-11e8-914d-12c2d049fd4b.png)

After
![pay1at_a](https://user-images.githubusercontent.com/5439713/44880885-0bf9b000-acae-11e8-939d-288b155d2168.png)

[ATM eclipsing label of a bigger amenity at z18:](https://www.openstreetmap.org/#map=18/52.23101/21.01254)
Before
![iuttcv0](https://user-images.githubusercontent.com/5439713/44880102-be7c4380-acab-11e8-9aac-ca6cc8e93784.png)

After
![ru1sfhmv](https://user-images.githubusercontent.com/5439713/44880104-c20fca80-acab-11e8-86d1-ebd0de7f206a.png)
