### PR TITLE
Add missing oneway arrows for tracks and paths

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2001,7 +2001,7 @@ Layer:
             horse,
             bicycle
           FROM planet_osm_line
-          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')
+          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'construction')
             AND (name IS NOT NULL
               OR oneway IN ('yes', '-1')
               OR junction IN ('roundabout'))

--- a/project.mml
+++ b/project.mml
@@ -1982,6 +1982,7 @@ Layer:
     properties:
       minzoom: 13
   - id: paths-text-name
+    class: directions
     geometry: linestring
     <<: *extents
     Datasource:
@@ -1991,10 +1992,19 @@ Layer:
             way,
             highway,
             construction,
-            name
+            name,
+            CASE
+              WHEN oneway IN ('yes', '-1') THEN oneway
+              WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
+              ELSE NULL
+            END AS oneway,
+            horse,
+            bicycle
           FROM planet_osm_line
-          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'construction')
-            AND name IS NOT NULL
+          WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps')
+            AND (name IS NOT NULL
+              OR oneway IN ('yes', '-1')
+              OR junction IN ('roundabout'))
         ) AS paths_text_name
     properties:
       minzoom: 15

--- a/roads.mss
+++ b/roads.mss
@@ -3262,24 +3262,24 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-placement: line;
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
-      text-dy: 5;
+      text-dy: -5;
       [oneway = '-1'] {
-        text-dy: -5;
+        text-dy: 5;
       }
       text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
-      text-dy: 7;
+      text-dy: -7;
       [oneway = '-1'] {
-        text-dy: -7;
+        text-dy: 7;
       }
     }
     [zoom >= 17] {
       text-size: 11;
-      text-dy: 9;
+      text-dy: -9;
       [oneway = '-1'] {
-        text-dy: -9;
+        text-dy: 9;
       }
     }
   }
@@ -3305,18 +3305,18 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-placement: line;
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
-      text-dy: 7;
+      text-dy: -7;
       [oneway = '-1'] {
-        text-dy: -7;
+        text-dy: 7;
       }
       text-repeat-distance: @major-highway-text-repeat-distance;
       [highway = 'steps'] { text-repeat-distance: @minor-highway-text-repeat-distance; }
     }
     [zoom >= 17] {
       text-size: 11;
-      text-dy: 9;
+      text-dy: -9;
       [oneway = '-1'] {
-        text-dy: -9;
+        text-dy: 9;
       }
     }
   }
@@ -3341,13 +3341,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [highway = 'road'],
     [highway = 'service'],
     [highway = 'pedestrian'],
