### PR TITLE
Change man made gray and text color, make text-dy uniform

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -15,7 +15,7 @@
 @culture: @amenity-brown;
 @public-service: @amenity-brown;
 @office: #4863A0;
-@man-made-icon: #555;
+@man-made-icon: #666666;
 @advertising-grey: @man-made-icon;
 @landform-color: #d08f55;
 @leisure-green: darken(@park, 60%);
@@ -1924,7 +1924,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: darken(@man-made-icon, 15%);
+    text-fill: darken(@man-made-icon, 20%);
     [feature = 'man_made_cross'],
     [feature = 'historic_wayside_cross'] {
       text-dy: 6;
@@ -1981,7 +1981,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: darken(@man-made-icon, 15%);
+    text-fill: darken(@man-made-icon, 20%);
     text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
@@ -2517,7 +2517,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: darken(@man-made-icon, 15%);
+    text-fill: darken(@man-made-icon, 20%);
     text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
@@ -2994,7 +2994,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-dy: 10;
-    text-fill: darken(@man-made-icon, 15%);
+    text-fill: darken(@man-made-icon, 20%);
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1925,7 +1925,6 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: darken(@man-made-icon, 15%);
-    [feature = 'natural_cave_entrance'] { text-dy: 11; }
     [feature = 'man_made_cross'],
     [feature = 'historic_wayside_cross'] {
       text-dy: 6;
@@ -1940,6 +1939,9 @@
     [feature = 'man_made_silo'],
     [feature = 'man_made_chimney'] {
       text-dy: 10;
+    }
+    [feature = 'natural_cave_entrance'] {
+      text-dy: 11;
     }
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1938,9 +1938,7 @@
     [feature = 'man_made_water_tower'],
     [feature = 'man_made_storage_tank'],
     [feature = 'man_made_silo'],
-    [feature = 'man_made_chimney'],
-    [feature = 'man_made_water_works'],
-    [feature = 'man_made_wastewater_plant'] { 
+    [feature = 'man_made_chimney'] {
       text-dy: 10;
     }
     text-face-name: @standard-font;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1982,7 +1982,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: darken(@man-made-icon, 15%);
-    text-dy: 11;
+    text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
@@ -2518,8 +2518,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: darken(@man-made-icon, 15%);
-    text-dy: 16;
-    [feature = 'man_made_windmill'] { text-dy: 12; }
+    text-dy: 10;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
@@ -2994,7 +2993,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-dy: 11;
+    text-dy: 10;
     text-fill: darken(@man-made-icon, 15%);
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1924,7 +1924,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: black;
+    text-fill: darken(@man-made-icon, 15%);
     [feature = 'natural_cave_entrance'] { text-dy: 11; }
     [feature = 'man_made_cross'],
     [feature = 'historic_wayside_cross'] {
@@ -1981,7 +1981,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @man-made-icon;
+    text-fill: darken(@man-made-icon, 15%);
     text-dy: 11;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
@@ -2517,7 +2517,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: @man-made-icon;
+    text-fill: darken(@man-made-icon, 15%);
     text-dy: 16;
     [feature = 'man_made_windmill'] { text-dy: 12; }
     text-face-name: @standard-font;
@@ -2995,7 +2995,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-dy: 11;
-    text-fill: @man-made-icon;
+    text-fill: darken(@man-made-icon, 15%);
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
Fixes #3510
Related to #3512 

**Changes proposed in this pull request:**
- Change the text color of man-made feature's name labels to man-made-icon gray darkened by 15%
- Make text-dy 10 for all of these man-made features
- Remove redundant name label code for wastewater and water plants
- Fix formating of natural_cave_entrance text-dy

**Features affected**
man_made = lighthouse, windmill, hunting_stand, bunker (currently gray)
historic = wayside_shrine (currently gray)
man_made = tower, mast, communications_tower, water_tower, chimney
_power = generator with generator:sourece=wind_ - if this is merged (currently black)

Not affected: Religious items with black icon and text
man_made = cross
historic = wayside cross

**Rational**
All man_made features with icons in man-made-icon color (currently #555, dark gray) should have a name label in a matching color.

Currently, some man_made features have black text for the name label, others use man-made-icon gray. The text appears to be lighter than the corresponding icon when man-made-icon is used, but darker than the icon when black is used.

I would suggest darkening the man-made-icon color 10% or 15%

Also, the text-dy for lighthouses is currently excessive. I would also like to make the text-dy the same for all of these icons, which are all 14 x 14 pixels. As little as 8 is possible, but 10 looks best with extra-tall characters, as found in some languages.

**Test rendering with links to the example places:**

_Test area 1:_
Current rendering, z17
![tower-labels-1-before](https://user-images.githubusercontent.com/42757252/48453015-0152af80-e7f5-11e8-89dc-b5bf078c9712.png)
Man-made-icon 15% darker (except wayside cross)
![tower-labels1-15darker](https://user-images.githubusercontent.com/42757252/48453037-192a3380-e7f5-11e8-9709-c1bb91e77403.png)

_Test area 2:_
Current
![tower-labels-2-before](https://user-images.githubusercontent.com/42757252/48453067-3959f280-e7f5-11e8-8093-3c292c27526b.png)
15% Darkened
![tower-labels-2-15darker](https://user-images.githubusercontent.com/42757252/48453089-4d9def80-e7f5-11e8-955d-d074b1c48d09.png)

_Samphire tower:_
https://www.openstreetmap.org/?mlat=51.1056&mlon=1.275&zoom=17
Current
![](https://user-images.githubusercontent.com/42757252/48452621-4aa1ff80-e7f3-11e8-8956-87d2726cf637.png)
15%
![samphire-darken15](https://user-images.githubusercontent.com/42757252/48453128-71613580-e7f5-11e8-98c4-a765aa9d9829.png)

_WRC and WKYS towers in Washington, DC_
Current black
![wrc-wkys-black](https://user-images.githubusercontent.com/42757252/48453202-b1281d00-e7f5-11e8-85dc-232627d4722d.png)
15%
![wrc-wkys-darken15](https://user-images.githubusercontent.com/42757252/48453193-aa99a580-e7f5-11e8-8918-78380f7fd2f7.png)

_WDCU in Washington, DC_
Current black
![wdcu-black](https://user-images.githubusercontent.com/42757252/48453287-0cf2a600-e7f6-11e8-86e5-d21cfe1233e1.png)
15%
![wdcu-darken-15](https://user-images.githubusercontent.com/42757252/48453278-06fcc500-e7f6-11e8-87db-07b2492e2e22.png)

_Diamond Head Lighthouse, Hawaii_
https://www.openstreetmap.org/?mlat=21.256944&mlon=-157.809444&zoom=17
man-made-gray (current rendering):
![diamond-head-gray](https://user-images.githubusercontent.com/42757252/48454560-fdc22700-e7fa-11e8-8310-df49b9bac6e8.png)
15% darker
![diamond-head-darken15](https://user-images.githubusercontent.com/42757252/48454256-edf61300-e7f9-11e8-8fb5-a84bebb7f56b.png)

**Test of text-dy: 10 with tall characters**
![](https://user-images.githubusercontent.com/42757252/48302781-5fa53700-e544-11e8-99d5-3f69683d8fbc.png)

![](https://user-images.githubusercontent.com/42757252/48526981-d76cbc00-e8cc-11e8-8d3c-aff65ccd7074.png)
