### PR TITLE
Adjust width of highway=construction rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1985,9 +1985,10 @@ Layer:
         (SELECT
             way,
             highway,
+            construction,
             name
           FROM planet_osm_line
-          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')
+          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'construction')
             AND name IS NOT NULL
         ) AS paths_text_name
     properties:

--- a/roads.mss
+++ b/roads.mss
@@ -1189,10 +1189,13 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-width: 8;
           b/line-width: 7;
           b/line-dasharray: 8,6;
-          [construction = 'secondary_link'],
-          [construction = 'tertiary_link'] {
+          [construction = 'secondary_link'] {
             line-width: @secondary-link-width-z15;
             b/line-width: @secondary-link-width-z15 - 2 * @casing-width-z15;
+          }
+          [construction = 'tertiary_link'] {
+            line-width: @tertiary-link-width-z15;
+            b/line-width: @tertiary-link-width-z15 - 2 * @casing-width-z15;
           }
         }
         [zoom >= 17] {

--- a/roads.mss
+++ b/roads.mss
@@ -1201,6 +1201,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
       }
 
+      [construction = null][zoom >= 14],
       [construction = 'residential'][zoom >= 14],
       [construction = 'unclassified'][zoom >= 14] {
         line-color: @minor-construction;
@@ -1302,7 +1303,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
       }
 
