### PR TITLE
Show big states labels

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -44,7 +44,8 @@
 }
 
 .state {
-  [zoom >= 5][way_pixels > 3000][way_pixels < 196000] {
+  [zoom >= 5][zoom < 7][way_pixels > 3000],
+  [zoom >= 7][way_pixels > 3000][way_pixels < 196000] {
     text-name: "[name]";
     text-size: 10;
     text-wrap-width: 30; // 3.0 em


### PR DESCRIPTION
Follow up to #3353.

There are limits in the code for showing state labels that hide them if the area on the screen is big enough. However some huge states (further inflated by Web Merkator projection) are too big from the start, so their labels are never shown. This occurs with countries on the north, like Russia, Canada and USA (Alaska).

Removing this limit on z5 and z6 makes some cities start being visible along the state name. For Alaska it does not help, because capital is on far south and renders from z7, but at least the name of the state is shown on more than one level.

Testing on filtered subset of the planet file (`osmium tags-filter -o planet-admin-2-4.osm.pbf planet-latest.osm.pbf admin_level=2 admin_level=4`), so any objects other than admin data are not shown. @rrzefox could you apply this patch on your server, just in case?

Examples:

![screenshot_2018-11-04 openstreetmap carto kosmtik](https://user-images.githubusercontent.com/5439713/47959396-6d5a3a00-dfe3-11e8-9405-5461e4e4adbe.png)

![screenshot_2018-11-04 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/47959406-a1cdf600-dfe3-11e8-846f-58bc3640691e.png)

![screenshot_2018-11-04 openstreetmap carto kosmtik 2](https://user-images.githubusercontent.com/5439713/47959426-130da900-dfe4-11e8-8d1c-2a3c8150d246.png)



