### PR TITLE
Clean up z13

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -9,12 +9,16 @@
 @entrance-normal: @building-line;
 
 #buildings {
-  [zoom >= 15] {
-    polygon-fill: @building-fill;
+  [zoom >= 14] {
+    polygon-fill: @building-low-zoom;
     polygon-clip: false;
-    line-color: @building-line;
-    line-width: .75;
-    line-clip: false;
+    line-width: 0;
+    [zoom >= 15] {
+      polygon-fill: @building-fill;
+      line-color: @building-line;
+      line-width: .75;
+      line-clip: false;
+    }
     [amenity = 'place_of_worship'],
     [aeroway = 'terminal'],
     [aerialway = 'station'],

--- a/buildings.mss
+++ b/buildings.mss
@@ -9,16 +9,12 @@
 @entrance-normal: @building-line;
 
 #buildings {
-  [zoom >= 13] {
-    polygon-fill: @building-low-zoom;
+  [zoom >= 15] {
+    polygon-fill: @building-fill;
     polygon-clip: false;
-    line-width: 0;
-    [zoom >= 15] {
-      polygon-fill: @building-fill;
-      line-color: @building-line;
-      line-width: .75;
-      line-clip: false;
-    }
+    line-color: @building-line;
+    line-width: .75;
+    line-clip: false;
     [amenity = 'place_of_worship'],
     [aeroway = 'terminal'],
     [aerialway = 'station'],

--- a/landcover.mss
+++ b/landcover.mss
@@ -108,8 +108,10 @@
   [feature = 'leisure_playground'][zoom >= 13],
   [feature = 'leisure_fitness_station'][zoom >= 13] {
     polygon-fill: @leisure;
-    line-color: darken(@leisure, 60%);
-    line-width: 0.3;
+    [zoom >= 15] {
+      line-color: darken(@leisure, 60%);
+      line-width: 0.3;
+    }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }

--- a/project.mml
+++ b/project.mml
@@ -437,7 +437,7 @@ Layer:
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS buildings
     properties:
-      minzoom: 13
+      minzoom: 14
   - id: tunnels
     class: access
     geometry: linestring
@@ -2063,7 +2063,7 @@ Layer:
                                                   'school', 'college', 'kindergarten', 'hospital', 'ice_cream', 'pharmacy', 'doctors', 'dentist',
                                                   'atm', 'bicycle_rental', 'bureau_de_change', 'car_rental', 'car_wash', 'post_box', 'post_office',
                                                   'recycling', 'telephone', 'toilets', 'taxi', 'drinking_water', 'hunting_stand', 'internet_cafe', 'public_bookcase',
-                                                  'nightclub', 'veterinary', 'social_facility', 'vehicle_inspection', 'charging_station', 'arts_centre', 
+                                                  'nightclub', 'veterinary', 'social_facility', 'vehicle_inspection', 'charging_station', 'arts_centre',
                                                   'ferry_terminal', 'marketplace', 'shower', 'bbq', 'nursing_home', 'childcare', 'driving_school',
                                                   'casino', 'boat_rental', 'bicycle_repair_station') THEN amenity ELSE NULL END,
               'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,

--- a/roads.mss
+++ b/roads.mss
@@ -109,11 +109,9 @@
 @secondary-link-width-z13:        4;
 @tertiary-width-z13:              4;
 @residential-width-z13:           2.5;
-@service-width-z13:               0.8;
 @living-street-width-z13:         2;
-@pedestrian-width-z13:            2;
 @bridleway-width-z13:             0.3;
-@footway-width-z13:               0.7;
+@footway-width-z14:               0.7;
 @cycleway-width-z13:              0.7;
 @track-width-z13:                 0.5;
 @track-grade1-width-z13:          0.5;
@@ -556,10 +554,9 @@
     }
 
     [feature = 'highway_pedestrian'] {
-      [zoom >= 13] {
+      [zoom >= 14] {
         line-color: @pedestrian-casing;
-        line-width: @pedestrian-width-z13;
-        [zoom >= 14] { line-width: @pedestrian-width-z14; }
+        line-width: @pedestrian-width-z14;
         [zoom >= 15] { line-width: @pedestrian-width-z15; }
         [zoom >= 16] { line-width: @pedestrian-width-z16; }
         [zoom >= 17] { line-width: @pedestrian-width-z17; }
@@ -573,19 +570,20 @@
           line-dasharray: 4,2;
         }
         #bridges {
-          [zoom >= 14] {
-            line-color: @bridge-casing;
-            line-join: round;
-          }
+          line-color: @bridge-casing;
+          line-join: round;
         }
       }
     }
 
     [feature = 'highway_living_street'] {
       [zoom >= 13] {
-        line-color: @living-street-casing;
+        line-color: @residential-casing;
         line-width: @living-street-width-z13;
-        [zoom >= 14] { line-width: @living-street-width-z14; }
+        [zoom >= 14] {
+          line-color: @living-street-casing;
+          line-width: @living-street-width-z14;
+        }
         [zoom >= 15] { line-width: @living-street-width-z15; }
         [zoom >= 16] { line-width: @living-street-width-z16; }
         [zoom >= 17] { line-width: @living-street-width-z17; }
@@ -655,7 +653,7 @@
       #bridges {
         [zoom >= 14][access != 'no'],
         [zoom >= 15] {
-          line-width: @footway-width-z13 + 2 * (@paths-background-width + @paths-bridge-casing-width);
+          line-width: @footway-width-z14 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
           [zoom >= 18] { line-width: @footway-width-z18 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -667,7 +665,7 @@
       #tunnels {
         [zoom >= 14][access != 'no'],
         [zoom >= 15] {
-          line-width: @footway-width-z13 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
+          line-width: @footway-width-z14 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
           [zoom >= 18] { line-width: @footway-width-z18 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
@@ -859,7 +857,7 @@
       #bridges {
         [zoom >= 14][access != 'no'],
         [zoom >= 15] {
-          line-width: @footway-width-z13 + 2 * @paths-background-width;
+          line-width: @footway-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * @paths-background-width; }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * @paths-background-width; }
           [zoom >= 18] { line-width: @footway-width-z18 + 2 * @paths-background-width; }
@@ -869,12 +867,12 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 14][access != 'no'],
         [zoom >= 15] {
           line-color: @footway-casing;
           line-cap: round;
           line-join: round;
-          line-width: @footway-width-z13 + 2 * @paths-background-width;
+          line-width: @footway-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * @paths-background-width; }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * @paths-background-width; }
           [zoom >= 18] { line-width: @footway-width-z18 + 2 * @paths-background-width; }
@@ -1558,10 +1556,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_service'] {
-      [zoom >= 13][service = 'INT-normal'] {
-        line-width: @service-width-z13;
-        line-color: @unimportant-road;
-      }
       [zoom >= 14][service = 'INT-normal'],
       [zoom >= 16][service = 'INT-minor'] {
         line-color: @service-fill;
@@ -1602,9 +1596,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_pedestrian'] {
-      [zoom >= 13] {
-        line-width: @living-street-width-z13 - 2 * @casing-width-z13;
-        [zoom >= 14] { line-width: @pedestrian-width-z14 - 2 * @casing-width-z14; }
+      [zoom >= 14] {
+        line-width: @pedestrian-width-z14 - 2 * @casing-width-z14;
         [zoom >= 15] { line-width: @pedestrian-width-z15 - 2 * @casing-width-z15; }
         [zoom >= 16] { line-width: @pedestrian-width-z16 - 2 * @casing-width-z16; }
         [zoom >= 17] { line-width: @pedestrian-width-z17 - 2 * @casing-width-z17; }
@@ -1612,8 +1605,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 19] { line-width: @pedestrian-width-z19 - 2 * @casing-width-z19; }
         line-color: @pedestrian-fill;
         #bridges {
-          line-width: @pedestrian-width-z13 - 2 * @casing-width-z13;
-          [zoom >= 14] { line-width: @pedestrian-width-z14 - 2 * @bridge-casing-width-z14; }
+          line-width: @pedestrian-width-z14 - 2 * @bridge-casing-width-z14;
           [zoom >= 15] { line-width: @pedestrian-width-z15 - 2 * @bridge-casing-width-z15; }
           [zoom >= 16] { line-width: @pedestrian-width-z16 - 2 * @bridge-casing-width-z16; }
           [zoom >= 17] { line-width: @pedestrian-width-z17 - 2 * @bridge-casing-width-z17; }
@@ -1696,7 +1688,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
-      [zoom >= 13][access != 'no'],
+      [zoom >= 14][access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @footway-casing;
@@ -1719,7 +1711,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line/line-dasharray: 1,3;
         line/line-join: round;
         line/line-cap: round;
-        line/line-width: @footway-width-z13;
+        line/line-width: @footway-width-z14;
         [zoom >= 15][int_surface = 'paved'] {
           line/line-dasharray: 2,3.5;
           line/line-width: @footway-width-z15;
@@ -2016,7 +2008,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line-color: #6E6E6E;
         line-width: 0.75;
         [zoom >= 13] {
-          line-color: #444;
+          line-color: #8E8E8E;
         }
         [zoom >= 14] {
           line-width: 1;
@@ -2400,7 +2392,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #highway-area-casing {
   [feature = 'highway_residential'],
-  [feature = 'highway_unclassified'] {
+  [feature = 'highway_unclassified'],
+  [feature = 'highway_service'] {
     [zoom >= 14] {
       line-color: #999;
       line-width: 1;
@@ -2408,17 +2401,16 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 
   [feature = 'highway_pedestrian'],
-  [feature = 'highway_service'],
   [feature = 'highway_footway'],
   [feature = 'highway_cycleway'],
   [feature = 'highway_path'] {
-    [zoom >= 14] {
+    [zoom >= 15] {
       line-color: grey;
       line-width: 1;
     }
   }
 
-  [feature = 'highway_track'][zoom >= 14] {
+  [feature = 'highway_track'][zoom >= 15] {
     line-color: @track-fill;
     line-width: 1;
     line-dasharray: 5,4,2,4;
@@ -2454,12 +2446,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [feature = 'highway_footway'],
   [feature = 'highway_cycleway'],
   [feature = 'highway_path'] {
-    [zoom >= 14] {
+    [zoom >= 15] {
       polygon-fill: @pedestrian-fill;
     }
   }
 
-  [feature = 'highway_track'][zoom >= 14] {
+  [feature = 'highway_track'][zoom >= 15] {
     polygon-fill: #cdbea0;
   }
 

--- a/roads.mss
+++ b/roads.mss
@@ -2007,9 +2007,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 12] {
         line-color: #6E6E6E;
         line-width: 0.75;
-        [zoom >= 13] {
-          line-color: #8E8E8E;
-        }
         [zoom >= 14] {
           line-width: 1;
         }

--- a/water.mss
+++ b/water.mss
@@ -87,7 +87,7 @@
   [waterway = 'ditch'],
   [waterway = 'drain'] {
     [int_tunnel = 'no'] {
-      [zoom >= 13] {
+      [zoom >= 14] {
         line-width: 2.5;
         line-color: white;
         [waterway = 'stream'][zoom >= 15] {

--- a/water.mss
+++ b/water.mss
@@ -193,7 +193,7 @@
   [waterway = 'stream'],
   [waterway = 'ditch'],
   [waterway = 'drain'] {
-    [zoom >= 13] {
+    [zoom >= 14] {
       // the additional line of land color is used to provide a background for dashed casings
       [int_tunnel = 'yes'] {
         background/line-width: 2;
@@ -203,16 +203,14 @@
       water/line-color: @water-color;
 
       [bridge = 'yes'] {
-        [zoom >= 14] {
-          bridgecasing/line-color: black;
-          bridgecasing/line-join: round;
-          bridgecasing/line-width: 4;
-          [waterway = 'stream'][zoom >= 15] { bridgecasing/line-width: 4; }
-          bridgeglow/line-color: white;
-          bridgeglow/line-join: round;
-          bridgeglow/line-width: 3;
-          [waterway = 'stream'][zoom >= 15] { bridgeglow/line-width: 3; }
-        }
+        bridgecasing/line-color: black;
+        bridgecasing/line-join: round;
+        bridgecasing/line-width: 4;
+        [waterway = 'stream'][zoom >= 15] { bridgecasing/line-width: 4; }
+        bridgeglow/line-color: white;
+        bridgeglow/line-join: round;
+        bridgeglow/line-width: 3;
+        [waterway = 'stream'][zoom >= 15] { bridgeglow/line-width: 3; }
       }
 
       [int_intermittent = 'yes'] {

--- a/water.mss
+++ b/water.mss
@@ -87,7 +87,8 @@
   [waterway = 'ditch'],
   [waterway = 'drain'] {
     [int_tunnel = 'no'] {
-      [zoom >= 14] {
+      [int_intermittent != 'yes'][zoom >= 14],
+      [zoom >= 15] {
         line-width: 2.5;
         line-color: white;
         [waterway = 'stream'][zoom >= 15] {
@@ -193,7 +194,8 @@
   [waterway = 'stream'],
   [waterway = 'ditch'],
   [waterway = 'drain'] {
-    [zoom >= 14] {
+    [int_intermittent != 'yes'][zoom >= 14],
+    [zoom >= 15] {
       // the additional line of land color is used to provide a background for dashed casings
       [int_tunnel = 'yes'] {
         background/line-width: 2;


### PR DESCRIPTION
This pull request cleans up the rendering on z13 and z14, by removing a number of features from these zoom levels.

* Drop buildings from z13 ~~and z14~~
* Drop footways from z13
* Drop service roads from z13
* Drop pedestrian roads from z13
* Different rendering of living_street on z13
* Drop playground outlines from z13 and z14
* Lighten up the color of trams
* Drop streams, ditches and drains from z13 (and intermittent ones from z14)

Fixes #3331.

The primary purpose of this pull request is to remove visual clutter from z13 and z14. These zoom levels contain lots of tiny elements that are hard to interpret, and lead to noise in the images. As a consequence of removing these features, the remaining features (such as the street pattern) become easier to read.

The secondary purpose is to give more attention to landuse rendering on these zoom levels. Especially landuse=retail is currently hardly visible on the map on any zoom level, this pull request should improve this.