### PR TITLE
Showing natural areas on z5+ [WIP]

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -81,7 +81,7 @@
   ::first {
     [feature = 'wetland_mud'],
     [feature = 'wetland_tidalflat'] {
-      [zoom >= 9] {
+      [zoom >= 5] {
         polygon-fill: @mud;
         [way_pixels >= 4]  { polygon-gamma: 0.75; }
         [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -307,7 +307,7 @@
 
   [feature = 'landuse_forest'],
   [feature = 'natural_wood'] {
-    [zoom >= 8] {
+    [zoom >= 5] {
       polygon-fill: @forest;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -329,7 +329,7 @@
 
   [feature = 'landuse_farmland'],
   [feature = 'landuse_greenhouse_horticulture'] {
-    [zoom >= 8] {
+    [zoom >= 5] {
       polygon-fill: @farmland;
       [zoom >= 16] {
         line-width: .5;
@@ -340,8 +340,8 @@
     }
   }
 
-  [feature = 'natural_grassland'][zoom >= 8],
-  [feature = 'landuse_meadow'][zoom >= 8],
+  [feature = 'natural_grassland'][zoom >= 5],
+  [feature = 'landuse_meadow'][zoom >= 5],
   [feature = 'landuse_grass'][zoom >= 10],
   [feature = 'landuse_village_green'][zoom >= 10],
   [feature = 'leisure_common'][zoom >= 10] {
@@ -455,7 +455,7 @@
     }
   }
 
-  [feature = 'natural_bare_rock'][zoom >= 8] {
+  [feature = 'natural_bare_rock'][zoom >= 5] {
     polygon-fill: @bare_ground;
     polygon-pattern-file: url('symbols/rock_overlay.png');
     [way_pixels >= 4] {
@@ -470,7 +470,7 @@
 
   [feature = 'natural_scree'],
   [feature = 'natural_shingle'] {
-    [zoom >= 9] {
+    [zoom >= 5] {
       polygon-fill: @bare_ground;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -482,25 +482,25 @@
     }
   }
 
-  [feature = 'natural_sand'][zoom >= 8] {
+  [feature = 'natural_sand'][zoom >= 5] {
     polygon-fill: @sand;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'natural_heath'][zoom >= 8] {
+  [feature = 'natural_heath'][zoom >= 5] {
     polygon-fill: @heath;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'natural_scrub'][zoom >= 10] {
+  [feature = 'natural_scrub'][zoom >= 5] {
     polygon-fill: @scrub;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'wetland_swamp'][zoom >= 8] {
+  [feature = 'wetland_swamp'][zoom >= 5] {
     polygon-fill: @forest;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -669,11 +669,11 @@
 }
 
 #landcover-area-symbols {
-  [natural = 'sand'][zoom >= 8] {
+  [natural = 'sand'][zoom >= 5] {
     polygon-pattern-file: url('symbols/beach.png');
     polygon-pattern-alignment: global;
   }
-  [int_wetland != null][zoom >= 10] {
+  [int_wetland != null][zoom >= 5] {
     polygon-pattern-file: url('symbols/wetland.png');
     polygon-pattern-alignment: global;
   }

--- a/project.mml
+++ b/project.mml
@@ -103,7 +103,7 @@ Layer:
           ) AS features
         ) AS landcover_low_zoom
     properties:
-      minzoom: 7
+      minzoom: 5
       maxzoom: 9
   - id: landcover
     geometry: polygon
@@ -214,7 +214,7 @@ Layer:
       file: data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp
       type: shape
     properties:
-      minzoom: 8
+      minzoom: 5
   - id: water-areas
     geometry: polygon
     <<: *extents
@@ -269,7 +269,7 @@ Layer:
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS landcover_area_symbols
     properties:
-      minzoom: 8
+      minzoom: 5
   - id: icesheet-outlines
     geometry: linestring
     <<: *extents
@@ -277,7 +277,7 @@ Layer:
       file: data/antarctica-icesheet-outlines-3857/icesheet_outlines.shp
       type: shape
     properties:
-      minzoom: 8
+      minzoom: 5
   - id: springs
     geometry: point
     <<: *extents

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -31,13 +31,13 @@
 }
 
 #icesheet-poly {
-  [zoom >= 8] {
+  [zoom >= 5] {
     polygon-fill: @glacier;
   }
 }
 
 #icesheet-outlines {
-  [zoom >= 8] {
+  [zoom >= 5] {
     [ice_edge = 'ice_ocean'],
     [ice_edge = 'ice_land'] {
       line-width: 0.375;

--- a/water.mss
+++ b/water.mss
@@ -6,7 +6,7 @@
 
 #water-areas {
   [natural = 'glacier']::natural {
-    [zoom >= 8] {
+    [zoom >= 5] {
       line-width: 1.0;
       line-color: @glacier-line;
       polygon-fill: @glacier;


### PR DESCRIPTION
Related to #2688
Implements parts of https://github.com/gravitystorm/openstreetmap-carto/blob/master/USECASES.md

Changes proposed in this pull request:
- Start rendering natural and semi-natural areas from z5 instead of z8+. Since we have usecases for some low zoom levels, it's time to show them there. z0-z4 might need separate attention, so it's good to make gradual progress and gather some experiences on z5-z7 first. This is also good opportunity for showing glacier and icesheets in a more balanced way (effectively reverting #2970).

Examples (click on images to see the full size):

**Poland**

z5

![b61mojiq](https://user-images.githubusercontent.com/5439713/47117095-bbd9ab80-d263-11e8-9f75-0748531aefe9.png)

z6

![yj1jhpun](https://user-images.githubusercontent.com/5439713/47117101-bf6d3280-d263-11e8-8c40-b9573fc64c29.png)

z7

![yxdavqqx](https://user-images.githubusercontent.com/5439713/47117104-c2682300-d263-11e8-8350-e0a0e5b279e6.png)


**Egypt**

z5

![vr4 7d1r](https://user-images.githubusercontent.com/5439713/47117164-ecb9e080-d263-11e8-9fbc-3df06220c1a5.png)

z6

![t6dccn3i](https://user-images.githubusercontent.com/5439713/47117174-f0e5fe00-d263-11e8-8614-41dfa9629eb8.png)

z7

![dn_8susl](https://user-images.githubusercontent.com/5439713/47117179-f6dbdf00-d263-11e8-9522-ad37edd15477.png)
