### PR TITLE
Render Wind Turbines names, Change icon to gray, Do not render before z19 if location is rooftop

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1473,8 +1473,10 @@
   }
 
   [feature = 'power_generator']['generator:source' = 'wind'],
-  [feature = 'power_generator'][power_source = 'wind'] {
-    [zoom >= 15] {
+  [feature = 'power_generator']['generator:method' = 'wind_turbine'] {
+    [zoom >= 15][location != 'rooftop'][location != 'roof'],
+    [zoom >= 15][location = null],
+    [zoom >= 19] {
       marker-file: url('symbols/power_wind.svg');
       marker-placement: interior;
       marker-fill: black;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1479,7 +1479,7 @@
     [zoom >= 19] {
       marker-file: url('symbols/power_wind.svg');
       marker-placement: interior;
-      marker-fill: black;
+      marker-fill: @man-made-icon;
       marker-clip: false;
     }
   }

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1472,8 +1472,7 @@
     marker-clip: false;
   }
 
-  [feature = 'power_generator']['generator:source' = 'wind'],
-  [feature = 'power_generator']['generator:method' = 'wind_turbine'] {
+  [feature = 'power_generator']['generator:source' = 'wind'] {
     [zoom >= 15][location != 'rooftop'][location != 'roof'],
     [zoom >= 15][location = null],
     [zoom >= 19] {
@@ -1908,6 +1907,9 @@
   }
 
   [feature = 'man_made_cross'][zoom >= 17],
+  [feature = 'power_generator'][location != 'rooftop'][location != 'roof'][zoom >= 17],
+  [feature = 'power_generator'][location = null][zoom >= 17],
+  [feature = 'power_generator'][zoom >= 19],
   [feature = 'historic_wayside_cross'][zoom >= 17],
   [feature = 'historic_wayside_shrine'][zoom >= 17],
   [feature = 'historic_city_gate'][zoom >= 17],
@@ -1932,6 +1934,7 @@
     [feature = 'historic_wayside_cross'] {
       text-dy: 6;
     }
+    [feature = 'power_generator'],
     [feature = 'historic_city_gate'],
     [feature = 'man_made_mast'],
     [feature = 'man_made_tower'],
@@ -2824,7 +2827,7 @@
 
   [feature = 'power_plant'][is_building = 'no'][zoom >= 10],
   [feature = 'power_station'][is_building = 'no'][zoom >= 10],
-  [feature = 'power_generator'][is_building = 'no'][zoom >= 10],
+  [feature = 'power_generator'][is_building = 'no']["generator:source" != 'wind'][zoom >= 10],
   [feature = 'power_sub_station'][is_building = 'no'][zoom >= 13],
   [feature = 'power_substation'][is_building = 'no'][zoom >= 13]{
     [way_pixels > 3000],

--- a/project.mml
+++ b/project.mml
@@ -1479,6 +1479,7 @@ Layer:
             religion,
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
+            tags->'generator:method' as "generator:method",
             CASE
               WHEN (man_made IN ('mast', 'tower', 'chimney') AND (tags->'location' NOT IN ('roof', 'rooftop') OR (tags->'location') IS NULL)) THEN
                 CASE
@@ -1487,7 +1488,7 @@ Layer:
                 END
               ELSE NULL
             END AS height,
-            tags->'power_source' as power_source,
+            tags->'location' as location,
             tags->'icao' as icao,
             tags->'iata' as iata,
             tags->'office' as office,
@@ -1538,7 +1539,7 @@ Layer:
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
             OR military IN ('bunker')
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
-            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> 'power_source=>wind'))
+            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> '"generator:method"=>wind_turbine'))
           ORDER BY way_area desc
         ) AS amenity_points_poly
     properties:
@@ -1631,6 +1632,7 @@ Layer:
             religion,
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
+            tags->'generator:method' as "generator:method",
             CASE
               WHEN (man_made IN ('mast', 'tower', 'chimney') AND (tags->'location' NOT IN ('roof', 'rooftop') OR (tags->'location') IS NULL))
                     OR waterway IN ('waterfall') THEN
