### PR TITLE
[Ready for Review] Change @placenames-light color 

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -1,5 +1,5 @@
 @placenames: #222;
-@placenames-light: #777777;
+@placenames-light: #4d4d4d;
 @country-labels: darken(@admin-boundaries, 15%);
 @state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
 


### PR DESCRIPTION
This PR changes the @placenames-light color from `#777777` to `#404040`, because the original color was to light. Closes #3537.
[Rzeszow](https://www.openstreetmap.org/#map=14/50.0353/22.0072)
Rzeszow before
![rzeszow 404040 before](https://user-images.githubusercontent.com/30259065/50380839-4656d680-062a-11e9-9128-60d36a3ee426.png)
Rzeszow after
![rzeszow 404040 after](https://user-images.githubusercontent.com/30259065/50380840-4f47a800-062a-11e9-98f0-3f63f3c25f46.png)
[Poznan](https://www.openstreetmap.org/#map=15/52.3856/16.9564)
Poznan before 
![poznan 404040 before](https://user-images.githubusercontent.com/30259065/50380842-58d11000-062a-11e9-99b3-02154efcfc28.png)
Poznan after
![poznan 404040 after](https://user-images.githubusercontent.com/30259065/50380850-6090b480-062a-11e9-8790-3836fb193d8d.png)
[Gdansk](https://www.openstreetmap.org/#map=14/54.3477/18.6205)
Gdansk before 
![gdansk 404040 before](https://user-images.githubusercontent.com/30259065/50380852-74d4b180-062a-11e9-9387-bfdaaa86c5a7.png)
Gdansk after
![gdansk 404040 after](https://user-images.githubusercontent.com/30259065/50380853-7f8f4680-062a-11e9-8ea5-c0d05bfa708a.png)
[Location](https://www.openstreetmap.org//#map=15/52.4734/20.4740)
Location 4 before
![location 4 404040 before](https://user-images.githubusercontent.com/30259065/50380855-8f0e8f80-062a-11e9-85fd-6f36ac1cd903.png)
Location 4 after
![location 4 404040 after](https://user-images.githubusercontent.com/30259065/50380865-9f266f00-062a-11e9-8ce9-3663d4d8ac08.png)
