### PR TITLE
Reduce priority of tourism=attraction and render from z17

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1728,13 +1728,6 @@
     }
   }
 
-  [feature = 'tourism_attraction'][zoom >= 17] {
-    marker-width: 4;
-    marker-line-width: 0;
-    marker-fill: @tourism;
-    marker-placement: interior;
-  }
-
   // waste_disposal tagging on nodes - tagging on ways is defined earlier
   [feature = 'amenity_waste_disposal'][zoom >= 19]::amenity {
     [access = null],
@@ -3234,7 +3227,6 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-dy: 6;
     text-fill: @tourism;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1728,6 +1728,13 @@
     }
   }
 
+  [feature = 'tourism_attraction'][zoom >= 17] {
+    marker-width: 4;
+    marker-line-width: 0;
+    marker-fill: @tourism;
+    marker-placement: interior;
+  }
+
   // waste_disposal tagging on nodes - tagging on ways is defined earlier
   [feature = 'amenity_waste_disposal'][zoom >= 19]::amenity {
     [access = null],
@@ -2362,7 +2369,6 @@
   [feature = 'landuse_construction'],
   [feature = 'tourism_theme_park'],
   [feature = 'tourism_zoo'],
-  [feature = 'tourism_attraction'],
   [feature = 'amenity_kindergarten'],
   [feature = 'amenity_school'],
   [feature = 'amenity_college'],
@@ -2474,10 +2480,6 @@
       [feature = 'tourism_zoo'] {
         text-fill: @tourism;
         text-face-name: @bold-fonts; /*rendered bold to improve visibility since theme parks tend to have crowded backgrounds*/
-      }
-      [feature = 'tourism_attraction'] {
-        text-fill: @tourism;
-        text-face-name: @standard-font;
       }
       [feature = 'amenity_kindergarten'],
       [feature = 'amenity_school'],
@@ -3225,6 +3227,19 @@
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;
+  }
+
+  [feature = 'tourism_attraction'][zoom >= 17][is_building = 'no'] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-dy: 6;
+    text-fill: @tourism;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+    text-face-name: @standard-font;
   }
 }
 

--- a/project.mml
+++ b/project.mml
@@ -2317,9 +2317,9 @@ Layer:
                   'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator') THEN highway ELSE NULL END,
                   'boundary_' || CASE WHEN boundary IN ('national_park') THEN boundary ELSE NULL END,
                   'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
-                  'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
                   'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-                  'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END
+                  'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END,
+                  'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END
                 ) AS feature,
                 access,
                 name,
@@ -2547,10 +2547,11 @@ Layer:
                             'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END,
+              'tourism_' || CASE WHEN tourism IN ('attraction') THEN tourism ELSE NULL END
             )  AS feature,
             access,
-            CASE WHEN amenity IN ('waste_basket', 'waste_disposal') THEN 2 ELSE 1 END AS prio
+            CASE WHEN amenity IN ('waste_basket', 'waste_disposal') OR tourism IN ('attraction') THEN 2 ELSE 1 END AS prio
           FROM planet_osm_point p
           WHERE highway IN ('mini_roundabout')
              OR railway IN ('level_crossing', 'crossing')
@@ -2558,6 +2559,7 @@ Layer:
              OR historic IN ('wayside_cross', 'wayside_shrine')
              OR man_made IN ('cross')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile')
+             OR tourism IN ('attraction')
           ORDER BY prio
           ) AS amenity_low_priority
     properties:
@@ -2573,12 +2575,14 @@ Layer:
             way,
             COALESCE(
               'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END,
+              'tourism_' || CASE WHEN tourism IN ('attraction') THEN tourism ELSE NULL END
             )  AS feature,
             access
           FROM planet_osm_polygon p
           WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile')
+             OR tourism IN ('attraction')
           ) AS amenity_low_priority_poly
     properties:
       minzoom: 14

--- a/project.mml
+++ b/project.mml
@@ -2547,11 +2547,10 @@ Layer:
                             'waste_basket', 'waste_disposal') THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') THEN man_made ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END,
