### PR TITLE
Rendering railway pattern on z12

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1935,16 +1935,20 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-dasharray: 5,2;
         }
       }
-      [zoom >= 13] {
+      [zoom >= 12] {
         #roads-fill, #bridges {
           dark/line-join: round;
           light/line-color: white;
           light/line-join: round;
           [feature = 'railway_rail'] {
             dark/line-color: #707070;
-            dark/line-width: 3;
-            light/line-width: 1;
+            dark/line-width: 2;
+            light/line-width: 0.75;
             light/line-dasharray: 8,8;
+            [zoom >= 13] {
+              dark/line-width: 3;
+              light/line-width: 1;
+            }
             [zoom >= 15] {
               light/line-dasharray: 0,8,8,1;
             }


### PR DESCRIPTION
Related to #3467.

Changes proposed in this pull request:
- Rendering railway pattern on z12 instead of a simple black line. It allows to recognize railways from tram lines in urban areas and makes it easier to recognize them in the outdoor (we show power lines later, but one does not have to know that).

Test rendering with links to the example places:

[Bratislava](https://www.openstreetmap.org/#map=12/48.1478/17.1361)

![screenshot_2018-11-01 openstreetmap carto kosmtik](https://user-images.githubusercontent.com/5439713/47849725-0108ec00-ddd3-11e8-8a19-03cf992bd240.png)
![screenshot_2018-11-01 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/47849726-02d2af80-ddd3-11e8-9a9c-cdc742ba6334.png)

[Amsterdam](https://www.openstreetmap.org/#map=12/52.3756/4.8987)

![screenshot_2018-11-01 openstreetmap carto kosmtik 6](https://user-images.githubusercontent.com/5439713/47850754-a2de0800-ddd6-11e8-886e-d9ac8066587e.png)
![screenshot_2018-11-01 openstreetmap carto kosmtik 7](https://user-images.githubusercontent.com/5439713/47850755-a40f3500-ddd6-11e8-9fdd-2d84e56a00c3.png)

[Zagreb](https://www.openstreetmap.org/#map=12/45.8123/15.9757)

![screenshot_2018-11-01 openstreetmap carto kosmtik 2](https://user-images.githubusercontent.com/5439713/47849944-c94e7400-ddd3-11e8-81eb-4c2724a71c96.png)
![screenshot_2018-11-01 openstreetmap carto kosmtik 3](https://user-images.githubusercontent.com/5439713/47849946-ca7fa100-ddd3-11e8-9eb0-22dfd2411050.png)

[Bytom](https://www.openstreetmap.org/#map=12/50.3406/18.9142)

![screenshot_2018-11-01 openstreetmap carto kosmtik 4](https://user-images.githubusercontent.com/5439713/47850648-44188e80-ddd6-11e8-94d7-f38acd09cbc9.png)
![screenshot_2018-11-01 openstreetmap carto kosmtik 5](https://user-images.githubusercontent.com/5439713/47850650-4549bb80-ddd6-11e8-85cf-25c60e31c959.png)
