### PR TITLE
Render tourism outlines one zoom level sooner for small zoos and theme parks

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -863,30 +863,29 @@
 }
 
 #tourism-boundary {
-  [tourism = 'zoo'][zoom >= 10][way_pixels >= 750],
-  [tourism = 'zoo'][zoom >= 17],
-  [tourism = 'theme_park'][zoom >= 10][way_pixels >= 750],
-  [tourism = 'theme_park'][zoom >= 17] {
-    a/line-width: 1;
-    a/line-offset: -0.5;
-    a/line-color: @tourism;
-    a/line-opacity: 0.5;
-    a/line-join: round;
-    a/line-cap: round;
-    [zoom >= 17],
-    [way_pixels >= 60] {
+  [tourism = 'zoo'],
+  [tourism = 'theme_park'] {
+    [zoom >= 10][way_pixels >= 750],
+    [zoom >= 13][way_pixels >= 180],
+    [zoom >= 17] {
+      a/line-width: 1;
+      a/line-offset: -0.5;
+      a/line-color: @tourism;
+      a/line-opacity: 0.5;
+      a/line-join: round;
+      a/line-cap: round;
       b/line-width: 4;
       b/line-offset: -2;
       b/line-color: @tourism;
       b/line-opacity: 0.3;
       b/line-join: round;
       b/line-cap: round;
-    }
-    [zoom >= 17] {
-      a/line-width: 2;
-      a/line-offset: -1;
-      b/line-width: 6;
-      b/line-offset: -3;
+      [zoom >= 17] {
+        a/line-width: 2;
+        a/line-offset: -1;
+        b/line-width: 6;
+        b/line-offset: -3;
+      }
     }
   }
 }


### PR DESCRIPTION
Partially reverts #2835

### Changes proposed in this pull request:

- From z13 to z16, render tourism area outlines when way_pixels > 180 instead of the current limit of 750
- Removed redundant code that rendered thinner outlines when way_pixels < 60; this has not been used since #2835

### Explanation:

Prior to #2835, all zoos and theme parks were rendered from z10 if the way_pixels was > 20. This meant that very small features, for example 5 pixels tall and 5 pixels wide, would render. Those with less than way_pixels between 20 and 60 were rendered with a thin 1 pixel border, which was difficult to see and looked quite different than the wide, double border used for larger areas (as seen now).

#2835 improved this situation by only rendering tourism area outlines when the waypixels was > 750. This is 1/4 of 3000 way_pixels, the number used to show the name of the area, so the outline would show exactly 1 zoom level sooner than the name label. Very small areas were hidden.

However, this caused some mid-sized areas to disappear; for example a 30 by 20 pixel area is hidden, even though this is 3 times larger than an icon. This looks strange when there are two tourism areas adjacent, a situation sometimes found in areas with more than one theme park or zoo next to each other (as see in Singapore, below). If one of the areas is slightly smaller, it could disappear a zoom level sooner than it's neighbor, leaving a gap in the map. 

I initially considered rendering all zoos and theme parks from >=z13, because that is where all landcover colors and patterns are now shown. However, I found that it was not helpful to show very small areas less than 100 waypixels. The limit in this PR is now set to 180, which will cause small zoos and theme parks to render approximately 1 zoom levels sooner than before. This solves the problems without losing most of the benefits of #2835


### Test renderings:

**Sentosa Island, Singapore**
- Universal Studios (large) next to KidZania (small) theme park
https://www.openstreetmap.org/#map=15/1.2513/103.8229

z15 Current
![z15-sentosa-master](https://user-images.githubusercontent.com/42757252/51370386-40c1b300-1b3a-11e9-90f5-7f5374d81e47.png)

z15 After
![z15-sentosa-after](https://user-images.githubusercontent.com/42757252/51370393-49b28480-1b3a-11e9-8eef-9172f107803c.png)

z16 (Same)
![z16-universal-studios-660033](https://user-images.githubusercontent.com/42757252/50271067-e9ff8580-0476-11e9-8b0f-debe1d4fb662.png)


**Jurong Bird Park, Singapore**
- Zoo in an otherwise industrial area
https://www.openstreetmap.org/#map=14/1.3229/103.7269

z13 Current
![z13-jurong-bird-park-master](https://user-images.githubusercontent.com/42757252/51370406-520abf80-1b3a-11e9-9852-c4b2e4dea2d4.png)
z13 After
![z13-jurong-bird-after](https://user-images.githubusercontent.com/42757252/51371410-7025ef00-1b3d-11e9-9f15-7f905957091a.png)

z14 (unchanged)
![z14-jurong-bird-same](https://user-images.githubusercontent.com/42757252/51370412-559e4680-1b3a-11e9-90a5-ad8fb84bc850.png)

z15 (unchanged)
![z15-jurong-660033](https://user-images.githubusercontent.com/42757252/50271089-f97ece80-0476-11e9-929a-e3fba0379700.png)


**Singapore Zoo and Night Safari**
https://www.openstreetmap.org/#map=14/1.4043/103.7957

z13 Current
![z13-singapore-zoos-master](https://user-images.githubusercontent.com/42757252/51371323-35bc5200-1b3d-11e9-8440-acb411356ab1.png)
z13 After
![z13-signapore-zoos-after](https://user-images.githubusercontent.com/42757252/51371341-394fd900-1b3d-11e9-94a1-d50d4aa1c351.png)

z14 (Same)
![z14-singapore-zoos-same](https://user-images.githubusercontent.com/42757252/51371350-4240aa80-1b3d-11e9-9dcd-4ff58d6249bd.png)


**Bangor, Northern Ireland**
https://www.openstreetmap.org/#map=15/54.6637905/-5.6726521
- "Pickie Fun Park" is long and narrow, so it's rather challenging to render with an outline

z13 current
![z13-bangor-master](https://user-images.githubusercontent.com/42757252/51370967-1cff6c80-1b3c-11e9-9326-b6416baa02c1.png)
z13 after
![z13-bangor-after](https://user-images.githubusercontent.com/42757252/51371148-ad3db180-1b3c-11e9-94c6-2f03529de0b2.png)

z14 (same)
![z14-bangor-master](https://user-images.githubusercontent.com/42757252/51370963-1a9d1280-1b3c-11e9-8712-87df3492e3b4.png)

z15 (same)
![z15-pickie-fun-park-master](https://user-images.githubusercontent.com/42757252/51370952-14a73180-1b3c-11e9-9166-476f5c6587dc.png)


**Damhead Miniature Railway**
https://www.openstreetmap.org/#map=17/55.1115842/-6.5977664
- There are 4 or 5 of these railway theme parks in rural Northern Ireland, all are similar to this one.

z15 (Same)
![z15-damhead-master](https://user-images.githubusercontent.com/42757252/51371206-dd855000-1b3c-11e9-90db-86221da22b25.png)

z14 Current
![z14-damhead-master](https://user-images.githubusercontent.com/42757252/51371216-e2e29a80-1b3c-11e9-9273-ec7d658b23c5.png)
z14 After
![z14-damhead-after](https://user-images.githubusercontent.com/42757252/51371241-f857c480-1b3c-11e9-909e-48bd5066de88.png)

z13 (same before and after)
![z13-damhead-railway](https://user-images.githubusercontent.com/42757252/51371250-00afff80-1b3d-11e9-9a21-8c5c31704bed.png)

_[Before #2835 this would have been the rendering at z13:]_
_z13 Damhead railway rendering with 20 way_pixels limit:_
![z13-damhead-way_pixels-20-limit](https://user-images.githubusercontent.com/42757252/51371278-14f3fc80-1b3d-11e9-891d-d46a871af734.png)