@@ -1640,7 +1642,7 @@ Layer:
                 END
               ELSE NULL
             END AS height,
-            tags->'power_source' as power_source,
+            tags->'location' as location,
             tags->'icao' as icao,
             tags->'iata' as iata,
             tags->'office' as office,
@@ -1696,7 +1698,7 @@ Layer:
             OR tags @> 'emergency=>phone'
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
             OR tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
-            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> 'power_source=>wind'))
+            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> '"generator:method"=>wind_turbine'))
           ORDER BY score DESC NULLS LAST
           ) AS amenity_points
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1479,7 +1479,6 @@ Layer:
             religion,
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
-            tags->'generator:method' as "generator:method",
             CASE
               WHEN (man_made IN ('mast', 'tower', 'chimney') AND (tags->'location' NOT IN ('roof', 'rooftop') OR (tags->'location') IS NULL)) THEN
                 CASE
@@ -1539,7 +1538,7 @@ Layer:
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
             OR military IN ('bunker')
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
-            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> '"generator:method"=>wind_turbine'))
+            OR (power = 'generator' AND tags @> '"generator:source"=>wind')
           ORDER BY way_area desc
         ) AS amenity_points_poly
     properties:
@@ -1632,7 +1631,6 @@ Layer:
             religion,
             tags->'denomination' as denomination,
             tags->'generator:source' as "generator:source",
-            tags->'generator:method' as "generator:method",
             CASE
               WHEN (man_made IN ('mast', 'tower', 'chimney') AND (tags->'location' NOT IN ('roof', 'rooftop') OR (tags->'location') IS NULL))
                     OR waterway IN ('waterfall') THEN
@@ -1698,7 +1696,7 @@ Layer:
             OR tags @> 'emergency=>phone'
             OR highway IN ('bus_stop', 'elevator', 'traffic_signals')
             OR tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
-            OR (power = 'generator' AND (tags @> '"generator:source"=>wind' OR tags @> '"generator:method"=>wind_turbine'))
+            OR (power = 'generator' AND tags @> '"generator:source"=>wind')
           ORDER BY score DESC NULLS LAST
           ) AS amenity_points
     properties:
@@ -2124,6 +2122,8 @@ Layer:
               ELSE NULL
             END AS height,
             tags->'operator' as operator,
+            tags->'generator:source' as "generator:source",
+            tags->'location' as location,
             tags->'icao' as icao,
             tags->'iata' as iata,
             tags->'office' as office,
@@ -2230,6 +2230,8 @@ Layer:
             office,
             recycling_type,
             "telescope:type",
+            "generator:source",
+            location,
             castle_type,
             sport,
             information,
@@ -2318,6 +2320,8 @@ Layer:
                 "natural",
                 waterway,
                 tags->'operator' as operator,
+                tags->'location' as location,
+                tags->'generator:source' as "generator:source",
                 tags->'icao' as icao,
                 tags->'iata' as iata,
                 tags->'office' as office,


### PR DESCRIPTION
Fixes #2734
Also related to #1017

**Changes proposed in this pull request:**
- Start rendering names of wind turbines (power=generator, generator:source=wind)
- Change wind turbine icon color to man-made-gray
- Render wind turbines only at z19 if location=rooftop or =roof
- Remove rendering for deprecated tagging power=generator with power_source=wind

**Explanation:**
Wind turbine name labels do not currently render, because the names for power=generator are done in landcover style without any text-dy. This PR adds `text-dy: 10` for wind turbines, and the names will be rendered the same as other man_made features, starting at z17 (unless location=rooftop or roof)

The icon color is changed to match other man_made features, because it is currently black. This color is otherwise used only for religious feature icons.

