### PR TITLE
[WIP] Change retail and commercial area colors

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -15,7 +15,7 @@
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
 @retail: #fbecd7;
-@retail-line: darken(@retail, 5%);
+@retail-line: darken(@retail, 20%);
 @commercial: #f2dad9;       // Lch(89,8.5,25)
 @commercial-line: #d1b2b0;  // Lch(75,12,25)
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)

--- a/landcover.mss
+++ b/landcover.mss
@@ -14,9 +14,9 @@
 @built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
-@retail: #fcf7ed;
+@retail: #fbecd7;
 @retail-line: darken(@retail, 20%);
-@commercial: #e6eef0;
+@commercial: #f2ebdc;
 @commercial-line: darken(@commercial, 20%);
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line, wastewater_plant-line)

--- a/landcover.mss
+++ b/landcover.mss
@@ -14,9 +14,9 @@
 @built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
-@retail: #fbecd7;
+@retail: #f2ebdc;
 @retail-line: darken(@retail, 20%);
-@commercial: #f2ebdc;
+@commercial: #e4e0d7;
 @commercial-line: darken(@commercial, 20%);
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line, wastewater_plant-line)

--- a/landcover.mss
+++ b/landcover.mss
@@ -14,8 +14,8 @@
 @built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
-@retail: #ffd6d1;           // Lch(89,16,30)
-@retail-line: #d99c95;      // Lch(70,25,30)
+@retail: #fbecd7;
+@retail-line: darken(@retail, 5%);
 @commercial: #f2dad9;       // Lch(89,8.5,25)
 @commercial-line: #d1b2b0;  // Lch(75,12,25)
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)

--- a/landcover.mss
+++ b/landcover.mss
@@ -14,9 +14,9 @@
 @built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
-@retail: #f2ebdc;
+@retail: #f5eddc;
 @retail-line: darken(@retail, 20%);
-@commercial: #e4e0d7;
+@commercial: #f0ebe1;
 @commercial-line: darken(@commercial, 20%);
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line, wastewater_plant-line)

--- a/landcover.mss
+++ b/landcover.mss
@@ -14,10 +14,10 @@
 @built-up-z12: #d0d0d0;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
-@retail: #fbecd7;
+@retail: #fcf7ed;
 @retail-line: darken(@retail, 20%);
-@commercial: #f2dad9;       // Lch(89,8.5,25)
-@commercial-line: #d1b2b0;  // Lch(75,12,25)
+@commercial: #e6eef0;
+@commercial-line: darken(@commercial, 20%);
 @industrial: #ebdbe8;       // Lch(89,9,330) (Also used for railway, wastewater_plant)
 @industrial-line: #c6b3c3;  // Lch(75,11,330) (Also used for railway-line, wastewater_plant-line)
 @farmland: #eef0d5;         // Lch(94,14,112)


### PR DESCRIPTION
Changes proposed in this pull request:
- Replace retail color with something not aggressive (reusing light orange from what was a temporary societal area color)

We use few different reddish landcover colors. They are proper for military or police areas, kind of violet works for industrial areas and less intensive for commercial areas, but retail areas look like dangerous places. I think we should change that to make them not look scary, especially when downtown is tagged like this, for example Hannover:

Before

![screenshot_2018-12-01 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/49323981-f30ad000-f524-11e8-9940-ba2fb9ab643f.png)

After

![screenshot_2018-12-01 openstreetmap carto kosmtik 2](https://user-images.githubusercontent.com/5439713/49323982-f69e5700-f524-11e8-8f58-8a201b040cb2.png)

Some other examples:

![screenshot_2018-12-01 openstreetmap carto kosmtik 3](https://user-images.githubusercontent.com/5439713/49323990-24839b80-f525-11e8-8cc5-b6dcc6bdb049.png)
![screenshot_2018-12-01 openstreetmap carto kosmtik 4](https://user-images.githubusercontent.com/5439713/49323992-264d5f00-f525-11e8-85ca-010c14d13826.png)

![screenshot_2018-12-01 openstreetmap carto kosmtik 5](https://user-images.githubusercontent.com/5439713/49324010-952ab800-f525-11e8-9133-41cbe4cc625b.png)
![screenshot_2018-12-01 openstreetmap carto kosmtik 6](https://user-images.githubusercontent.com/5439713/49324011-965be500-f525-11e8-9c8a-daba5042e99f.png)

![screenshot_2018-12-01 openstreetmap carto kosmtik 7](https://user-images.githubusercontent.com/5439713/49324019-d4f19f80-f525-11e8-9997-55c6e9c9d131.png)
![screenshot_2018-12-01 openstreetmap carto kosmtik 8](https://user-images.githubusercontent.com/5439713/49324021-d622cc80-f525-11e8-9698-09e824bc0f4e.png)
