### PR TITLE
[WIP] Add healthcare to list of polygons in lua transformations

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -14,6 +14,7 @@ local polygon_keys = {
     'building',
     'building:part',
     'harbour',
+    'healthcare',
     'historic',
     'landuse',
     'leisure',


### PR DESCRIPTION
**Fixes #3639**

## Changes proposed in this pull request:
- Add 'healthcare' to list of polygon objects in openstreetmap-carto.lua

## Explanation:
- This will allow closed ways ("areas") that are tagged with "healthcare=*" to be imported as polygons, so that they can be rendered properly
- Currently imported objects will not be immediately affected, but newly added and edited objects should render properly now, and all should render properly after database reload.

## Test rendering:

Before
![healthcare-areas-before](https://user-images.githubusercontent.com/42757252/51227399-7712fd00-1997-11e9-8b30-718e937b9aab.png)

After
- Rendered after reloading database. Before database reload the rendering was unchanged.
![healthcare-areas-after](https://user-images.githubusercontent.com/42757252/51227400-79755700-1997-11e9-9db1-e6be7fcd2f1a.png)