-      [construction = null][zoom >= 15],
       [construction = 'road'][zoom >= 15],
       [construction = 'raceway'][zoom >= 15] {
         line-color: @minor-construction;

--- a/roads.mss
+++ b/roads.mss
@@ -42,7 +42,7 @@
 
 @unimportant-road: @residential-casing;
 
-@residential-construction: #aaa;
+@minor-construction: #aaa;
 @service-construction: #aaa;
 
 @destination-marking: #c2e0ff;
@@ -1149,60 +1149,34 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
   ::fill {
     /*
-     * The construction rules for small roads are strange, since if construction is null its assumed that
-     * it's a more major road. The line-width = 0 could be removed by playing with the query to set a construction
-     * string for non-small roads.
-     *
-     * Also note that these rules are quite sensitive to re-ordering, since the instances end up swapping round
-     * (and then the dashes appear below the fills). See
+     * The highway_construction rules below are quite sensitive to re-ordering, since the instances end up swapping round
+     * (and then the dashes appear below the fills). See:
      * https://github.com/gravitystorm/openstreetmap-carto/issues/23
      * https://github.com/mapbox/carto/issues/235
      * https://github.com/mapbox/carto/issues/237
      */
-    [feature = 'highway_construction'] {
-      [zoom >= 12] {
-        line-width: 2;
-        line-color: #9cc;
-
+    [feature = 'highway_construction'][zoom >= 12] {
+      [construction = 'motorway'][zoom >= 12],
+      [construction = 'motorway_link'][zoom >= 13],
+      [construction = 'trunk'][zoom >= 12],
+      [construction = 'trunk_link'][zoom >= 13],
+      [construction = 'primary'][zoom >= 12],
+      [construction = 'primary_link'][zoom >= 13],
+      [construction = 'secondary'][zoom >= 12],
+      [construction = 'secondary_link'][zoom >= 13],
+      [construction = 'tertiary'][zoom >= 13],
+      [construction = 'tertiary_link'][zoom >= 14] {
         [construction = 'motorway'],
-        [construction = 'motorway_link'] {
-          line-color: @motorway-fill;
-        }
+        [construction = 'motorway_link'] { line-color: @motorway-fill; }
         [construction = 'trunk'],
-        [construction = 'trunk_link'] {
-          line-color: @trunk-fill;
-        }
+        [construction = 'trunk_link'] { line-color: @trunk-fill; }
         [construction = 'primary'],
-        [construction = 'primary_link'] {
-          line-color: @primary-fill;
-        }
+        [construction = 'primary_link'] { line-color: @primary-fill; }
         [construction = 'secondary'],
-        [construction = 'secondary_link'] {
-          line-color: @secondary-fill;
-        }
+        [construction = 'secondary_link'] { line-color: @secondary-fill; }
         [construction = 'tertiary'],
-        [construction = 'tertiary_link'],
-        [construction = 'residential'],
-        [construction = 'unclassified'],
-        [construction = 'living_street'] {
-          line-color: @residential-construction;
-          [zoom < 13] {
-            line-width: 0;
-            b/line-width: 0;
-          }
-          [zoom >= 13][zoom < 14] {
-            line-width: 3;
-            b/line-width: 2;
-            b/line-dasharray: 5,3;
-          }
-        }
-        [construction = 'service'] {
-          line-color: @service-construction;
-          [zoom < 14] {
-            line-width: 0;
-            b/line-width: 0;
-          }
-        }
+        [construction = 'tertiary_link'] { line-color: @minor-construction; }
+        line-width: 2;
         b/line-width: 2;
         b/line-dasharray: 4,2;
         b/line-color: white;
@@ -1215,24 +1189,153 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-width: 8;
           b/line-width: 7;
           b/line-dasharray: 8,6;
-        }
-        [construction = 'footway'],
-        [construction = 'cycleway'],
-        [construction = 'bridleway'],
-        [construction = 'path'],
-        [construction = 'track'],
-        [construction = 'steps']{
-          [zoom < 14] {
-            line-width: 0;
-            b/line-width: 0;
+          [construction = 'secondary_link'],
+          [construction = 'tertiary_link'] {
+            line-width: @secondary-link-width-z15;
+            b/line-width: @secondary-link-width-z15 - 2 * @casing-width-z15;
           }
-          line-color: white;
-          line-width: 3;
-          line-opacity: 0.4;
-          b/line-width: 1.2;
-          b/line-color: #69f;
-          b/line-dasharray: 2,6;
         }
+        [zoom >= 17] {
+          line-width: 8;
+          b/line-width: 7;
+        }
+      }
+
+      [construction = 'residential'][zoom >= 14],
+      [construction = 'unclassified'][zoom >= 14] {
+        line-color: @minor-construction;
+        b/line-color: white;
+        line-width: @residential-width-z14;
+        b/line-width: @residential-width-z14 - 2 * @casing-width-z13;
+        b/line-dasharray: 6,4;
+        [zoom >= 15] {
+          line-width: @residential-width-z15;
+          b/line-width: @residential-width-z15 - 2 * @casing-width-z15;
+          }
+        [zoom >= 16] {
+          line-width: @residential-width-z16;
+          b/line-width: @residential-width-z16 - 2 * @casing-width-z16;
+          b/line-dasharray: 8,6;
+        }
+        [zoom >= 17] {
+          line-width: 8;
+          b/line-width: 7;
+        }
+      }
+      [construction = 'living_street'][zoom >= 14] {
+        line-color: @minor-construction;
+        b/line-color: @living-street-fill;
+        line-width: @living-street-width-z14;
+        b/line-width: @living-street-width-z14 - 2 * @casing-width-z13;
+        b/line-dasharray: 6,4;
+        [zoom >= 15] {
+          line-width: @living-street-width-z15;
+          b/line-width: @living-street-width-z15 - 2 * @casing-width-z15;
+        }
+        [zoom >= 16] {
+          line-width: @living-street-width-z16;
+          b/line-width: @living-street-width-z16 - 2 * @casing-width-z16;
+          b/line-dasharray: 8,6;
+        }
+        [zoom >= 17] {
+          line-width: 8;
+          b/line-width: 7;
+        }
+      }
+      [construction = 'pedestrian'][zoom >= 14] {
+        line-color: @minor-construction;
+        b/line-color: @pedestrian-fill;
+        line-width: @pedestrian-width-z14;
+        b/line-width: @pedestrian-width-z14 - 2 * @casing-width-z13;
+        b/line-dasharray: 6,4;
+        [zoom >= 15] {
+          line-width: @pedestrian-width-z15;
+          b/line-width: @pedestrian-width-z15 - 2 * @casing-width-z15;
+        }
+        [zoom >= 16] {
+          line-width: @pedestrian-width-z16;
+          b/line-width: @pedestrian-width-z16 - 2 * @casing-width-z16;
+          b/line-dasharray: 8,6;
+        }
+        [zoom >= 17] {
+          line-width: 8;
+          b/line-width: 7;
+        }
+      }
+
+      [construction = 'service'] {
+        [zoom >= 15][service = 'INT-normal'],
+        [zoom >= 17][service = 'INT-minor'] {
+          line-color: @minor-construction;
+          b/line-color: white;
+          b/line-dasharray: 6,4;
+          [service = 'INT-normal'] {
+            line-width: @service-width-z14;
+            b/line-width: @service-width-z14;
+            [zoom >= 16] {
+              line-width: @service-width-z16;
+              b/line-width: @service-width-z16 - 2 * @casing-width-z16;
+              b/line-dasharray: 8,6;
+            }
+            [zoom >= 17] {
+              line-width: @service-width-z17;
+              b/line-width: @service-width-z17 - 2 * @casing-width-z17;
+            }
+            [zoom >= 18] {
+              line-width: 8;
+              b/line-width: 7
+            }
+          }
+          [service = 'INT-minor'] {
+            line-width: @minor-service-width-z17;
+            b/line-width: @minor-service-width-z17 - 2 * @casing-width-z17;
+            b/line-dasharray: 8,6;
+            [zoom >= 18] {
+              line-width: @minor-service-width-z18;
+              b/line-width: @minor-service-width-z18 - 2 * @casing-width-z18;
+            }
+            [zoom >= 19] {
+              line-width: @minor-service-width-z19 - 2 * @casing-width-z19;
+              b/line-width: @minor-service-width-z19 - 4 * @casing-width-z19;
+            }
+          }
+        }
+      }
+
+      [construction = null][zoom >= 15],
+      [construction = 'road'][zoom >= 15],
+      [construction = 'raceway'][zoom >= 15] {
+        line-color: @minor-construction;
+        b/line-color: @road-fill;
+        line-width: @road-width-z14;
+        b/line-width: @road-width-z14;
+        b/line-dasharray: 6,4;
+        [zoom >= 16] {
+          line-width: @road-width-z16;
+          b/line-width: @road-width-z16 - 2 * @casing-width-z16;
+          b/line-dasharray: 8,6;
+        }
+        [zoom >= 17] {
+          line-width: @road-width-z17;
+          b/line-width: @road-width-z17 - 2 * @casing-width-z17;
+        }
+        [zoom >= 18] {
+          line-width: 8;
+          b/line-width: 7;
+        }
+      }
+      [construction = 'footway'][zoom >= 15],
+      [construction = 'cycleway'][zoom >= 15],
+      [construction = 'bridleway'][zoom >= 15],
+      [construction = 'path'][zoom >= 15],
+      [construction = 'track'][zoom >= 15],
+      [construction = 'steps'][zoom >= 15] {
+        line-color: white;
+        line-width: 3;
+        line-opacity: 0.4;
+        b/line-width: 1.2;
+        b/line-color: @minor-construction;
+        b/line-dasharray: 2,6;
       }
     }
 
@@ -3046,6 +3149,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'residential'],
   [highway = 'unclassified'],
   [highway = 'road'],
+  [highway = 'construction'][construction = null],
   [highway = 'construction'][construction = 'residential'],
   [highway = 'construction'][construction = 'unclassified'],
   [highway = 'construction'][construction = 'road'] {
@@ -3078,7 +3182,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'raceway'],
   [highway = 'service'],
   [highway = 'construction'][construction = 'raceway'],
-  [highway = 'construction'][construction = 'service'] {
+  [highway = 'construction'][construction = 'service'][zoom >= 17] {
     [zoom >= 16] {
       text-name: "[name]";
       text-size: 9;
@@ -3099,8 +3203,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
   [highway = 'living_street'],
   [highway = 'pedestrian'],
-  [highway = 'construction'][construction = 'living_street'],
-  [highway = 'construction'][construction = 'pedestrian'] {
+  [highway = 'construction'][construction = 'living_street'][zoom >= 16],
+  [highway = 'construction'][construction = 'pedestrian'][zoom >= 16] {
     [zoom >= 15] {
       text-name: "[name]";
       text-size: 8;
@@ -3142,7 +3246,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #paths-text-name {
-  [highway = 'track'] {
+  [highway = 'track'],
+  [highway = 'construction'][construction = 'track'][zoom >= 16] {
     [zoom >= 15] {
       text-name: "[name]";
       text-fill: #222;
@@ -3171,7 +3276,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [highway = 'footway'],
   [highway = 'cycleway'],
   [highway = 'path'],
-  [highway = 'steps'] {
+  [highway = 'steps'],
+  [highway = 'construction'][construction = 'bridleway'],
+  [highway = 'construction'][construction = 'footway'],
+  [highway = 'construction'][construction = 'cycleway'],
+  [highway = 'construction'][construction = 'path'],
+  [highway = 'construction'][construction = 'steps'] {
     [zoom >= 16] {
       text-name: "[name]";
       text-fill: #222;


### PR DESCRIPTION
Fixes #2595

**Changes proposed in this pull request:**

- Stop rendering undocumented construction=* types
- Specifically render raceway, pedestrian, living_street, road as types of other construction roads
- Render minor construction=* types later
- Reduce width for narrow highway=construction, to match finished road times (or narrower)
- Add paths, track and null construction name label rendering
- Change color of construction=null and construction=path/track to #aaa, medium gray (same as minor highway=construction)

**Explanation:**
There are several issues with the current highway=construction rendering. This PR addresses several:
1. Highways under construction (construction=*) should be no wider than their finished counterparts (highway=*) on a given zoom level.
2. Highway=construction with construction=null or =road and =track, =footway, etc currently render with a dark blue-gray color, which can look quite similar to an intermittent stream or river
3. Highway=construction with construction=road, =pedestrian, =living_street and =raceway currently render starting at z12. 
- In fact, all highway=construction without construction=* are rendering at this level, and all unspecified values of construction=* get rendered at z12".
4. Name labels are not rendered for construction=track/path/<null>

There are several issues that this PR does not address, which will be discussed in #3579

I previously attempted to match the width of all roads at all zoom levels to their construction=* counterpart. However, the wider major roads at low zoom levels do not look right. Extensive adjustments would be needed to the dash pattern length, casing, and layering. 

Dashed white and colored lines are quite prominent. This is problem is reduced currently, because highway=construction is rendered much narrower than major highways. Highway=construction does not follow proper layering order. Link roads (eg construction=motorway_link) can render on top of construction=motorway, and minor highways sometimes render on to of major highways. The layering order will sometimes reverse between different zoom levels. This is much more apparent if the roads are significantly wider.

These issues would need to be addressed before trying to match the width to wider roads at high zoom levels. But I believe this PR is a good start.

**Test rendering:**

**z12** Before
![z12-construction-master](https://user-images.githubusercontent.com/42757252/50202594-f36aee00-03a1-11e9-830e-0cb002a983c6.png)

After
![z12-construction-after](https://user-images.githubusercontent.com/42757252/50202597-f665de80-03a1-11e9-9821-8baf78e9bf0f.png)

**z13**
Before
![z13-construction-master](https://user-images.githubusercontent.com/42757252/50202603-fc5bbf80-03a1-11e9-9c86-9f253db59a0d.png)
After
![z13-construction-after](https://user-images.githubusercontent.com/42757252/50202627-11d0e980-03a2-11e9-832e-36368f75f138.png)

**z14** Before
![z14-construction-master](https://user-images.githubusercontent.com/42757252/50202619-08478180-03a2-11e9-9462-49039ddf53df.png)
After
![z14-construction-after](https://user-images.githubusercontent.com/42757252/50202641-1ac1bb00-03a2-11e9-8831-af18d63118b5.png)

**z15** Before
![z15-construction-master](https://user-images.githubusercontent.com/42757252/50202659-21e8c900-03a2-11e9-9cf0-a653377c6d41.png)
After
![z15-construction-after](https://user-images.githubusercontent.com/42757252/50202670-2a410400-03a2-11e9-961a-fcd211a4a589.png)

**z16** Before
![z16-construction-master](https://user-images.githubusercontent.com/42757252/50202680-35942f80-03a2-11e9-876a-1f8aac1f64fd.png)
After
![z16-construction-after](https://user-images.githubusercontent.com/42757252/50202686-3b8a1080-03a2-11e9-8d06-c5996ad47e44.png)

**z17** Before
![z17-construction-master](https://user-images.githubusercontent.com/42757252/50202702-4775d280-03a2-11e9-9449-829c004781e4.png)
After
![z17-construction-after](https://user-images.githubusercontent.com/42757252/50202705-4c3a8680-03a2-11e9-8bd9-1d90dfed3024.png)

**Link roads z16** before
![z16-construction-link-master](https://user-images.githubusercontent.com/42757252/50202726-59f00c00-03a2-11e9-90a9-050b02482d92.png)
After
![z16-construction-links-after](https://user-images.githubusercontent.com/42757252/50202735-5fe5ed00-03a2-11e9-8b3d-5c93314ca4d6.png)
- construction=secondary_link is now slightly narrower at this zoom level, to match the finished road.