### PR TITLE
Move station=subway to z=14

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1405,6 +1405,7 @@ Layer:
             ref,
             railway,
             aerialway,
+            tags->'station' as "station",
             CASE railway
               WHEN 'station' THEN 1
               WHEN 'subway_entrance' THEN 3
@@ -1430,7 +1431,8 @@ Layer:
             name,
             ref,
             railway,
-            aerialway
+            aerialway,
+            tags->'station' as "station"
         FROM planet_osm_polygon
         WHERE railway IN ('station', 'halt', 'tram_stop')
           OR aerialway = 'station'

--- a/stations.mss
+++ b/stations.mss
@@ -20,13 +20,16 @@
     }
   }
 
-  [railway = 'station'][zoom >= 12] {
+  [railway = 'station'] {
     marker-file: url('symbols/square.svg');
     marker-placement: interior;
     marker-fill: @station-color;
-    marker-width: 4;
     marker-clip: false;
-    [zoom >= 13] {
+    [zoom >= 12][station != 'subway'] {
+      marker-width: 4;
+    }
+    [zoom >= 13][station != 'subway'],
+    [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
     [zoom >= 14] {

--- a/stations.mss
+++ b/stations.mss
@@ -20,12 +20,12 @@
     }
   }
 
-  [railway = 'station'] {
+  [railway = 'station'][zoom >= 12] {
     marker-file: url('symbols/square.svg');
     marker-placement: interior;
     marker-fill: @station-color;
     marker-clip: false;
-    [zoom >= 12][station != 'subway'] {
+    [station != 'subway'] {
       marker-width: 4;
     }
     [zoom >= 13][station != 'subway'],


### PR DESCRIPTION
Fixes #3559

Changes proposed in this pull request:
Move `railway=station` + `station=subway` to z14 as well as `railway=tram_stop` following #3541

Test rendering with links to the example places:

`z12`
before
![subway_before_z12](https://user-images.githubusercontent.com/9897203/49745742-f24e0880-fc9f-11e8-8127-e5e91b776319.png)
after
![subway_after_z12](https://user-images.githubusercontent.com/9897203/49745749-f67a2600-fc9f-11e8-9032-bc3e90cd4324.png)

`z13`
before
![subway_before_z13](https://user-images.githubusercontent.com/9897203/49745767-00038e00-fca0-11e8-8c22-79e991e54650.png)
master (with #3541)
![subway_master_z13](https://user-images.githubusercontent.com/9897203/49746425-7785ed00-fca1-11e8-9b30-be3476f2812b.png)
after
![subway_after_z13](https://user-images.githubusercontent.com/9897203/49745805-16114e80-fca0-11e8-89c8-ba80dab8f38e.png)

`z14` (no changes)
before
![subway_before_z14](https://user-images.githubusercontent.com/9897203/49745918-540e7280-fca0-11e8-87bb-a4f19a68aa10.png)
after
![subway_after_z14](https://user-images.githubusercontent.com/9897203/49745895-48bb4700-fca0-11e8-8d82-4c3f2722a78b.png)


