### PR TITLE
Thicker country borders at z8 and z9

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -37,6 +37,14 @@ overlapping borders correctly.
       background/line-width: 2;
       line-width: 2;
     }
+    [zoom >= 8] {
+      background/line-width: 3;
+      line-width: 3;
+    }
+    [zoom >= 9] {
+      background/line-width: 3.2;
+      line-width: 3.2;
+    }
     [zoom >= 10] {
       background/line-width: 6;
       line-width: 6;


### PR DESCRIPTION
Related to #3538.

Change proposed in this pull request:
- Make country borders thicker at z8 and z9.

This will make these borders more prominent at these zoom levels, where they are currently quite thin. It will also make them easier to distinguish from railways when the border color from #3553 is implemented and when railways are made lighter in the future.

The "after" renders are shown with the border color from #3553. 

z8 before 
![z8osm](https://user-images.githubusercontent.com/5209216/49812802-8387b280-fd66-11e8-8979-1d6e85270c47.png)

z8 after
![z8bordersonly](https://user-images.githubusercontent.com/5209216/49812826-8da9b100-fd66-11e8-91f0-ade9602f3f51.png)

z9 before
![z9osm](https://user-images.githubusercontent.com/5209216/49812844-969a8280-fd66-11e8-9732-61e4c129294d.png)

z9 after
![z9bordersonly](https://user-images.githubusercontent.com/5209216/49812851-9b5f3680-fd66-11e8-954d-4538675c83c0.png)