Wind turbines on building rooftops are always much smaller than the large stand-alone towers common in rural areas, so they will now be rendered starting at z19. This will prevent them from blocking building names and the icons for amenities or shops in buildings at z17 and z18. The name label will also be rendered only at z19 in this case.

The tag power_source=wind is deprecated, and is now only used 200 times, vs 200,000 times for generator:source=wind, therefore it will be removed from rendering.

Test rendering with links to the example places:

**Before**
Blackfriars road z18 before
https://www.openstreetmap.org/#map=18/51.504541/-0.10496
![blackfriars-z18](https://user-images.githubusercontent.com/42757252/48593036-6c83b980-e98e-11e8-9227-aa8fb48bca8a.png)

Islington Council building 
https://www.openstreetmap.org/#map=18/51.54401/-0.10262 
z18 before
![islington-z18-before](https://user-images.githubusercontent.com/42757252/48594129-e74ed380-e992-11e8-997d-544e76e29704.png)
z19 before
![islington-wind-19](https://user-images.githubusercontent.com/42757252/48593048-75748b00-e98e-11e8-85f5-fdf02a04ae38.png)

Strata Building 
https://www.openstreetmap.org/#map=18/51.492857/-0.0995045
z18 before
![strata-z18-before](https://user-images.githubusercontent.com/42757252/48594407-bfac3b00-e993-11e8-818d-f982490e5037.png)
z19 before
![chase-wind-19](https://user-images.githubusercontent.com/42757252/48593055-7e655c80-e98e-11e8-9ef8-62a1d633c1ec.png)

Prototype named wind turbine, before
https://www.openstreetmap.org/#map=17/53.5056716/8.5790005
![](https://user-images.githubusercontent.com/42757252/48466798-37f6ed00-e82a-11e8-90d1-223d973f4b81.png)

Test rendering z19 before
![z19-test-before](https://user-images.githubusercontent.com/42757252/48593720-604d2b80-e991-11e8-8273-9feadd9c156e.png)

Test z18 before
![z18-test-before](https://user-images.githubusercontent.com/42757252/48593723-62af8580-e991-11e8-8069-3a6fb36e0314.png)

**After**
Blackfriars Road, London z18 (*Name added for test) - still renders because no location tag
![](https://user-images.githubusercontent.com/42757252/48466765-26154a00-e82a-11e8-99ae-03115d36df10.png)

AD 8-180 Prototype wind turbine, z17
![](https://user-images.githubusercontent.com/42757252/48466798-37f6ed00-e82a-11e8-90d1-223d973f4b81.png)

Islington Council building, z18 - turbine hidden
![islington-after-z18](https://user-images.githubusercontent.com/42757252/48594413-c6d34900-e993-11e8-91a9-86eda4e4c8e5.png)
z19 after
![islington-wind-gray](https://user-images.githubusercontent.com/42757252/48592989-40683880-e98e-11e8-9302-16ac7eb97d4d.png)

Strata building, z18 - hidden
![strata-after-z18](https://user-images.githubusercontent.com/42757252/48594417-cf2b8400-e993-11e8-89ea-ca7b83beb4dc.png)
z19 after
![chase-wind-grayicons](https://user-images.githubusercontent.com/42757252/48593385-f2eccb00-e98f-11e8-8b7f-fde8748975b2.png)

Prototype after
![z17-prototyp-after](https://user-images.githubusercontent.com/42757252/48594452-f4b88d80-e993-11e8-9652-81f11ce3133d.png)

Test rendering z19
- Named rooftop wind turbines show with label
![z19-test-after](https://user-images.githubusercontent.com/42757252/48593732-66dba300-e991-11e8-87d6-d0b89292098f.png)

Test z18
-rooftop wind turbines hidden, but others render with label.
-Power plants and other power generator labels still render properly as a node or polygon
![z18-test-after](https://user-images.githubusercontent.com/42757252/48593733-66dba300-e991-11e8-9609-8feb926b63c4.png)