### PR TITLE
Order amenity_lines by layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1564,6 +1564,7 @@ Layer:
         (SELECT
           way,
           name,
+          layer,
           COALESCE(
            'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' ELSE NULL END,
            'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure ELSE NULL END,
@@ -1574,6 +1575,7 @@ Layer:
           WHERE tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
             OR leisure IN ('slipway')
             OR tags @> 'attraction=>water_slide'
+          ORDER BY COALESCE(layer,0)
         ) AS amenity_line
     properties:
       minzoom: 16


### PR DESCRIPTION
This way, we respect the layer tag for water slides, and it should not harm for fords.

Fixes #3413 

Changes proposed in this pull request:
Order amenity_lines by layer

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=19/48.51073/9.03904

Before
![screenshot_20180929_145854](https://user-images.githubusercontent.com/3518185/46246090-a574c880-c3f8-11e8-9626-13e32b7128d1.png)

After
![screenshot_20180929_145912](https://user-images.githubusercontent.com/3518185/46246091-a7d72280-c3f8-11e8-9336-254a2a6b222b.png)
