### PR TITLE
Render ref of minor roads more than once

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -3019,7 +3019,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
       text-fill: #000;
       text-face-name: @book-fonts;
-      text-min-distance: 40;
+      text-placement: line;
+      text-repeat-distance: @major-highway-text-repeat-distance;
       text-halo-radius: 2;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 760;


### PR DESCRIPTION
### Changes proposed in this pull request:
- Modify the code for display of the ref on unclassified and residential highways:
- Add `text-placement: line` for ref of minor roads so that the ref will display more than once on a way
- Remove deprecated `text-min-distance`, replace with `text-repeat-distance` instead.

### Explanation
- Currently the reference number of an unclassified or residential highway (aka "minor highway") is only displayed once at the center of the OSM way, because `text-placement` has not been set to `line`. This PR will allow ref numbers to display every 760 pixels approximately, as intended. 
- Also, `text-min-distance` was used, but this has been deprecated in the CartoCSS documentation. This has been changed to use the new recommended option, `text-repeat-distance`, which is already used for name label rendering in most other parts of roads.mss

### Test renderings:

**Before**
![refs-master](https://user-images.githubusercontent.com/42757252/50898118-7b985c80-1451-11e9-84b7-51d1f4746ed3.png)
![ref-10-before](https://user-images.githubusercontent.com/42757252/50898122-7d622000-1451-11e9-80ce-d0929caaccea.png)

**After**
![refs-res-unclass](https://user-images.githubusercontent.com/42757252/50898133-8bb03c00-1451-11e9-8f57-795f56fe8b50.png)
![ref-10-after](https://user-images.githubusercontent.com/42757252/50898136-8d79ff80-1451-11e9-966f-4f64926154f0.png)
