### PR TITLE
Change certain amenity icons to grey

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -49,7 +49,7 @@
       marker-file: url('symbols/tourism/alpinehut.svg');
     }
     [feature = 'amenity_shelter'] {
-      marker-fill: @amenity-brown;
+      marker-fill: @man-made-icon;
     }
     marker-fill: @accommodation-icon;
     marker-placement: interior;
@@ -1427,7 +1427,7 @@
 
   [feature = 'leisure_picnic_table'][zoom >= 17] {
     marker-file: url('symbols/tourism/picnic.svg');
-    marker-fill: @amenity-brown;
+    marker-fill: @man-made-icon;
     marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
@@ -1615,7 +1615,7 @@
     [access = 'permissive'],
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
-      marker-fill: @amenity-brown;
+      marker-fill: @man-made-icon;
       marker-placement: interior;
     }
   }
@@ -1712,7 +1712,7 @@
 
   [feature = 'amenity_bench'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/bench.svg');
-    marker-fill: @amenity-brown;
+    marker-fill: @man-made-icon;
     marker-placement: interior;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1721,7 +1721,7 @@
 
   [feature = 'amenity_waste_basket'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/waste_basket.svg');
-    marker-fill: @amenity-brown;
+    marker-fill: @man-made-icon;
     marker-placement: interior;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1734,7 +1734,7 @@
     [access = 'permissive'],
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
-      marker-fill: @amenity-brown;
+      marker-fill: @man-made-icon;
       marker-placement: interior;
     }
   }
@@ -1949,8 +1949,7 @@
   [feature = 'amenity_bicycle_repair_station'][zoom >= 19],
   [feature = 'amenity_drinking_water'][zoom >= 17],
   [feature = 'amenity_shower'][zoom >= 18],
-  [feature = 'tourism_picnic_site'][zoom >= 17],
-  [feature = 'leisure_picnic_table'][zoom >= 17] {
+  [feature = 'tourism_picnic_site'][zoom >= 17] {
     text-name: "[name]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
@@ -2571,6 +2570,7 @@
   
   [feature = 'tourism_alpine_hut'][zoom >= 14],
   [feature = 'amenity_shelter'][zoom >= 17],
+  [feature = 'leisure_picnic_table'][zoom >= 17],
   [feature = 'tourism_hotel'][zoom >= 17],
   [feature = 'tourism_motel'][zoom >= 17],
   [feature = 'tourism_hostel'][zoom >= 17],
@@ -2597,8 +2597,9 @@
     [feature = 'tourism_caravan_site'] {
       text-dy: 15;
     }
+    [feature = 'leisure_picnic_table'][zoom >= 17],
     [feature = 'amenity_shelter'] {
-      text-fill: @amenity-brown;
+      text-fill: @man-made-icon;
     }
     [access != ''][access != 'permissive'][access != 'yes'] {
       text-opacity: 0.33;


### PR DESCRIPTION
This PR changes certain amenity icons that are passive to grey in order to help off load things color with amenity brown a little and to reflect the fact that they aren't "services." Included in the PR is bench, picnic table, waste basket, shelter, and waste disposal. Not included in the PR is things related to recycling. Which will be changed in a separate PR. The PR is related to PR #3402 and issue #3326. 

bench, waste basket, picnic table
https://www.openstreetmap.org/#map=19/40.68154/-122.36317 (node)
![bench waste basket picnic table](https://user-images.githubusercontent.com/30259065/50363965-f17c6880-0522-11e9-8ca0-993092a546de.png)
shelter
https://www.openstreetmap.org/#map=19/37.79619/-122.42138 (node)
![shelter node](https://user-images.githubusercontent.com/30259065/50364030-2a1c4200-0523-11e9-9deb-05872f7a7ef8.png)
https://www.openstreetmap.org/#map=19/40.58366/-122.39271 (way)
waste disposal
https://www.openstreetmap.org/#map=19/37.48214/-122.22696 (node)
![waste disposal node](https://user-images.githubusercontent.com/30259065/50363979-fd682a80-0522-11e9-8b8f-8fb41eb5c878.png)
https://www.openstreetmap.org/#map=19/37.49039/-122.22382 (way)
![waste disposal way](https://user-images.githubusercontent.com/30259065/50363998-09ec8300-0523-11e9-8846-e76b4dd644d6.png)