### PR TITLE
Render capacity next to bicycle_rental and parking markers.

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -96,6 +96,19 @@
     marker-fill: @transportation-icon;
     marker-placement: interior;
     marker-clip: false;
+    [zoom >= 18] {
+      text-name: "[capacity]";
+      text-size: @standard-font-size;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
+      text-fill: @transportation-text;
+      text-dy: -0.5;
+      text-dx: 8;
+      text-face-name: @standard-font;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
   }
 
   [feature = 'highway_bus_stop'] {
@@ -1468,8 +1481,25 @@
     marker-placement: interior;
     marker-clip: false;
     marker-fill: @transportation-icon;
+    [zoom >= 18] {
+      text-name: "[capacity]";
+      text-size: @standard-font-size;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
+      text-fill: @transportation-text;
+      text-dy: -0.5;
+      text-dx: 8;
+      text-face-name: @standard-font;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
+      [zoom >= 18] {
+        text-opacity: 0.33;
+        text-halo-radius: 0;
+      }
     }
   }
 

--- a/project.mml
+++ b/project.mml
@@ -1520,6 +1520,7 @@ Layer:
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
             tags->'information' as information,
+            tags->'capacity' as capacity,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'bookmaker', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -1660,6 +1661,7 @@ Layer:
             tags->'tower:type' as "tower:type",
             tags->'castle_type' as castle_type,
             tags->'information' as information,
+            tags->'capacity' as capacity,
             CASE WHEN shop IN ('supermarket', 'bag', 'bakery', 'beauty', 'bed', 'bookmaker', 'books', 'butcher', 'clothes', 'computer',
                                'confectionery', 'fashion', 'convenience', 'department_store', 'doityourself', 'hardware', 'fishmonger', 'florist',
                                'garden_centre', 'hairdresser', 'hifi', 'ice_cream', 'car', 'car_repair', 'bicycle', 'mall', 'pet',
@@ -2498,6 +2500,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log') THEN barrier ELSE NULL END
             )  AS feature,
+            tags->'capacity' AS capacity,
             access,
             CASE WHEN amenity IN ('waste_basket', 'waste_disposal') THEN 2 ELSE 1 END AS prio
           FROM planet_osm_point p
@@ -2524,6 +2527,7 @@ Layer:
               'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log') THEN barrier ELSE NULL END
             )  AS feature,
+            tags->'capacity' AS capacity,
             access
           FROM planet_osm_polygon p
           WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')


### PR DESCRIPTION
Add 'capacity' tag to amenity-points-poly, amenity-points,
amenity-low-priority and amenity-low-priority-poly layers.

Render capacity text as a superscript to (up and to the right of) the
markers of amenity=bicycle_rental, parking, bicycle_parking and
motorcycle_parking at z>=18.

Fixes #3428.

Test rendering from a mall with several bicycle parkings, underground car park and a citybike station [here](https://www.openstreetmap.org/#map=18/60.15993/24.88132) (My test dataset is ~1 year old, so the positions have changed somewhat).

z=18:
![lauttis_z18](https://user-images.githubusercontent.com/3215/46568835-5678e700-c954-11e8-8532-e4591f1734a7.png)

z=19, showing also the name label of the citybike station:
![lauttis_z19](https://user-images.githubusercontent.com/3215/46568840-698bb700-c954-11e8-82d5-1b5f33bd13b7.png)

The capacity text is a little bit too much to the right of the bicycle_parking marker IMO, but reducing the text-dx property apparently results in an overlap which hides the label. Markers for bicycle_rental and parking look fine to me. Hints on how to fix this would be appreciated.