### PR TITLE
Move amenity=post_box to z19+

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -643,7 +643,7 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_post_box'][zoom >= 17] {
+  [feature = 'amenity_post_box'][zoom >= 19] {
     marker-file: url('symbols/amenity/post_box.svg');
     marker-fill: @amenity-brown;
     marker-placement: interior;

--- a/landcover.mss
+++ b/landcover.mss
@@ -28,7 +28,7 @@
 // --- Transport ----
 
 @transportation-area: #e9e7e2;
-@apron: #e9d1ff;
+@apron: #dadae0;
 @garages: #dfddce;
 @parking: #eeeeee;
 @parking-outline: saturate(darken(@parking, 40%), 20%);

--- a/landcover.mss
+++ b/landcover.mss
@@ -28,7 +28,7 @@
 // --- Transport ----
 
 @transportation-area: #e9e7e2;
-@apron: #dadae0;
+@apron: #e9d1ff;
 @garages: #dfddce;
 @parking: #eeeeee;
 @parking-outline: saturate(darken(@parking, 40%), 20%);


### PR DESCRIPTION
This PR moves post box's to z19+. There are multiple reasons why this is a good idea. A few are that they clutter things up to much and block more important icons and names at zoom levels above 19. Also, its a small feature that is not used that often, and is only important on a neighborhood or even block level most of the time. Closes #3431
![post box z17 before](https://user-images.githubusercontent.com/30259065/46662975-ac76a600-cb71-11e8-8fe3-1981b711cf0b.png)
![post box z17 after](https://user-images.githubusercontent.com/30259065/46662980-b0a2c380-cb71-11e8-9340-68798c32a302.png)
![san fransico post box](https://user-images.githubusercontent.com/30259065/46669853-74795e00-cb85-11e8-964f-1f862acd270d.png)
![san franisco post box 2](https://user-images.githubusercontent.com/30259065/46669861-79d6a880-cb85-11e8-9362-8d9f9c94e346.png)



