### PR TITLE
Add "barrier-icon" color variable with #3f3f3f for barriers

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -17,6 +17,7 @@
 @office: #4863A0;
 @man-made-icon: #666666;
 @advertising-grey: @man-made-icon;
+@barrier-icon: #3f3f3f;
 @landform-color: #d08f55;
 @leisure-green: darken(@park, 60%);
 
@@ -1691,49 +1692,49 @@
   [feature = 'barrier_lift_gate'][zoom >= 17]::barrier,
   [feature = 'barrier_swing_gate'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/lift_gate.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_cattle_grid'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/cattle_grid.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_stile'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/stile.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_motorcycle_barrier'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/motorcycle_barrier.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_cycle_barrier'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/cycle_barrier.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_full-height_turnstile'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/full-height_turnstile.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_kissing_gate'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/kissing_gate.svg');
-    marker-fill: #3f3f3f;
+    marker-fill: @barrier-icon;
     marker-placement: interior;
     marker-clip: false;
   }


### PR DESCRIPTION
Related to #3395

Changes proposed in this pull request:
- Add `@barrier-icon` color variable with value of `#3f3f3f `
- Change barriers marker-fill to use `@barrier-icon` instead of `#3f3f3f `

Note: 
-bollards, logs and blocks are unchanged, because these currently use a much lighter shade of gray.
- 'barrier_gate' does not use marker-fill, because the icon uses two colors (#3f3f3f plus a white halo)

In the future this variable could be changed to use @man-made-icon if we wish to reduce the number of shade of gray.

Test rendering is not shown, because the cartography is unaffected.
I have tested this commit and found that it works without changing the rendering.