-              'tourism_' || CASE WHEN tourism IN ('attraction') THEN tourism ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END
             )  AS feature,
             access,
-            CASE WHEN amenity IN ('waste_basket', 'waste_disposal') OR tourism IN ('attraction') THEN 2 ELSE 1 END AS prio
+            CASE WHEN amenity IN ('waste_basket', 'waste_disposal') THEN 2 ELSE 1 END AS prio
           FROM planet_osm_point p
           WHERE highway IN ('mini_roundabout')
              OR railway IN ('level_crossing', 'crossing')
@@ -2559,7 +2558,6 @@ Layer:
              OR historic IN ('wayside_cross', 'wayside_shrine')
              OR man_made IN ('cross')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile')
-             OR tourism IN ('attraction')
           ORDER BY prio
           ) AS amenity_low_priority
     properties:
@@ -2575,14 +2573,12 @@ Layer:
             way,
             COALESCE(
               'amenity_' || CASE WHEN amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END,
-              'tourism_' || CASE WHEN tourism IN ('attraction') THEN tourism ELSE NULL END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile') THEN barrier ELSE NULL END
             )  AS feature,
             access
           FROM planet_osm_polygon p
           WHERE amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking')
              OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile')
-             OR tourism IN ('attraction')
           ) AS amenity_low_priority_poly
     properties:
       minzoom: 14


### PR DESCRIPTION
Fixes #3545
Related to https://github.com/gravitystorm/openstreetmap-carto/pull/1063#issuecomment-67853592

Changes proposed in this pull request:
- Add generic "dot" icon for tourism=attraction
- Render tourism=attraction only at z17 and above
- Move tourism=attraction to low-priority label, after other features, so that it will only render if there is no other more specific tag (this fixes #3545 "tourism=attraction stops man_made=cross from rendering")
- Change text to standard font, render text and dot in tourism color ( `#660033` now)

Explanation:
- Features tagged tourism=attraction will currently render earlier than z17 if tagged on a large area (closed way or multi polygon), however there is no area fill or icon
- Area rendering was previously rejected in #1257 "Add area rendering for tourism=attraction"
- This PR will add a generic icon (a small circle) to show the location of the node or center of the area
- Large areas will no longer get a label before z17, because this invites misuse of the tag to get a text label to render on features that would otherwise not be rendered
- Generally we should avoid showing text name labels without an icon, outline or area fill, because this can lead to mistagging for rendering. This is particularly prone to vandalism when it can be used to render text at very early zoom levels (eg before z15)
- The feature is moved to the low-priority layer, and last in the SQL query, so that it will only be rendered if it is the only tag on the feature. This fixes a problem where wayside crosses and man_made=cross that are also tagged tourism=attraction do not render properly.

Test rendering with links to the example places:

**Singapore zoos**
http://openstreetmap.org/#map=16/1.4034/103.7966
z16 - unchanged before/after
![z16-zoos-after](https://user-images.githubusercontent.com/42757252/50468377-df02a300-09ea-11e9-9ca6-1d29ad1c8508.png)
z17 Before
![z17-singapore-zoo-660033](https://user-images.githubusercontent.com/42757252/50271011-c2a8b880-0476-11e9-9f12-7787e6848c02.png)
z17 After
![z17-zoo-after](https://user-images.githubusercontent.com/42757252/50468389-f3df3680-09ea-11e9-9701-240ceffb443f.png)

**Universal Studios and Kidzania**
http://openstreetmap.org/#map=17/1.25438/103.82532
z17 before
![z17-universal-studios-660033](https://user-images.githubusercontent.com/42757252/50468430-1ffab780-09eb-11e9-9cae-4f4ceaaf640f.png)
z17 after
![z17-universal-kidzania-after](https://user-images.githubusercontent.com/42757252/50468435-25f09880-09eb-11e9-8cad-4d82c58f79d7.png)