### PR TITLE
Nature reserve boundaries revision

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -221,34 +221,37 @@ overlapping borders correctly.
 }
 
 #nature-reserve-boundaries {
-  [way_pixels > 3000][zoom >= 8] {
-    [zoom < 10] {
+  [way_pixels > 3000] {
+    [zoom >= 8][zoom < 10] {
       ::fill {
         opacity: 0.05;
         polygon-fill: green;
       }
+      opacity: 0.2;
+      line-width: 1.2;
+      line-color: green;
+      [zoom >= 9] {
+        line-width: 1.5;
+      }
     }
-    a/line-width: 1;
-    a/line-offset: -0.5;
-    a/line-color: green;
-    a/line-opacity: 0.15;
-    a/line-join: round;
-    a/line-cap: round;
-    b/line-width: 2;
-    b/line-offset: -1;
-    b/line-color: green;
-    b/line-opacity: 0.15;
-    b/line-join: round;
-    b/line-cap: round;
     [zoom >= 10] {
-      a/line-width: 2;
-      a/line-offset: -1;
-      b/line-width: 4;
-      b/line-offset: -2;
-    }
-    [zoom >= 14] {
-      b/line-width: 6;
-      b/line-offset: -3;
+      ::wideline {
+        opacity: 0.15;
+        line-width: 4;
+        line-offset: -1;
+        line-color: green;
+        line-join: round;
+        line-cap: round;
+        [zoom >= 14] {
+          line-width: 6;
+          line-offset: -2;
+        }
+      }
+      opacity: 0.15;
+      line-width: 2;
+      line-color: green;
+      line-join: round;
+      line-cap: round;
     }
   }
 }

--- a/admin.mss
+++ b/admin.mss
@@ -227,11 +227,13 @@ overlapping borders correctly.
         opacity: 0.05;
         polygon-fill: green;
       }
-      opacity: 0.2;
-      line-width: 1.2;
-      line-color: green;
-      [zoom >= 9] {
-        line-width: 1.5;
+      ::outline {
+        opacity: 0.2;
+        line-width: 1.2;
+        line-color: green;
+        [zoom >= 9] {
+          line-width: 1.5;
+        }
       }
     }
     [zoom >= 10] {
@@ -247,11 +249,13 @@ overlapping borders correctly.
           line-offset: -2;
         }
       }
-      opacity: 0.15;
-      line-width: 2;
-      line-color: green;
-      line-join: round;
-      line-cap: round;
+      ::narrowline {
+        opacity: 0.15;
+        line-width: 2;
+        line-color: green;
+        line-join: round;
+        line-cap: round;
+      }
     }
   }
 }

--- a/admin.mss
+++ b/admin.mss
@@ -244,7 +244,7 @@ overlapping borders correctly.
         line-color: green;
         line-join: round;
         line-cap: round;
-        [zoom >= 11] {
+        [zoom >= 12] {
           line-width: 4;
           line-offset: -1;
         }
@@ -259,7 +259,7 @@ overlapping borders correctly.
         line-color: green;
         line-join: round;
         line-cap: round;
-        [zoom >= 11] {
+        [zoom >= 12] {
             line-width: 2;
         }
       }

--- a/admin.mss
+++ b/admin.mss
@@ -228,7 +228,7 @@ overlapping borders correctly.
         polygon-fill: green;
       }
       ::outline {
-        opacity: 0.2;
+        opacity: 0.25;
         line-width: 1.2;
         line-color: green;
         [zoom >= 9] {
@@ -239,11 +239,15 @@ overlapping borders correctly.
     [zoom >= 10] {
       ::wideline {
         opacity: 0.15;
-        line-width: 4;
-        line-offset: -1;
+        line-width: 3.6;
+        line-offset: -0.9;
         line-color: green;
         line-join: round;
         line-cap: round;
+        [zoom >= 11] {
+          line-width: 4;
+          line-offset: -1;
+        }
         [zoom >= 14] {
           line-width: 6;
           line-offset: -2;
@@ -251,10 +255,13 @@ overlapping borders correctly.
       }
       ::narrowline {
         opacity: 0.15;
-        line-width: 2;
+        line-width: 1.8;
         line-color: green;
         line-join: round;
         line-cap: round;
+        [zoom >= 11] {
+            line-width: 2;
+        }
       }
     }
   }


### PR DESCRIPTION
Related to #3538, #2978

Changes proposed in this pull request:
- Make nature reserve boundaries less prominent at z8 and z9
- On all zoom levels: Reduce the "glowing" effect that occurs on boundaries that are shared between two adjacent nature reserves

Test renderings of [Northern California](https://www.openstreetmap.org/#map=8/41.263/-122.574)

z8 before:
![z8osm](https://user-images.githubusercontent.com/5209216/50043955-36188780-007d-11e9-9158-96a7ec4bf12b.png)

z8 after:
![z8tuned](https://user-images.githubusercontent.com/5209216/50424607-32e47f00-0867-11e9-940a-a705a193233f.png)

z9 before:
![z9osm](https://user-images.githubusercontent.com/5209216/50043958-403a8600-007d-11e9-9e64-3ec56f802a23.png)

z9 after:
![z9tuned](https://user-images.githubusercontent.com/5209216/50424610-3b3cba00-0867-11e9-9c9f-fdc9349c4671.png)

z10 before:
![z10osm](https://user-images.githubusercontent.com/5209216/50043960-492b5780-007d-11e9-975b-ae48360adde4.png)

z10 after:
![z10tuned](https://user-images.githubusercontent.com/5209216/50424613-40016e00-0867-11e9-94cd-52adf9c30aa9.png)
