### PR TITLE
Added 3D buildings using Mapnik building symbolizers.

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -9,33 +9,21 @@
 @entrance-normal: @building-line;
 
 #buildings {
-  [zoom >= 13] {
-    polygon-fill: @building-low-zoom;
-    polygon-clip: false;
-    [zoom >= 15] {
-      line-color: @building-line;
-      polygon-fill: @building-fill;
-      line-width: .75;
-      line-clip: false;
-    }
-  }
-}
-
-#buildings-major {
-  [zoom >= 13] {
+  [zoom >= 15] {
+    building-fill: @building-fill;
     [aeroway = 'terminal'],
     [amenity = 'place_of_worship'],
     [building = 'train_station'],
     [aerialway = 'station'],
     [public_transport = 'station'] {
-      polygon-fill: @building-major-fill;
-      polygon-clip: false;
-      [zoom >= 15] {
-        line-width: .75;
-        line-clip: false;
-        line-color: @building-major-line;
-      }
+      building-fill: @building-major-fill;
     }
+    building-fill-opacity: 1.0;
+    building-height: "4.0*[levels]";
+    [height != null] {
+      building-height: "[height]";
+    }
+    opacity: 0.6;
   }
 }
 

--- a/landcover.mss
+++ b/landcover.mss
@@ -216,17 +216,6 @@
     }
   }
 
-  [feature = 'amenity_place_of_worship'][zoom >= 13],
-  [feature = 'landuse_religious'][zoom >= 13] {
-    polygon-fill: @place_of_worship;
-    polygon-clip: false;
-    [zoom >= 15] {
-      line-color: @place_of_worship_outline;
-      line-width: 0.3;
-      line-clip: false;
-    }
-  }
-
   [feature = 'amenity_prison'][zoom >= 10][way_pixels > 75] {
     polygon-pattern-file: url('symbols/grey_vertical_hatch.png');
     polygon-pattern-alignment: global;

--- a/project.mml
+++ b/project.mml
@@ -417,54 +417,6 @@ Layer:
         ) AS bridge
     properties:
       minzoom: 12
-  - id: buildings
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            building
-          FROM planet_osm_polygon
-          WHERE building IS NOT NULL
-            AND building != 'no'
-            AND (aeroway IS NULL OR aeroway != 'terminal')
-            AND (amenity IS NULL OR amenity != 'place_of_worship')
-            AND building != 'train_station'
-            AND (aerialway IS NULL OR aerialway != 'station')
-            AND ((tags->'public_transport') IS NULL OR tags->'public_transport' != 'station')
-            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          ORDER BY COALESCE(layer,0), way_area DESC
-        ) AS buildings
-    properties:
-      minzoom: 13
-  - id: buildings-major
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            building,
-            amenity,
-            aeroway,
-            aerialway,
-            tags->'public_transport' as public_transport
-          FROM planet_osm_polygon
-          WHERE building IS NOT NULL
-            AND building != 'no'
-            AND (aeroway = 'terminal'
-                 OR amenity = 'place_of_worship'
-                 OR building = 'train_station'
-                 OR aerialway = 'station'
-                 OR tags->'public_transport' = 'station')
-            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          ORDER BY COALESCE(layer,0), way_area DESC)
-        AS buildings_major
-    properties:
-      minzoom: 13
   - id: tunnels
     class: access
     geometry: linestring
@@ -1124,6 +1076,35 @@ Layer:
         ) AS guideways
     properties:
       minzoom: 11
+  - id: buildings
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            building,
+            amenity,
+            aeroway,
+            aerialway,
+            tags->'public_transport' as public_transport,
+            CASE
+              WHEN tags->'building:height' ~ '^\d{1,3}(\.\d+)?( ?m)?$' THEN (SUBSTRING(tags->'building:height', '^(\d{1,3}(\.\d+)?)( ?m)?$'))::NUMERIC
+              ELSE NULL
+            END AS height,
+            CASE
+              WHEN tags->'building:levels' ~ '^\d{1,2}(\.\d+)?$' THEN (tags->'building:levels')::NUMERIC
+              ELSE 1
+            END AS levels
+          FROM planet_osm_polygon
+          WHERE building IS NOT NULL
+            AND building != 'no'
+            AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          ORDER BY ST_YMax(way) DESC
+        ) AS buildings
+    properties:
+      minzoom: 15
   - id: entrances
     geometry: point
     <<: *extents


### PR DESCRIPTION
Implementation of #3425.

Buldings (3D and semi-transparent) are rendered _above_road features and land uses. This has a benefit of making land uses visible in dense urban areas. Also railway stations are now displayed correctly (not obsured by platforms and other internal objects, whilst making them still visible).

Building height are calculated using building:levels (defaults to 1) and building:height (in metres). Building:height has priority over building:levels.

There are some z-order issues due to Mapnik limitations. Hopefully will be fixed in future versions of Mapnik https://github.com/mapnik/mapnik/pull/3969.

Will probably not support complex building designs like [this one](https://www.openstreetmap.org/#map=19/31.24168/121.49560).

I've deferred rendering buildings to z15+, mostly for code simplicity, but then realized that looks better/more readable. Alternatively, we could use flat buildings at z13-14 or reduce opacity.
