### PR TITLE
[Bugfix] Add zoom level to vending_machine

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -187,7 +187,7 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_vending_machine'] {
+  [feature = 'amenity_vending_machine'][zoom >= 19] {
     [vending = 'excrement_bags'] {
       marker-file: url('symbols/amenity/excrement_bags.svg');
     }


### PR DESCRIPTION
Fixes #3623

Changes proposed in this pull request:
Restrict `amenity=vending_machine` to z19

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=15/46.2108/6.1451

Before
![vendingbugfix_before](https://user-images.githubusercontent.com/9897203/50788702-7359e900-12ba-11e9-9be2-ed061721db18.png)

After
![vendingbugfix_after](https://user-images.githubusercontent.com/9897203/50788586-22e28b80-12ba-11e9-922f-9045f79238a9.png)
