### PR TITLE
Change zoom level and text size for place=hamlet

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -372,8 +372,9 @@
 }
 
 #placenames-small::quarter {
+  [place = 'hamlet'],
   [place = 'quarter'] {
-    [zoom >= 14][zoom < 17] {
+    [zoom >= 14][zoom < 18] {
       text-name: "[name]";
       text-fill: @placenames;
       text-face-name: @book-fonts;
@@ -403,8 +404,7 @@
   }
 }
 
-#placenames-small::hamlet {
-  [place = 'hamlet'],
+#placenames-small::neighborhood {
   [place = 'locality'],
   [place = 'neighbourhood'],
   [place = 'isolated_dwelling'],

--- a/placenames.mss
+++ b/placenames.mss
@@ -372,9 +372,8 @@
 }
 
 #placenames-small::quarter {
-  [place = 'hamlet'],
   [place = 'quarter'] {
-    [zoom >= 14][zoom < 18] {
+    [zoom >= 14][zoom < 17] {
       text-name: "[name]";
       text-fill: @placenames;
       text-face-name: @book-fonts;
@@ -399,6 +398,40 @@
         text-wrap-width: 70; // 5.0 em
         text-line-spacing: -0.70; // -0.05 em
         text-margin: 9.8; // 0.7 em
+      }
+    }
+  }
+}
+
+#placenames-small::hamlet { 
+  [place = 'hamlet'] {
+    [zoom >= 14][zoom < 18] {
+      text-name: "[name]";
+      text-fill: @placenames;
+      text-face-name: @book-fonts;
+      text-halo-fill: white;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      [zoom >= 14] {
+        text-size: 10;
+        text-wrap-width: 55; // 5.0 em
+        text-line-spacing: -0.55; // -0.05 em
+        text-margin: 7.7; // 0.7 em
+      }
+      [zoom >= 15] {
+        text-size: 11;
+        text-fill: @placenames-light;
+        text-halo-fill: @standard-halo-fill;
+        text-wrap-width: 45; // 4.5 em
+        text-line-spacing: -0.8; // -0.08 em
+        text-margin: 7.0; // 0.7 em
+      }
+      [zoom >= 16] {
+        text-size: 12;
+        text-wrap-width: 60; // 5.0 em
+        text-line-spacing: -0.60; // -0.05 em
+        text-margin: 8.4; // 0.7 em
+        text-fill: @placenames-light;
+        text-halo-fill: white;
       }
     }
   }

--- a/placenames.mss
+++ b/placenames.mss
@@ -401,9 +401,6 @@
       }
     }
   }
-}
-
-#placenames-small::hamlet { 
   [place = 'hamlet'] {
     [zoom >= 14][zoom < 18] {
       text-name: "[name]";


### PR DESCRIPTION
Fixes #1984

### Changes proposed in this pull request:
- Start rendering hamlets at z14 (instead of z15) through z17
- Use a slightly larger text label for hamlets, intermediate between place=quarter and place=neighborhood / locality / farm
- Move place=hamlet to same layer as place=quarter

### Explanation:
- In areas where hamlets are common, the map may not display any place names, or too few, at z14
- Mappers sometimes misuse place=village for very small settlements so that they will render sooner. This change will reduce this incentive. 
- Hamlets are larger and more important than farms, isolated_dwellings, and "localities", since they are found in rural areas but have more than one or two families, so they should be rendered sooner and with a subtly different text.

### Test renderings: 

**Wales**
_high latitude_
z14 Trefin - current
![z14-trefin-master](https://user-images.githubusercontent.com/42757252/50833757-a2915880-1395-11e9-9e32-647f6d7a902b.png)
After
![z14-trefin-hamlet](https://user-images.githubusercontent.com/42757252/50833009-49282a00-1393-11e9-896b-dd82abd2b838.png)

z14 Dobshill - current
![z14-dobshill-master](https://user-images.githubusercontent.com/42757252/50833845-dcfaf580-1395-11e9-9d7e-3b973d3f0798.png)
After
![z14-dobshill-hamlet](https://user-images.githubusercontent.com/42757252/50833857-e5533080-1395-11e9-9c97-b9024ee684aa.png)

**Sixaloa, Costa Rica**
_low latitude_
z14 current rendering:
![z14-sixaola-master](https://user-images.githubusercontent.com/42757252/50833065-6c52d980-1393-11e9-8d4d-13a5ef184455.png)
After
![z14-sixaola-hamlets](https://user-images.githubusercontent.com/42757252/50833062-6957e900-1393-11e9-8530-09fe5c62ebb1.png)

**Syokosimo, Papua Indonesia**
_low latitude_
z14 current
![z14-syokosimo-master](https://user-images.githubusercontent.com/42757252/50833288-0d419480-1394-11e9-9d99-db408123caca.png)
z14 after
![z14-syokosimo-hamlet2](https://user-images.githubusercontent.com/42757252/50833276-031f9600-1394-11e9-88a7-27641ae0ad89.png)

_Soba, Papua Indonesia_
z18 current
![z18-soba-master](https://user-images.githubusercontent.com/42757252/50833797-c2288100-1395-11e9-938e-715ba097d131.png)
z18 after
![z18-soba-hamlet](https://user-images.githubusercontent.com/42757252/50833812-c8b6f880-1395-11e9-800c-4ec2a4ba06d3.png)
- There is no need to show these labels on z18 and z19

Also see additional images in https://github.com/gravitystorm/openstreetmap-carto/issues/1984#issuecomment-452296750