### PR TITLE
Change icon for artwork_type=bust

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -202,6 +202,9 @@
     [artwork_type = 'statue'] {
       marker-file: url('symbols/historic/statue.svg');
     }
+    [artwork_type = 'bust'] {
+      marker-file: url('symbols/historic/bust.svg');
+    }
     marker-fill: @memorials;
     marker-placement: interior;
   }


### PR DESCRIPTION
Related to #3565

Changes proposed in this pull request:
Use `bust.svg` icon for `artwork_type=bust` instead of generic artwork icon

Test rendering with links to the example places:
https://www.openstreetmap.org/node/3156678281
The upper right one is `artwork_type=sculpture`

Before
![bust_before](https://user-images.githubusercontent.com/9897203/50120167-fad0b100-0254-11e9-9b3f-60f29021b213.png)

After
![bust_after](https://user-images.githubusercontent.com/9897203/50120171-fd330b00-0254-11e9-84ce-af4d45bf4c0f.png)
