### PR TITLE
Fix inconsistency of leisure=ice_rink

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -269,7 +269,7 @@
   }
 
   [feature = 'leisure_ice_rink'][is_building = 'no'] {
-    [zoom >= 10][way_pixels > 3000] {
+    [zoom >= 10] {
       polygon-fill: @glacier;
       line-width: 0.5;
       line-color: saturate(darken(@pitch, 30%), 20%);


### PR DESCRIPTION
Fixes #3597

Changes proposed in this pull request:
remove variable `[way_pixels > 3000]` to allow correct display of `leisure=ice_rink` from z10

Test rendering with links to the example places:
https://www.openstreetmap.org/way/87188308
Before
![icerink_2_z17](https://user-images.githubusercontent.com/9897203/50451543-01d28000-0935-11e9-9ff6-c70d9ea62fea.png)
After
![icerink_2_z17_after](https://user-images.githubusercontent.com/9897203/50452626-81fbe400-093b-11e9-9bf7-c5811e8cc95a.png)
