### PR TITLE
Add tertiary-link width, same as other links

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -96,6 +96,7 @@
 @secondary-width-z12:             3.5;
 @secondary-link-width-z12:        1.5;
 @tertiary-width-z12:              2.5;
+@tertiary-link-width-z12:         1.5;
 @residential-width-z12:           0.5;
 @unclassified-width-z12:          0.8;
 
@@ -108,6 +109,7 @@
 @secondary-width-z13:             5;
 @secondary-link-width-z13:        4;
 @tertiary-width-z13:              4;
+@tertiary-link-width-z13:         3;
 @residential-width-z13:           2.5;
 @living-street-width-z13:         2;
 @bridleway-width-z13:             0.3;
@@ -135,6 +137,7 @@
 @secondary-width-z15:             9;
 @secondary-link-width-z15:        7;
 @tertiary-width-z15:              9;
+@tertiary-link-width-z15:         7;
 @residential-width-z15:           5;
 @living-street-width-z15:         5;
 @pedestrian-width-z15:            5;
@@ -166,6 +169,7 @@
 @secondary-width-z17:            18;
 @secondary-link-width-z17:       12;
 @tertiary-width-z17:             18;
+@tertiary-link-width-z17:        12;
 @residential-width-z17:          12;
 @living-street-width-z17:        12;
 @pedestrian-width-z17:           12;
@@ -182,6 +186,7 @@
 @secondary-width-z18:            21;
 @secondary-link-width-z18:       13;
 @tertiary-width-z18:             21;
+@tertiary-link-width-z18:        13;
 @residential-width-z18:          13;
 @living-street-width-z18:        13;
 @pedestrian-width-z18:           13;
@@ -198,6 +203,7 @@
 @secondary-width-z19:            27;
 @secondary-link-width-z19:       16;
 @tertiary-width-z19:             27;
+@tertiary-link-width-z19:        16;
 @residential-width-z19:          17;
 @living-street-width-z19:        17;
 @pedestrian-width-z19:           17;
@@ -460,6 +466,14 @@
         [zoom >= 17] { line-width: @tertiary-width-z17; }
         [zoom >= 18] { line-width: @tertiary-width-z18; }
         [zoom >= 19] { line-width: @tertiary-width-z19; }
+        [link = 'yes'] {
+          line-width: @tertiary-link-width-z12;
+          [zoom >= 13] { line-width: @tertiary-link-width-z13; }
+          [zoom >= 15] { line-width: @tertiary-link-width-z15; }
+          [zoom >= 17] { line-width: @tertiary-link-width-z17; }
+          [zoom >= 18] { line-width: @tertiary-link-width-z18; }
+          [zoom >= 19] { line-width: @tertiary-link-width-z19; }
+        }
         #roads-casing {
           line-join: round;
           line-cap: round;
@@ -1442,6 +1456,14 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           [zoom >= 17] { line-width: @tertiary-width-z17 - 2 * @casing-width-z17; }
           [zoom >= 18] { line-width: @tertiary-width-z18 - 2 * @casing-width-z18; }
           [zoom >= 19] { line-width: @tertiary-width-z19 - 2 * @casing-width-z19; }
+          [link = 'yes'] {
+            line-width: @tertiary-link-width-z12 - 2 * @casing-width-z12;
+            [zoom >= 13] { line-width: @tertiary-link-width-z13 - 2 * @casing-width-z13; }
+            [zoom >= 15] { line-width: @tertiary-link-width-z15 - 2 * @casing-width-z15; }
+            [zoom >= 17] { line-width: @tertiary-link-width-z17 - 2 * @casing-width-z17; }
+            [zoom >= 18] { line-width: @tertiary-link-width-z18 - 2 * @casing-width-z18; }
+            [zoom >= 19] { line-width: @tertiary-link-width-z19 - 2 * @casing-width-z19; }
+          }
           #tunnels {
             line-color: @tertiary-tunnel-fill;
           }
@@ -1454,6 +1476,14 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
             [zoom >= 17] { line-width: @tertiary-width-z17 - 2 * @bridge-casing-width-z17; }
             [zoom >= 18] { line-width: @tertiary-width-z18 - 2 * @bridge-casing-width-z18; }
             [zoom >= 19] { line-width: @tertiary-width-z19 - 2 * @bridge-casing-width-z19; }
+            [link = 'yes'] {
+              line-width: @tertiary-link-width-z12 - 2 * @bridge-casing-width-z12;
+              [zoom >= 13] { line-width: @tertiary-link-width-z13 - 2 * @bridge-casing-width-z13; }
+              [zoom >= 15] { line-width: @tertiary-link-width-z15 - 2 * @bridge-casing-width-z15; }
+              [zoom >= 17] { line-width: @tertiary-link-width-z17 - 2 * @bridge-casing-width-z17; }
+              [zoom >= 18] { line-width: @tertiary-link-width-z18 - 2 * @bridge-casing-width-z18; }
+              [zoom >= 19] { line-width: @tertiary-link-width-z19 - 2 * @bridge-casing-width-z19; }
+            }
           }
           line-cap: round;
           line-join: round;


### PR DESCRIPTION
**Fixes #1109** 
(This issue is currently closed, but tertiary_link was not added)

**Changes proposed in this pull request:**
- Render highway=tertiary_link thinner than highway_tertiary (generally the same width as secondary_link)

**Explanation:**
Leaving different tertiary links causes oddities in connections to higher-order tertiary links, eg 
[](https://user-images.githubusercontent.com/19976610/45986666-4d7a4280-c043-11e8-97cb-28c287caaa12.PNG)

Tertiary_link is used over 150k times and is mentioned in the highway link documentation, and it is currently rendered, but at the same width as highway=tertiary. This makes the tertiary links significantly wider than motorway, trunk, primary and secondary links.

Previously this was not fixed, because tertiary has been rendered in white, the same as minor roads such as highway=unclassified and highway=residential, and the thinner tertiary links will be similar in appearance to these roads. However, there is currently a plan to change the highway colors, which will render tertiary in yellow. Even if this is not implemented, it is better to render the link roads consistently.

**Test rendering with links to the example places:**

Tertiary links in Wales, Great Britain
1.  Before
![1-tertiary-master](https://user-images.githubusercontent.com/42757252/50000905-707f1780-ffde-11e8-996f-aa8dcf426567.png)

After
![1-tertiary-after](https://user-images.githubusercontent.com/42757252/50000907-737a0800-ffde-11e8-8e18-fa8ab91fe6f4.png)

2. Before
![2-tertiary-master](https://user-images.githubusercontent.com/42757252/50000935-8a205f00-ffde-11e8-89e7-076f82023e49.png)

After
![2-tertiary-after](https://user-images.githubusercontent.com/42757252/50000948-8e4c7c80-ffde-11e8-8718-3446aefe7ab6.png)

3. Before
![3-tertiary-master](https://user-images.githubusercontent.com/42757252/50000956-960c2100-ffde-11e8-9793-11e14f339be1.png)

After
![3-tertiary-after](https://user-images.githubusercontent.com/42757252/50000961-9a383e80-ffde-11e8-8d7a-cd85f4dbf125.png)
