### PR TITLE
Improve intermittent waterbody rendering of basins

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -230,6 +230,7 @@ Layer:
             way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              OR tags->'basin' IN ('detention', 'infiltration')
               THEN 'yes' ELSE 'no' END AS int_intermittent
           FROM planet_osm_polygon
           WHERE


### PR DESCRIPTION
Fixes #709

Changes proposed in this pull request:
Add support of `basin=detention` and `basin=infiltration` in `int_intermittent` variable

Test rendering with links to the example places:

`basin=detention` https://www.openstreetmap.org/way/220462429
Before
![basin_detention_before](https://user-images.githubusercontent.com/9897203/48218693-c121a600-e38a-11e8-8577-1080627e89f6.png)
After
![basin_detention](https://user-images.githubusercontent.com/9897203/48218646-a51e0480-e38a-11e8-82a1-2daf6bdb207e.png)

`basin=infiltration` https://www.openstreetmap.org/way/234418071
Before
![basin_infiltration_before](https://user-images.githubusercontent.com/9897203/48299715-37302500-e4d1-11e8-86c4-2f709c5ea386.png)
After
![basin_infiltration_after](https://user-images.githubusercontent.com/9897203/48299718-3e573300-e4d1-11e8-841d-b92d96dce18d.png)

`basin=infiltration` https://www.openstreetmap.org/way/532562272 (no modification)
![basin_retention_after](https://user-images.githubusercontent.com/9897203/48299749-ee2ca080-e4d1-11e8-8cda-9c97d952876c.png)