-    [highway = 'raceway'],
-    [highway = 'cycleway'],
-    [highway = 'footway'],
-    [highway = 'path'],
-    [highway = 'steps'],
-    [highway = 'track'],
-    [highway = 'bridleway'] {
+    [highway = 'raceway'] {
       [oneway = 'yes'],
       [oneway = '-1'] {
         marker-placement: line;
@@ -3393,45 +3387,56 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [highway = 'raceway'] {
           marker-fill: @raceway-oneway-arrow-color;
         }
+      }
+    }
 
-        [highway = 'steps'] {
-          marker-fill: @steps-oneway-arrow-color;
-          marker-transform: 'translate(0,5)';
-          [oneway = '-1'] {
-            marker-transform: 'translate(0,-5)';
+    [highway = 'steps'],
+    [highway = 'cycleway'],
+    [highway = 'footway'],
+    [highway = 'path'],
+    [highway = 'track'],
+    [highway = 'bridleway'] {
+      [oneway = 'yes'],
+      [oneway = '-1'] {
+        text-name: "'⭢'";
+        text-size: 18;
+        text-clip: false;
+        text-spacing: 180;
+        text-placement: line;
+        text-halo-fill: @standard-halo-fill;
+        text-halo-radius: 1.5;
+        text-margin: 2;
+        text-dy: 4;
+        text-upright: right;
+        text-vertical-alignment: middle;
+        text-face-name: @book-fonts;
+        [oneway = '-1'] {
+          text-upright: left;
+          text-dy: -4;
+        }
+        [highway = 'footway'] {
+          text-fill: @footway-oneway-arrow-color;
+        }
+        [highway = 'path'] {
+          text-fill: @footway-oneway-arrow-color;
+          [horse = 'designated'] {
+            text-fill: @bridleway-oneway-arrow-color;
+          }
+          [bicycle = 'designated'] {
+            text-fill: @cycleway-oneway-arrow-color;
           }
         }
-
-        [highway = 'footway'],
-        [highway = 'path'],
-        [highway = 'cycleway'],
-        [highway = 'track'],
+        [highway = 'steps'] {
+          text-fill: @steps-oneway-arrow-color;
+        }
+        [highway = 'cycleway'] {
+          text-fill: @cycleway-oneway-arrow-color;
+        }
+        [highway = 'track'] {
+          text-fill: @track-oneway-arrow-color;
+        }
         [highway = 'bridleway'] {
-          marker-transform: 'translate(0,4)';
-          [oneway = '-1'] {
-            marker-transform: 'translate(0,-4)';
-          }
-          [highway = 'footway'] {
-            marker-fill: @footway-oneway-arrow-color;
-          }
-          [highway = 'path'] {
-            marker-fill: @footway-oneway-arrow-color;
-            [horse = 'designated'] {
-              marker-fill: @bridleway-oneway-arrow-color;
-            }
-            [bicycle = 'designated'] {
-              marker-fill: @cycleway-oneway-arrow-color;
-            }
-          }
-          [highway = 'cycleway'] {
-            marker-fill: @cycleway-oneway-arrow-color;
-          }
-          [highway = 'track'] {
-            marker-fill: @track-oneway-arrow-color;
-          }
-          [highway = 'bridleway'] {
-            marker-fill: @bridleway-oneway-arrow-color;
-          }
+          text-fill: @bridleway-oneway-arrow-color;
         }
       }
     }

--- a/roads.mss
+++ b/roads.mss
@@ -288,11 +288,11 @@
 @living-street-oneway-arrow-color: darken(@residential-casing, 30%);
 @pedestrian-oneway-arrow-color:   darken(@pedestrian-casing, 25%);
 @raceway-oneway-arrow-color:      darken(@raceway-fill, 50%);
-@footway-oneway-arrow-color:      darken(@footway-fill, 40%);
-@steps-oneway-arrow-color:        darken(@steps-fill, 45%);
-@cycleway-oneway-arrow-color:     darken(@cycleway-fill, 30%);
-@track-oneway-arrow-color:        darken(@track-fill, 20%);
-@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 20%);
+@footway-oneway-arrow-color:      darken(@footway-fill, 35%);
+@steps-oneway-arrow-color:        darken(@steps-fill, 35%);
+@cycleway-oneway-arrow-color:     darken(@cycleway-fill, 25%);
+@track-oneway-arrow-color:        darken(@track-fill, 10%);
+@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 15%);
 
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.
@@ -3263,15 +3263,24 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 5;
+      [oneway = '-1'] {
+        text-dy: -5;
+      }
       text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
       text-dy: 7;
+      [oneway = '-1'] {
+        text-dy: -7;
+      }
     }
     [zoom >= 17] {
       text-size: 11;
       text-dy: 9;
+      [oneway = '-1'] {
+        text-dy: -9;
+      }
     }
   }
 
@@ -3297,12 +3306,18 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
       text-dy: 7;
+      [oneway = '-1'] {
+        text-dy: -7;
+      }
       text-repeat-distance: @major-highway-text-repeat-distance;
       [highway = 'steps'] { text-repeat-distance: @minor-highway-text-repeat-distance; }
     }
     [zoom >= 17] {
       text-size: 11;
       text-dy: 9;
+      [oneway = '-1'] {
+        text-dy: -9;
+      }
     }
   }
 }
@@ -3338,7 +3353,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         marker-placement: line;
         marker-spacing: 180;
         marker-max-error: 0.5;
