### PR TITLE
Move tram stops later

### DIFF
--- a/stations.mss
+++ b/stations.mss
@@ -101,7 +101,7 @@
   }
 
   [railway = 'tram_stop'] {
-    [zoom >= 13] {
+    [zoom >= 14] {
       marker-file: url('symbols/square.svg');
       marker-placement: interior;
       marker-fill: @station-color;


### PR DESCRIPTION
Follow up to #3467.

Changes proposed in this pull request:
- After cleaning of z13 tram stops became too visible and make a noise, so they are pushed to z14+.

Warsaw, z13

Before

![screenshot_2018-11-30 openstreetmap carto kosmtik](https://user-images.githubusercontent.com/5439713/49272913-7cfa6080-f473-11e8-8280-39d59e0aa16a.png)

After

![screenshot_2018-11-30 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/49272922-84216e80-f473-11e8-96c6-b36455c82dae.png)

