### PR TITLE
Reduce noise of swimming pools at low zoom

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -93,7 +93,7 @@
     polygon-fill: @water-color;
     [zoom >= 17] { 
       line-width: 0.5; 
-      line-color: saturate(darken(@water-color, 10%), 20%);
+      line-color: saturate(darken(@water-color, 20%), 20%);
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }

--- a/landcover.mss
+++ b/landcover.mss
@@ -91,8 +91,10 @@
 
   [feature = 'leisure_swimming_pool'][zoom >= 14] {
     polygon-fill: @water-color;
-    line-color: saturate(darken(@water-color, 40%), 30%);
-    line-width: 0.5;
+    [zoom >= 17] { 
+      line-width: 0.5; 
+      line-color: saturate(darken(@water-color, 10%), 20%);
+    }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }


### PR DESCRIPTION
Fixes #585

Changes proposed in this pull request:
* Remove outline of swimming pools between z14 and z17
* Lighten colour of outline

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=15/43.7081/7.3168
Before
z15
![swimming_poolfinal_before_z15](https://user-images.githubusercontent.com/9897203/47271788-eb96f500-d57c-11e8-8c92-b1f5e0d5f97c.png)

z17
![swimming_poolfinal_before_z17](https://user-images.githubusercontent.com/9897203/47271790-f05ba900-d57c-11e8-94a4-78f65b13e98a.png)

z19
![swimming_poolfinal_before_z19](https://user-images.githubusercontent.com/9897203/47271794-f782b700-d57c-11e8-9266-2b1ce3b35dbf.png)

After
z15
![swimming_poolfinal_after_z15](https://user-images.githubusercontent.com/9897203/47271798-036e7900-d57d-11e8-8d20-db911483afcc.png)

z17
![swimming_poolfinal_after_z17](https://user-images.githubusercontent.com/9897203/47271801-108b6800-d57d-11e8-96f5-37f6cbb21b49.png)

z19
![swimming_poolfinal_after_z19](https://user-images.githubusercontent.com/9897203/47271804-1719df80-d57d-11e8-901e-02eef44685ad.png)
