### PR TITLE
Making societal amenities look like residential on medium zoom

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -567,16 +567,20 @@
   [feature = 'amenity_social_facility'],
   [feature = 'amenity_arts_centre'] {
     [zoom >= 10] {
-      polygon-fill: @residential;
-      [zoom >= 12] {
-        polygon-fill: @societal_amenities;
-        [zoom >= 13] {
-          line-width: 0.3;
-          line-color: darken(@societal_amenities, 35%);
-        }
-      }
+      polygon-fill: @built-up-lowzoom;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
+    }
+    [zoom >= 11] {
+      polygon-fill: @built-up-z11;
+    }
+    [zoom >= 12] {
+      polygon-fill: @built-up-z12;
+    }
+    [zoom >= 13] {
+      polygon-fill: @societal_amenities;
+      line-width: 0.3;
+      line-color: darken(@societal_amenities, 35%);
     }
   }
 


### PR DESCRIPTION
Fixes #3004

Changes proposed in this pull request:
- Making societal amenities (schools, hospitals etc) look like regular built up areas on z10-z12, so we avoid light patches, which are too early to be identified and just create visual noise

**Warsaw, z10**

Before

![ptumifbk](https://user-images.githubusercontent.com/5439713/47263315-7c2ef000-d4ff-11e8-9b25-7ca39c58e46c.png)

After

![xv84_epr](https://user-images.githubusercontent.com/5439713/47263307-67eaf300-d4ff-11e8-8f0b-4ffb674d3030.png)

**Warsaw, z11**

Before
![ef04rlfw](https://user-images.githubusercontent.com/5439713/47263318-881ab200-d4ff-11e8-8cd8-e58beee92b2f.png)

After
![xki7dnnl](https://user-images.githubusercontent.com/5439713/47263319-8cdf6600-d4ff-11e8-9fe2-2f7872b5fe18.png)

**Warsaw, z12**

Before

![z0dcxqic](https://user-images.githubusercontent.com/5439713/47263324-95d03780-d4ff-11e8-841c-1906d8b8d75f.png)

After

![xczib px](https://user-images.githubusercontent.com/5439713/47263321-92d54700-d4ff-11e8-933b-3276e7600598.png)