-
         marker-file: url('symbols/oneway.svg');
         [oneway = '-1'] {
           marker-file: url('symbols/oneway-reverse.svg');
@@ -3379,34 +3393,51 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [highway = 'raceway'] {
           marker-fill: @raceway-oneway-arrow-color;
         }
-        [highway = 'footway'] {
-          marker-fill: @footway-oneway-arrow-color;
-        }
-        [highway = 'path'] {
-          marker-fill: @footway-oneway-arrow-color;
-          [horse = 'designated'] {
-            marker-fill: @bridleway-oneway-arrow-color;
-          }
-          [bicycle = 'designated'] {
-            marker-fill: @cycleway-oneway-arrow-color;
-          }
-        }
+
         [highway = 'steps'] {
           marker-fill: @steps-oneway-arrow-color;
+          marker-transform: 'translate(0,5)';
+          [oneway = '-1'] {
+            marker-transform: 'translate(0,-5)';
+          }
         }
-        [highway = 'cycleway'] {
-          marker-fill: @cycleway-oneway-arrow-color;
-        }
-        [highway = 'track'] {
-          marker-fill: @track-oneway-arrow-color;
-        }
+
+        [highway = 'footway'],
+        [highway = 'path'],
+        [highway = 'cycleway'],
+        [highway = 'track'],
         [highway = 'bridleway'] {
-          marker-fill: @bridleway-oneway-arrow-color;
+          marker-transform: 'translate(0,4)';
+          [oneway = '-1'] {
+            marker-transform: 'translate(0,-4)';
+          }
+          [highway = 'footway'] {
+            marker-fill: @footway-oneway-arrow-color;
+          }
+          [highway = 'path'] {
+            marker-fill: @footway-oneway-arrow-color;
+            [horse = 'designated'] {
+              marker-fill: @bridleway-oneway-arrow-color;
+            }
+            [bicycle = 'designated'] {
+              marker-fill: @cycleway-oneway-arrow-color;
+            }
+          }
+          [highway = 'cycleway'] {
+            marker-fill: @cycleway-oneway-arrow-color;
+          }
+          [highway = 'track'] {
+            marker-fill: @track-oneway-arrow-color;
+          }
+          [highway = 'bridleway'] {
+            marker-fill: @bridleway-oneway-arrow-color;
+          }
         }
       }
     }
   }
 }
+
 #railways-text-name {
   /* Mostly started from z17. */
   [railway = 'rail'],

--- a/roads.mss
+++ b/roads.mss
@@ -288,11 +288,11 @@
 @living-street-oneway-arrow-color: darken(@residential-casing, 30%);
 @pedestrian-oneway-arrow-color:   darken(@pedestrian-casing, 25%);
 @raceway-oneway-arrow-color:      darken(@raceway-fill, 50%);
-@footway-oneway-arrow-color:      darken(@footway-fill, 35%);
-@steps-oneway-arrow-color:        darken(@steps-fill, 50%);
-@cycleway-oneway-arrow-color:     darken(@cycleway-fill, 25%);
-@track-oneway-arrow-color:        darken(@track-fill, 15%);
-@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 25%);
+@footway-oneway-arrow-color:      darken(@footway-fill, 40%);
+@steps-oneway-arrow-color:        darken(@steps-fill, 45%);
+@cycleway-oneway-arrow-color:     darken(@cycleway-fill, 30%);
+@track-oneway-arrow-color:        darken(@track-fill, 20%);
+@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 20%);
 
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.

--- a/roads.mss
+++ b/roads.mss
@@ -3262,25 +3262,16 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-placement: line;
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
-      text-dy: -5;
-      [oneway = '-1'] {
-        text-dy: 5;
-      }
+      text-dy: 5;
       text-repeat-distance: @major-highway-text-repeat-distance;
     }
     [zoom >= 16] {
       text-size: 9;
-      text-dy: -7;
-      [oneway = '-1'] {
-        text-dy: 7;
-      }
+      text-dy: 7;
     }
     [zoom >= 17] {
       text-size: 11;
-      text-dy: -9;
-      [oneway = '-1'] {
-        text-dy: 9;
-      }
+      text-dy: 9;
     }
   }
 
@@ -3305,19 +3296,13 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-placement: line;
       text-face-name: @book-fonts;
       text-vertical-alignment: middle;
