### PR TITLE
Render gate ref's black instead of purple

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -3012,7 +3012,7 @@
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
-    text-fill: #aa66cc;
+    text-fill: black;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
This renders gate ref's in black instead of in purple. Purple used to be the airport color, but apart from gates purple is no longer used for airports.

Before:
<img width="461" alt="screen shot 2019-01-03 at 23 23 39" src="https://user-images.githubusercontent.com/5251909/50664795-9fb9f080-0fae-11e9-8fab-2e23302ed459.png">

After:
<img width="513" alt="screen shot 2019-01-03 at 23 20 02" src="https://user-images.githubusercontent.com/5251909/50664743-6bdecb00-0fae-11e9-8058-7a49330cb903.png">
