### PR TITLE
Change tourism outline color

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2413,7 +2413,7 @@
         text-face-name: @bold-fonts; /*rendered bold to improve visibility since theme parks tend to have crowded backgrounds*/
       }
       [feature = 'tourism_attraction'] {
-        text-fill: #660033;
+        text-fill: @tourism;
         text-face-name: @standard-font;
       }
       [feature = 'amenity_kindergarten'],

--- a/landcover.mss
+++ b/landcover.mss
@@ -51,7 +51,7 @@
 @power-line: darken(@industrial-line, 5%);
 @sand: #f5e9c6;
 @societal_amenities: #ffffe5;   // Lch(99,13,109)
-@tourism: #734a08;
+@tourism: #660033;
 @quarry: #c5c3c3;
 @military: #f55;
 @beach: #fff1ba;


### PR DESCRIPTION
Related to #3045 "Outline Coordination Meta Issue"
and #3521 "Add Aboriginal Areas"

Changes proposed in this pull request:
- Change tourism color from brown to `#660033` - this is currently the tourism=attraction text color

**Explanation:**
In #3521 it is planned to use brown for boundary=aboriginal_lands (eg American Indian reservations)
Therefore it is necessary to change the color of the outline used for zoos and theme parks.
This has also been desired, so that these tourist areas would be more visible on the map with a color more closely related to retail areas and other points of interest. The proposed change will also unify the color used for these two features with that used for tourism=attraction.

Purple and orange have also been discussed. Purple would work well, but would be more similar to the current administrative boundary rendering. Orange is another option.

Test renderings:

**Singapore zoos**
https://www.openstreetmap.org/#map=13/1.3950/103.8424
z17 Before
![z17-singapore-zoo-master](https://user-images.githubusercontent.com/42757252/50271007-bf153180-0476-11e9-9e8a-694c8559d1c0.png)
z17 After
- Attractions within the zoom now are shown in the same color
- I plan a PR to add generic icons (dots) for tourism=attraction
![z17-singapore-zoo-660033](https://user-images.githubusercontent.com/42757252/50271011-c2a8b880-0476-11e9-9f12-7787e6848c02.png)

z14 Before
- Can compare to military areas here
![z14-singapore-zoo-master](https://user-images.githubusercontent.com/42757252/50271014-c8060300-0476-11e9-8c66-2c83578bca9b.png)
z14 After
![z14-singapore-zoo-660033](https://user-images.githubusercontent.com/42757252/50271033-d2280180-0476-11e9-9ef3-8a7ef89ae642.png)

z13 Before
- Compare to the international administrative boundary at this level (top of image)
- Could we show zoos/theme parks with slightly smaller way_pixels at this zoom level?
![z13-zoos-master](https://user-images.githubusercontent.com/42757252/50271037-d5bb8880-0476-11e9-8e75-9201ce3a6d8f.png)
z13 After
![z13-zoos-660033](https://user-images.githubusercontent.com/42757252/50271045-d8b67900-0476-11e9-89dd-a6d0b940a906.png)

**Universal Studios Singapore**
- The boundaries are hard to see in both the before and after, because the area has been (mis)-tagged with leisure=recreation_ground in addition to tourism=theme_park
https://www.openstreetmap.org/#map=16/1.2546/103.8293
z16 before
![z16-universal-studios-master](https://user-images.githubusercontent.com/42757252/50271061-e3710e00-0476-11e9-9e34-f9f8661d2f23.png)
z16 after
![z16-universal-studios-660033](https://user-images.githubusercontent.com/42757252/50271067-e9ff8580-0476-11e9-8b0f-debe1d4fb662.png)

z17 before
![z17-universal-studios-master](https://user-images.githubusercontent.com/42757252/50271070-ee2ba300-0476-11e9-892a-c52347363a68.png)
z17 after
![z17-universal-studios-660033](https://user-images.githubusercontent.com/42757252/50271079-f1269380-0476-11e9-803e-05cf759646f6.png)

**Jurong Bird Park, Singapore**
- Near industrial and commercial landuse
https://www.openstreetmap.org/#map=15/1.3205/103.7153
z15 before
![z15-jurong-bird-master](https://user-images.githubusercontent.com/42757252/50271085-f552b100-0476-11e9-8009-4018bbffaae0.png)
z15 after
![z15-jurong-660033](https://user-images.githubusercontent.com/42757252/50271089-f97ece80-0476-11e9-929a-e3fba0379700.png)