### PR TITLE
Use usual subway bridge style for subway construction bridges

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -772,7 +772,8 @@
       }
     }
 
-    [feature = 'railway_subway'] {
+    [feature = 'railway_subway'],
+    [feature = 'railway_construction']['construction' = 'subway'] {
       #bridges {
         [zoom >= 14] {
           line-width: 5.5;
@@ -817,7 +818,7 @@
     }
 
     [feature = 'railway_disused'][zoom >= 15],
-    [feature = 'railway_construction'],
+    [feature = 'railway_construction']['construction' != 'subway'],
     [feature = 'railway_miniature'][zoom >= 15],
     [feature = 'railway_INT-preserved-ssy'][zoom >= 14] {
       #bridges {
@@ -1010,7 +1011,7 @@
     }
 
     [feature = 'railway_disused'][zoom >= 15],
-    [feature = 'railway_construction'],
+    [feature = 'railway_construction']['construction' != 'subway'],
     [feature = 'railway_miniature'][zoom >= 15],
     [feature = 'railway_INT-preserved-ssy'][zoom >= 14] {
       #bridges {
@@ -1035,7 +1036,8 @@
       }
     }
 
-    [feature = 'railway_subway'] {
+    [feature = 'railway_subway'],
+    [feature = 'railway_construction']['construction' = 'subway'] {
       #bridges {
         [zoom >= 14] {
           line-width: 4;


### PR DESCRIPTION
Changes proposed in this pull request:
* Make subway bridges under construction thinner and only appear from zoom 14 on.

Currently, all railway construction bridges are rendered the same. However not all (non-construction) railway bridges are identical.

Namely, subway bridges are thinner and appear later (zoom 14 instead of 13) than standard railways.

This PR unifies the appearance of subway bridges, whether under construction or not.

Some other railway types have their own rules for bridges (light rail, funicular, narrow gauge, etc.). They are not handled in this PR, but could be if there is interest.

### Examples
(Area: https://www.openstreetmap.org/#map=14/48.1131/-1.6690)
#### Zoom 13
Before
![image](https://user-images.githubusercontent.com/204831/50028055-a4facf80-ffee-11e8-99cf-fbf6caf079a9.png)

After
![image](https://user-images.githubusercontent.com/204831/50027670-539e1080-ffed-11e8-9a31-3688c84ddc90.png)

#### Zoom 14
(This one is more subtle.)

Before
![image](https://user-images.githubusercontent.com/204831/50028147-f99e4a80-ffee-11e8-982d-01a2ae45902c.png)
![image](https://user-images.githubusercontent.com/204831/50027890-1b4b0200-ffee-11e8-8f6c-42dc6d0fdf6d.png)

After
![image](https://user-images.githubusercontent.com/204831/50028254-5863c400-ffef-11e8-92b9-99d8765e76b1.png)
![image](https://user-images.githubusercontent.com/204831/50027717-81835500-ffed-11e8-818a-0a3f66d0e1e6.png)