### PR TITLE
Fix label opacity for tourism features

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2602,9 +2602,13 @@
     [feature = 'amenity_shelter'] {
       text-fill: @amenity-brown;
     }
-    [access != ''][access != 'permissive'][access != 'yes'] {
-      text-opacity: 0.33;
-      text-halo-radius: 0;
+    [feature = 'tourism_alpine_hut'],
+    [feature = 'tourism_wilderness_hut'],
+    [feature = 'amenity_shelter'] {
+      [access != ''][access != 'permissive'][access != 'yes'] {
+        text-opacity: 0.33;
+        text-halo-radius: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Changes proposed in this pull request:
Small fix of #3528 to restrict private rendering of label to `tourism=alpine_hut/wilderness_hut` and `amenity=shelter`. 
Currently several `tourism=*` with private access display an inconsistent rendering with transparent label and opaque icon 

Test rendering with links to the example places:
https://www.openstreetmap.org/way/67006491
Before
![hotel_private_before](https://user-images.githubusercontent.com/9897203/50560733-05368480-0d04-11e9-8212-da19352e72d4.png)
After
![hotel_private_after](https://user-images.githubusercontent.com/9897203/50560736-0b2c6580-0d04-11e9-9265-61db8c086036.png)

