### PR TITLE
Unify code of power=tower and power=pole

### DIFF
--- a/power.mss
+++ b/power.mss
@@ -33,21 +33,20 @@
 }
 
 #power-towers {
-  [zoom >= 14] {
-    marker-file: url('symbols/man_made/power_tower_small.svg');
-    marker-width: 3;
+  [power = 'tower'] {
+    [zoom >= 14] {
+      marker-file: url('symbols/man_made/power_tower_small.svg');
+      marker-width: 3;
+    }
+    [zoom >= 15] {
+      marker-file: url('symbols/man_made/power_tower.svg');
+      marker-width: 5;
+    }
+    [zoom >= 17] {
+      marker-width: 7;
+    }
   }
-  [zoom >= 15] {
-    marker-file: url('symbols/man_made/power_tower.svg');
-    marker-width: 5;
-  }
-  [zoom >= 17] {
-    marker-width: 7;
-  }
-}
-
-#power-poles {
-  [zoom >= 16] {
+  [power = 'pole'][zoom >= 16] {
     marker-file: url('symbols/square.svg');
     marker-fill: #928f8f;
     marker-width: 3;

--- a/project.mml
+++ b/project.mml
@@ -1722,15 +1722,14 @@ Layer:
         (SELECT
             way,
             power
-            CASE power
-              WHEN 'tower' THEN 1
-              WHEN 'pole' THEN 2
-              ELSE 3
-            END
-              AS prio
         FROM planet_osm_point
-        WHERE power = 'tower' OR power = 'pole'
-        ORDER BY prio
+        WHERE power IN ('tower', 'pole')
+        ORDER BY
+          CASE
+            WHEN power = 'tower' THEN 1
+            WHEN power = 'pole' THEN 2
+            ELSE NULL
+          END
         ) AS power_towers
     properties:
       minzoom: 14

--- a/project.mml
+++ b/project.mml
@@ -1722,8 +1722,15 @@ Layer:
         (SELECT
             way,
             power
-          FROM planet_osm_point
-          WHERE power = 'pole' OR power = 'tower'
+            CASE power
+              WHEN 'tower' THEN 1
+              WHEN 'pole' THEN 2
+              ELSE 3
+            END
+              AS prio
+        FROM planet_osm_point
+        WHERE power = 'tower' OR power = 'pole'
+        ORDER BY prio
         ) AS power_towers
     properties:
       minzoom: 14

--- a/project.mml
+++ b/project.mml
@@ -1720,25 +1720,13 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way
+            way,
+            power
           FROM planet_osm_point
-          WHERE power = 'tower'
+          WHERE power = 'tower' OR power = 'pole'
         ) AS power_towers
     properties:
       minzoom: 14
-  - id: power-poles
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way
-          FROM planet_osm_point
-          WHERE power = 'pole'
-        ) AS power_poles
-    properties:
-      minzoom: 16
   - id: roads-text-ref-low-zoom
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -1723,7 +1723,7 @@ Layer:
             way,
             power
           FROM planet_osm_point
-          WHERE power = 'tower' OR power = 'pole'
+          WHERE power = 'pole' OR power = 'tower'
         ) AS power_towers
     properties:
       minzoom: 14


### PR DESCRIPTION
Fixes #1179

Changes proposed in this pull request:
* Merge layers `power-towers` and `power-poles` in `project.mml`
* Adjust modifications in `power.mss`

Test rendering with links to the example places:
there is no rendering differences
https://www.openstreetmap.org/#map=17/46.17629/6.23976
`z=15`
![power_towers_z15](https://user-images.githubusercontent.com/9897203/49764889-06f6c480-fcd1-11e8-85bc-fc7259f458da.png)
`z=16`
![power_towers_z16](https://user-images.githubusercontent.com/9897203/49764893-0bbb7880-fcd1-11e8-8aad-f255332f3b62.png)
`z=17`
![power_towers_z17](https://user-images.githubusercontent.com/9897203/49764900-11b15980-fcd1-11e8-9189-db1a4e8e81e7.png)


