### PR TITLE
Start rendering most patterns at z13 instead of z14

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -146,7 +146,7 @@
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [zoom >= 14] {
+    [zoom >= 13] {
       polygon-pattern-file: url('symbols/vineyard.png');
       polygon-pattern-alignment: global;
       [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
@@ -160,7 +160,7 @@
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [zoom >= 14] {
+    [zoom >= 13] {
       polygon-pattern-file: url('symbols/orchard.png');
       polygon-pattern-alignment: global;
       [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
@@ -174,7 +174,7 @@
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [zoom >= 14] {
+    [zoom >= 13] {
       polygon-pattern-file: url('symbols/plant_nursery.png');
       polygon-pattern-opacity: 0.6;
       polygon-pattern-alignment: global;
@@ -189,7 +189,7 @@
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [zoom >= 14] {
+    [zoom >= 13] {
       polygon-pattern-file: url('symbols/plant_nursery.png');
       polygon-pattern-alignment: global;
       [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
@@ -204,7 +204,7 @@
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [zoom >= 14] {
+    [zoom >= 13] {
       [religion = 'jewish'] { polygon-pattern-file: url('symbols/grave_yard_jewish.svg'); }
       [religion = 'christian'] { polygon-pattern-file: url('symbols/grave_yard_christian.svg'); }
       [religion = 'muslim'] { polygon-pattern-file: url('symbols/grave_yard_muslim.svg'); }
@@ -721,7 +721,7 @@
     polygon-pattern-file: url('symbols/reef.png');
     polygon-pattern-alignment: global;
   }
-  [zoom >= 14] {
+  [zoom >= 13] {
     [int_wetland = 'marsh'],
     [int_wetland = 'saltmarsh'],
     [int_wetland = 'wet_meadow'] {


### PR DESCRIPTION
Fixes #3593

### Changes proposed in this pull request:

**Render the polygon fill pattern at z13 and above, instead of z14 and above, for the following areas:**

1. vineyard
2. orchard
3. garden
4. plant_nursery
5. cemetery / graveyard
6. scrub
7. beach, shoal (`beach`)
- _gravel, fine_gravel, pebbles, pebblestone, shingle, stones, shells_ (`beach_coarse`)
8. Specific wetland patterns, i.e.:
- _marsh, saltmarsh, wet_meadow_ (`wetland_marsh`)
- _reedbed_ (`wetland_reed`)
- _mangrove_ (`wetland_mangrove`)
- _swamp_ (`wetland_swamp`)
- _bog, fen, string_bog_ (`wetland_bog`)

**Unchanged:**
1. Allotments have recently begun to render the pattern from z13 instead of z14
2. Leisure=dog_park has a pattern at >= z16. This has an open issue, and has not been changed.
3. Some other patterns already render sooner: 
 - Forest/wood already renders at `>= z13`
 - landuse=quarry at `>=z10`
 - shingle, scree, bare_rock and glacier already render at `>= z5`

### Test renderings with links to the example places:
- Also see additional renderings in issue #3593

Magdalena - Vineyards, large to the south, smaller northeast of the town
https://www.openstreetmap.org/#map=13/38.5111/-28.4603
z13 before
![z13-magdalena-master](https://user-images.githubusercontent.com/42757252/50503816-eee2bb80-0aac-11e9-8ea1-b932ab12f7d8.png)
After
![z13-magdalena-patterns](https://user-images.githubusercontent.com/42757252/50503818-f1451580-0aac-11e9-80c2-4f39c68d2a10.png)

Monte Escuro - large area of scrub to the south, smaller orchards in the northeast (near Sâo Brás)
https://www.openstreetmap.org/#map=13/37.7890/-25.3962
z13 before
![z13-escuro-master](https://user-images.githubusercontent.com/42757252/50503828-fdc96e00-0aac-11e9-8960-be3cacfdf345.png)
After
![z13-monte-escuro-patterns](https://user-images.githubusercontent.com/42757252/50503830-04f07c00-0aad-11e9-8a44-1b192dc1a215.png)

Gellilydan, Wales - scrub, marsh and bog
https://www.openstreetmap.org/#map=13/52.9349/-3.9033
z13 before
![z13-gellilydan-master](https://user-images.githubusercontent.com/42757252/50504237-85b07780-0aaf-11e9-813b-9c000152a874.png)
After
![z13-gellilydan-after](https://user-images.githubusercontent.com/42757252/50504462-23f10d00-0ab1-11e9-98db-2eccca8a062f.png)

Gronant - beaches, wetland, cemetery, scrub
https://www.openstreetmap.org/#map=13/53.3439/-3.3186
z13 before
![z13-gronant-master](https://user-images.githubusercontent.com/42757252/50504238-85b07780-0aaf-11e9-8d9f-6fbccec6011a.png)
After
![z13-gronant-after](https://user-images.githubusercontent.com/42757252/50504624-34ee4e00-0ab2-11e9-8c05-9b3237716339.png)

Mangroves:
https://www.openstreetmap.org/#map=12/-5.1675/137.7358
z13 before
![z13-mangroves-master](https://user-images.githubusercontent.com/42757252/50505500-556cd700-0ab7-11e9-8fa1-21b0e4b8c103.png)
After
![z13-mangroves-after](https://user-images.githubusercontent.com/42757252/50505502-57cf3100-0ab7-11e9-99ce-30caa7032e1b.png)

Great Cypress Swamp, Delaware: - swamp
https://www.openstreetmap.org/#map=13/38.4833/-75.2247
z13 before
![z13-cypress-swamp-before](https://user-images.githubusercontent.com/42757252/50522460-6b59b680-0b0e-11e9-8905-f1d1f07ddb37.png)
After
![z13-cypress-swamp-after](https://user-images.githubusercontent.com/42757252/50522464-6eed3d80-0b0e-11e9-8058-7404eebcc9e4.png)

Cape Henlopen, Delaware - marshes, also beach and scrub pattern visible
https://www.openstreetmap.org/#map=13/38.7707/-75.0920
z13 before
![z13-cape-henlopen-before](https://user-images.githubusercontent.com/42757252/50522456-672d9900-0b0e-11e9-8026-651f0076ba39.png)
After
![z13-cape-henlopen-after](https://user-images.githubusercontent.com/42757252/50522455-6563d580-0b0e-11e9-86de-aacd8ad9ba49.png)

All Saint's Cemetery, Pike Creek, Delaware:
https://www.openstreetmap.org/#map=13/39.7096/-75.6226
z13 Before
![z13-drummond-cemetery-before](https://user-images.githubusercontent.com/42757252/50531224-edb39c00-0b49-11e9-8bd5-321fb7291d77.png)
After
![z13-drummond-cemetery-after](https://user-images.githubusercontent.com/42757252/50531226-eee4c900-0b49-11e9-962c-4ffa9c265778.png)