### PR TITLE
Fix icon for information=tactile_model

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -351,8 +351,7 @@
     [information = 'audioguide'] {
       marker-file: url('symbols/tourism/audioguide.svg');
     }    
-    [information = 'board'],
-    [information = 'tactile_model'] {
+    [information = 'board'] {
       marker-file: url('symbols/tourism/board.svg');
     }
     [information = 'guidepost'] {
@@ -363,7 +362,8 @@
       marker-fill: @amenity-brown;
     }
     [information = 'map'],
-    [information = 'tactile_map'] {
+    [information = 'tactile_map'],
+    [information = 'tactile_model'] {
       marker-file: url('symbols/tourism/map.svg');
     }
     [information = 'terminal'] {


### PR DESCRIPTION
Changes proposed in this pull request:
Replace board icon by map icon for `information=tactile_model ` following [comment](https://github.com/gravitystorm/openstreetmap-carto/pull/3246#issuecomment-427578416) of  @Tomasz-W from #3246

Test rendering with links to the example places:
https://www.openstreetmap.org/node/4362875819 (the land of gift shops)

Before
![tactile_model_before](https://user-images.githubusercontent.com/9897203/46581736-e5adf980-ca3d-11e8-9ce2-35ba9db7dde3.png)

After
![tactile_model_after](https://user-images.githubusercontent.com/9897203/46581737-eb0b4400-ca3d-11e8-8e44-17bfa12f9be9.png)
