### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ localconfig.json
 localconfig.js
 .kosmtik-config.yml
 .env
+.DS_Store
 
 # Generated at runtime by Python.
 *.pyc


### PR DESCRIPTION
**Changes proposed in this pull request:**
-Update .gitignore file to include .DS_Store

**Explanation:**
.DS_Store files are directory files that are automatically created by MacOS. They should not be accidentally committed to Git

This PR will prevent [mistakes like this](https://github.com/gravitystorm/openstreetmap-carto/pull/3463/commits/1b321a2af6eb02208c8c83ff8f24c71be7cd6f0c) from occurring in the future.