### PR TITLE
Render parking at z14 and greater

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -612,9 +612,9 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_parking'][way_pixels > 900],
-  [feature = 'amenity_bicycle_parking'][way_pixels > 900],
-  [feature = 'amenity_motorcycle_parking'][way_pixels > 900],
+  [feature = 'amenity_parking'][way_pixels > 900][zoom >= 14],
+  [feature = 'amenity_bicycle_parking'][way_pixels > 900][zoom >= 14],
+  [feature = 'amenity_motorcycle_parking'][way_pixels > 900][zoom >= 14],
   [feature = 'amenity_parking_entrance'][zoom >= 18] {
     [feature = 'amenity_parking'] {
       marker-file: url('symbols/amenity/parking.svg');

--- a/landcover.mss
+++ b/landcover.mss
@@ -603,17 +603,19 @@
     }
   }
 
-  [feature = 'amenity_parking'][zoom >= 10],
-  [feature = 'amenity_bicycle_parking'][zoom >= 10],
-  [feature = 'amenity_motorcycle_parking'][zoom >= 10],
-  [feature = 'amenity_taxi'][zoom >= 10] {
-    polygon-fill: @parking;
-    [zoom >= 15] {
-      line-width: 0.3;
-      line-color: @parking-outline;
+  [feature = 'amenity_parking'],
+  [feature = 'amenity_bicycle_parking'],
+  [feature = 'amenity_motorcycle_parking'],
+  [feature = 'amenity_taxi'] {
+    [zoom >= 14] {
+      polygon-fill: @parking;
+      [zoom >= 15] {
+        line-width: 0.3;
+        line-color: @parking-outline;
+      }
+      [way_pixels >= 4]  { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
-    [way_pixels >= 4]  { polygon-gamma: 0.75; }
-    [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
   [feature = 'amenity_parking_space'][zoom >= 18] {


### PR DESCRIPTION
### Changes proposed in this pull request:
- Render parking at z14 and above only
(No longer render parking lots at z10 to z13)

### Explanation:
- Parking lots currently render as soon as z10, and the icon is rendered as soon as the way_pixels (height x width) is greater than 900 (eg 30 pixels wind and high), without consideration of zoom level
- However, very few parking lots are large enough to have an icon at z13 (I have yet to find one), and generally only the fill color is visible
- The fill color for parking is nearly the same as the background land-color, or the color of untagged land, so parking lots are only visible at z13 and lower when they are surrounded by other land uses or natural areas, and they then appear as a "hole" in the landuse or other area.
- This is a particular problem in the USA, where many town centers have more than 50% of the land covered in parking lots, thus obscuring most of the retail or commercial area.
- By stopping rendering parking lots at z10 to z13, it will be easier to see the correct outline of retail, commercial and industrial areas at z13, and developed land in general at z12 and below. 

### Test renderings with links to the example places:

**Kahului, Hawaii**
https://www.openstreetmap.org/#map=13/20.9042/-156.4423
z12 Before
![z12-kahului](https://user-images.githubusercontent.com/42757252/50548029-3887fd80-0c89-11e9-91e7-e37b7f2dcb2f.png)
After
![z12-kahului-no-parking](https://user-images.githubusercontent.com/42757252/50548037-40e03880-0c89-11e9-86da-247e1c588650.png)

z13 Before
![z13-kahului](https://user-images.githubusercontent.com/42757252/50548030-39b92a80-0c89-11e9-9325-69b71137f0b4.png)
After
![z13-kahului-no-parking](https://user-images.githubusercontent.com/42757252/50548038-4178cf00-0c89-11e9-9c61-f70d9c44057d.png)

Double Resolution to show details:
Before z12 - double
![z12-kahului-master-2x](https://user-images.githubusercontent.com/42757252/50548032-3b82ee00-0c89-11e9-91c6-663e9e590a19.png)
After - double
![z12-kahului-no-parking-2x](https://user-images.githubusercontent.com/42757252/50548039-43429280-0c89-11e9-860c-ce085f3d8dec.png)

Before z13 - double
![z13-kahului-master-2x](https://user-images.githubusercontent.com/42757252/50548035-3c1b8480-0c89-11e9-9ea1-9317e9d0263e.png)
After - double
![z13-kahului-no-parking-2x](https://user-images.githubusercontent.com/42757252/50548041-4473bf80-0c89-11e9-975c-2613584d3a75.png)

**Washington, DC**
z12 Before
![z12-washington-master](https://user-images.githubusercontent.com/42757252/50548174-8c93e180-0c8b-11e9-891a-94bd2dbc7ed8.png)
z12 After
![washington-z12-no-parking](https://user-images.githubusercontent.com/42757252/50548176-8ef63b80-0c8b-11e9-9511-28379a469b7a.png)
z13 Before
![z13-washington-master](https://user-images.githubusercontent.com/42757252/50548175-8dc50e80-0c8b-11e9-9205-f9895d386878.png)
z13 After
![z13-washington-no-parking](https://user-images.githubusercontent.com/42757252/50548177-90276880-0c8b-11e9-9e07-72d1264dd8a9.png)

**Newcastle and Newark, Delaware**
z12 Before
![z12-newark-newcastle-master](https://user-images.githubusercontent.com/42757252/50548182-a8978300-0c8b-11e9-86c0-ff9153070141.png)
After
![z12-newark-newcastle-no-parking](https://user-images.githubusercontent.com/42757252/50548189-b0efbe00-0c8b-11e9-834e-cddb51ea23f2.png)

z13 Before
![z13-newcastle-airport-master](https://user-images.githubusercontent.com/42757252/50548181-a7665600-0c8b-11e9-815a-d257639cdddf.png)
After
![z13-newcastle-airport-no-parking](https://user-images.githubusercontent.com/42757252/50548190-b220eb00-0c8b-11e9-8207-6ee125b7b05a.png)

z12 - double resolution
Before
![z12-newark-master-2x](https://user-images.githubusercontent.com/42757252/50548184-aaf9dd00-0c8b-11e9-8568-587c7f715ac0.png)
After
![z12-newar-no-parking-2x](https://user-images.githubusercontent.com/42757252/50548186-afbe9100-0c8b-11e9-8f01-8d53486321d4.png)

z13 - 4x resolution
Before
![z13-newark-master-4x](https://user-images.githubusercontent.com/42757252/50548185-ac2b0a00-0c8b-11e9-8ba5-ce8ee3f8ad70.png)
After
![z13-newark-no-parking-4x](https://user-images.githubusercontent.com/42757252/50548187-afbe9100-0c8b-11e9-981e-f4e7bd19a711.png)


**Derry, N. Ireland:**
https://www.openstreetmap.org/#map=13/54.9936/-7.3074
z12 before
![z12-derry-master](https://user-images.githubusercontent.com/42757252/50548205-0fb53780-0c8c-11e9-91f7-51c493d9aeeb.png)
z12 after
![z12-derry-after](https://user-images.githubusercontent.com/42757252/50548211-1d6abd00-0c8c-11e9-83cb-9e030abda9fa.png)

z13 before
![z13-derry-master](https://user-images.githubusercontent.com/42757252/50548206-117efb00-0c8c-11e9-9c05-a16f668379b5.png)
z13 after
![z13-derry-after](https://user-images.githubusercontent.com/42757252/50548212-1e035380-0c8c-11e9-89fd-340915da24b4.png)

z12 double resolution - before
![z12-derry-master-2x](https://user-images.githubusercontent.com/42757252/50548210-1774dc00-0c8c-11e9-9de1-33ed0fe51274.png)
after
![z12-derry-2x-after](https://user-images.githubusercontent.com/42757252/50548213-1fcd1700-0c8c-11e9-881a-377a5c3e900c.png)


**Belfast, N. Ireland:**
https://www.openstreetmap.org/#map=13/54.5975/-5.9104
z12 Before
![z12-belfast-master](https://user-images.githubusercontent.com/42757252/50548215-28bde880-0c8c-11e9-930f-de18fdc7790e.png)
z12 After
![z12-belfast-after](https://user-images.githubusercontent.com/42757252/50548219-32475080-0c8c-11e9-92fc-dc65b5855872.png)

z13 Before
![z13-belfast-master](https://user-images.githubusercontent.com/42757252/50548217-2a87ac00-0c8c-11e9-8cd6-7916513d3330.png)
z13 After
![z13-belfast-after](https://user-images.githubusercontent.com/42757252/50548220-33787d80-0c8c-11e9-9e6f-b2465b4366c5.png)

z12 - at double resolution
![z12-belfast-master-2x](https://user-images.githubusercontent.com/42757252/50548218-2f4c6000-0c8c-11e9-8ead-859928db22fb.png)
After
![z12-belfast-after-2x](https://user-images.githubusercontent.com/42757252/50548221-383d3180-0c8c-11e9-8a17-515e931ce6b4.png)