### PR TITLE
Reverting lowzoom nobuilding test change

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -100,6 +100,7 @@ Layer:
             WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'vineyard', 'orchard')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
+              AND building IS NULL
           ) AS features
           ORDER BY way_area DESC, feature
         ) AS landcover_low_zoom


### PR DESCRIPTION
Partial revert of #3539.

Changes proposed in this pull request:
- bring back the "no building" checking line in `landcover-low-zoom` data layer, since this might have performance implications (see this comment: https://github.com/gravitystorm/openstreetmap-carto/pull/3539/files#r244279150)

Test rendering is positive (nothing is broken).