### PR TITLE
Add rendering for leisure=track on lines

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2948,6 +2948,39 @@
     marker-fill: @transportation-icon;
   }
 
+  [feature = 'leisure_track'] {
+    [zoom >= 16] {
+      [zoom >= 17] {
+        bridgecasing/line-color: saturate(darken(@pitch, 30%), 20%);
+        bridgecasing/line-join: round;
+        bridgecasing/line-smooth: 1;
+        bridgecasing/line-width: 1.25;
+        [zoom >= 18] { bridgecasing/line-width: 2.5; }
+        [zoom >= 19] { bridgecasing/line-width: 5; }
+      }
+      line-color: @pitch;
+      line-join: round;
+      line-cap: round;
+      line-smooth: 1;
+      line-width: 1;
+      [zoom >= 18] { line-width: 2; }
+      [zoom >= 19] { line-width: 4; }
+
+      [zoom >= 19] {
+        text-name: "[name]";
+        text-size: 10;
+        text-face-name: @oblique-fonts;
+        text-fill: darken(@pitch, 40%);
+        text-halo-radius: @standard-halo-radius;
+        text-halo-fill: @standard-halo-fill;
+        text-placement: line;
+        text-vertical-alignment: middle;
+        text-repeat-distance: @waterway-text-repeat-distance;
+        text-dy: 8;
+      }
+    } 
+  }
+
   [feature = 'attraction_water_slide'] {
     [zoom >= 16] {
       [zoom >= 17] {

--- a/project.mml
+++ b/project.mml
@@ -1567,13 +1567,13 @@ Layer:
           layer,
           COALESCE(
            'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' ELSE NULL END,
-           'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure ELSE NULL END,
+           'leisure_' || CASE WHEN leisure IN ('slipway', 'track') THEN leisure ELSE NULL END,
            'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' ELSE NULL END
             ) AS feature
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
           WHERE tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
-            OR leisure IN ('slipway')
+            OR leisure IN ('slipway', 'track')
             OR tags @> 'attraction=>water_slide'
           ORDER BY COALESCE(layer,0)
         ) AS amenity_line


### PR DESCRIPTION
This PR adds rendering for leisure=track on lines. As it is they are currently rendered on areas but not on ways. Closes #2632 
https://www.openstreetmap.org/#map=18/39.19833/-122.02187 (location 1)
![track loction 1](https://user-images.githubusercontent.com/30259065/46655773-5ac61f80-cb61-11e8-86de-7fe66125375c.png)
https://www.openstreetmap.org/#map=18/39.14384/-121.67329 (location 2)
![track location 2](https://user-images.githubusercontent.com/30259065/46655803-6ca7c280-cb61-11e8-9ca5-23e7c70c15e7.png)
There is also some other related issues in #2632 that it potentially closes, but I wasn't sure which ones. So I can add them later. Also, the line is a little thin and tracks are usually pretty wide. So maybe it could be made wider. 