### PR TITLE
Add "religious-icon" as a color variable

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -19,6 +19,7 @@
 @advertising-grey: @man-made-icon;
 @landform-color: #d08f55;
 @leisure-green: darken(@park, 60%);
+@religious-icon: #000000;
 
 @landcover-font-size: 10;
 @landcover-wrap-width-size: 30; // 3 em
@@ -740,7 +741,7 @@
 
   [feature = 'amenity_place_of_worship'][zoom >= 16] {
     marker-file: url('symbols/amenity/place_of_worship.svg');
-    marker-fill: #000000;
+    marker-fill: @religious-icon;
     marker-placement: interior;
     marker-clip: false;
     [religion = 'christian'] {
@@ -775,7 +776,7 @@
   [feature = 'man_made_cross'][zoom >= 17],
   [feature = 'historic_wayside_cross'][zoom >= 17] {
     marker-file: url('symbols/man_made/cross.svg');
-    marker-fill: #000000;
+    marker-fill: @religious-icon;
     marker-placement: interior;
     marker-clip: false;
   }
@@ -1640,7 +1641,7 @@
   [feature = 'man_made_cross'][zoom >= 16],
   [feature = 'historic_wayside_cross'][zoom >= 16] {
     marker-file: url('symbols/man_made/cross.svg');
-    marker-fill: #000000;
+    marker-fill: @religious-icon;
     marker-placement: interior;
     marker-clip: false;
   }


### PR DESCRIPTION
Related to #3395

Changes proposed in this pull request:
- Add `@religious-icon: #000000;` 
- Use this variable for place_of_worship, historic=wayside_cross and man_made=cross

In the future this could also be extended to other religious icons, such as wayside_shrine or other religious objects if they become defined in the database. 

Test rendering is not shown, because the cartography is unchanged. 
However, I have tested this commit and found that it works without problems. 