-      text-dy: -7;
-      [oneway = '-1'] {
-        text-dy: 7;
-      }
+      text-dy: 7;
       text-repeat-distance: @major-highway-text-repeat-distance;
       [highway = 'steps'] { text-repeat-distance: @minor-highway-text-repeat-distance; }
     }
     [zoom >= 17] {
       text-size: 11;
-      text-dy: -9;
-      [oneway = '-1'] {
-        text-dy: 9;
-      }
+      text-dy: 9;
     }
   }
 }

--- a/roads.mss
+++ b/roads.mss
@@ -292,7 +292,7 @@
 @steps-oneway-arrow-color:        darken(@steps-fill, 35%);
 @cycleway-oneway-arrow-color:     darken(@cycleway-fill, 25%);
 @track-oneway-arrow-color:        darken(@track-fill, 15%);
-@bridleway-oneway-arrow-color:    darken(@track-fill, 10%);
+@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 15%);
 
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.
@@ -3379,7 +3379,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [highway = 'raceway'] {
           marker-fill: @raceway-oneway-arrow-color;
         }
-        [highway = 'footway'],
+        [highway = 'footway'] {
+          marker-fill: @footway-oneway-arrow-color;
+        }
         [highway = 'path'] {
           marker-fill: @footway-oneway-arrow-color;
           [horse = 'designated'] {

--- a/roads.mss
+++ b/roads.mss
@@ -3398,21 +3398,21 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [highway = 'bridleway'] {
       [oneway = 'yes'],
       [oneway = '-1'] {
-        text-name: "'⭢'";
-        text-size: 18;
+        text-name: "'🠖'";
+        text-size: 15;
         text-clip: false;
         text-spacing: 180;
         text-placement: line;
         text-halo-fill: @standard-halo-fill;
         text-halo-radius: 1.5;
         text-margin: 2;
-        text-dy: 4;
+        text-dy: 3;
         text-upright: right;
         text-vertical-alignment: middle;
         text-face-name: @book-fonts;
         [oneway = '-1'] {
           text-upright: left;
-          text-dy: -4;
+          text-dy: -3;
         }
         [highway = 'footway'] {
           text-fill: @footway-oneway-arrow-color;

--- a/roads.mss
+++ b/roads.mss
@@ -289,10 +289,10 @@
 @pedestrian-oneway-arrow-color:   darken(@pedestrian-casing, 25%);
 @raceway-oneway-arrow-color:      darken(@raceway-fill, 50%);
 @footway-oneway-arrow-color:      darken(@footway-fill, 35%);
-@steps-oneway-arrow-color:        darken(@steps-fill, 35%);
+@steps-oneway-arrow-color:        darken(@steps-fill, 50%);
 @cycleway-oneway-arrow-color:     darken(@cycleway-fill, 25%);
 @track-oneway-arrow-color:        darken(@track-fill, 15%);
-@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 15%);
+@bridleway-oneway-arrow-color:    darken(@bridleway-fill, 25%);
 
 // Shield’s line wrap is based on OpenStreetMap data and not on line-wrap-width,
 // but lines are typically rather short, so we use narrow line spacing.


### PR DESCRIPTION
Fixes #2865 
Fixes #1937

### Changes proposed in this pull request:
- Add missing oneway arrows for tracks and paths
- Fixed rendering of arrows on footways: these will always use the footway color, rather than changing if there is (mis)-tagging with designated=bicycle or designated=bridleway.
- Fixed bridleway one-way arrow color. It is now based on brideway color instead of track color.

**EDITED: New changes**
- Change arrows to Unicode text with halo for better visibility.
- Adjust position of text based on `oneway = -1` to make sure text is always on the same side of one-way paths and tracks

### Test rendering:
(First option, without change to unicode text arrows and halos)

Before
![oneway-master](https://user-images.githubusercontent.com/42757252/50558547-b522e680-0d32-11e9-81e2-982ecba545db.png)

After - first option
![path-oneway-after](https://user-images.githubusercontent.com/42757252/50558361-fd410980-0d30-11e9-8296-d29f82d3dd33.png)

**EDITED: Current commit:** 
![](https://user-images.githubusercontent.com/42757252/50732684-ff88e500-11c2-11e9-8df8-edeefd06b863.png)
