### PR TITLE
Improve rendering of text labels on admin and nature-reserve borders

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -210,7 +210,11 @@ overlapping borders correctly.
   text-fill: @admin-boundaries;
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
+  text-largest-bbox-only: false;
   text-placement: line;
+  text-spacing: 750;
+  text-repeat-distance: 250;
+  text-margin: 10;
   text-clip: true;
   text-vertical-alignment: middle;
   text-dy: -10;
@@ -222,7 +226,11 @@ overlapping borders correctly.
   text-fill: green;
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
+  text-largest-bbox-only: false;
   text-placement: line;
+  text-spacing: 750;
+  text-repeat-distance: 250;
+  text-margin: 10;
   text-clip: true;
   text-vertical-alignment: middle;
   text-dy: -10;


### PR DESCRIPTION
Fixes #3152 "Multipolygon relations: All borders should be labeled"
Fixes #3649 "Administrative boundary text labels are displayed inconsistently"

### Changes proposed in this pull request:
- 
- Add `text-largest-bbox-only: false` for nature-reserve-text and admin-text
- Add `text-spacing: 750`
- Add `text-repeat-distance: 250`
- Add `text-margin: 10`

### Explanation:

Currently the labels that follow admin borders at z16 and higher, and the labels along nature-reserve and national-park borders, are not shown on all borders of multi polygons. This is a problem when an country has an enclave within another country, or a national park consists of two parts.

Also, Administrative boundary text labels are displayed inconsistently. Boundary text labels are often displayed several times in succession, but sometimes the labels are more than 1600 pixels apart, even in areas with no other objects mapped. When there is more than one level of administrative border that shares the same OSM way, the labels are often rendered immediately adjacent, with no white space or gap between. 

The changes above will address these issues.

1) `text-largest-bbox-only: false` will cause the text labels to render along all borders of a multi-polygon, rather than on the largest only. 
2) `text-spacing: 750` will cause the labels along border to repeat approximately every 750 pixel (if they are not blocked by earlier-rendered objects, or tight bends in the border), which will usually render one or two labels per full screen.
3) `text-repeat-distance: 250` prevents the labels from being rendered close than about 250 pixels apart. This fixes a problem where multiple copies of the label will be rendered right next to each other, if the border is cut off by a metatile boundary.
- This also has the effect of preventing the border labels from rendering if they are within 250 pixels of identical text, such as a text label of a place that has exactly the same name as the administrative boundary.
4) `text-margin: 10` prevents two different text labels from rendering too close together. This also prevents the text labels from rendering in areas that are crowded with other icons and text labels. 
- Because admin-text and nature-reserve-text are the last 2 layers to render (except for the low-priority amenities layer), this will not prevent the rendering of other icons or text labels.

### Test renderings with links to the example places:
- These renderings were made with `metatile: 8` to match the live rendering on openstreetmap.org
- I have used screenshots with Grab on MacOS (rendering with Kosmtik and Safari browser), rather than the export function

**Wamena, Papua, Indonesia** (_Screenshots for current_)
https://www.openstreetmap.org/#map=17/-4.07715/138.97202
- Repeated text labels along border. This area is tagged correctly, there is no duplication in the data. 
Current rendering:
![walelagama-boundary-label-x2](https://user-images.githubusercontent.com/42757252/51390426-a03bb500-1b72-11e9-926f-3d75980547b6.png)
After:
![z17-walelagama-after](https://user-images.githubusercontent.com/42757252/51446552-fc5f2e80-1d56-11e9-91c1-60a6a12552bd.png)

https://www.openstreetmap.org/#map=17/-4.08183/138.95416
- Currently the border text labels are repeated, due to what appears to be a Mapnik bug related to polygons that cross metatile borders twice and therefore have two disconnected sections in the same metatile. This admin_level=6 area is tagged correctly.
Current:
![wamena-x3-wesaput-border](https://user-images.githubusercontent.com/42757252/51390430-a29e0f00-1b72-11e9-918c-7b347e40d6a5.png)
After:
![z17-wamena-after](https://user-images.githubusercontent.com/42757252/51446555-0e40d180-1d57-11e9-8d5e-0b2fd59624cd.png)


**Andorra de la Vella - village boundary**
https://www.openstreetmap.org/#map=16/42.5096/1.5346
- The administrative boundary name currently renders twice, and right in a busy part of the map
- The changes in this PR prevent the labels from rendering twice in a row, and `text-margin: 10` causes them to be moved out into uncrowded parts of the rendering
z16 Current:
![andorra-la-vella-2x-master-16 42 5096 1 5346](https://user-images.githubusercontent.com/42757252/51446689-e18db980-1d58-11e9-86ab-59d1b614cedc.png)
After:
![z16-andora-la-vella-after](https://user-images.githubusercontent.com/42757252/51446690-e5214080-1d58-11e9-941e-a32f5f64b46f.png)


**Yahukimo/Jayawijaya border**
https://www.openstreetmap.org/#map=16/-4.2006/139.0261
- Two admin-level 5 areas and two admin-level 6 areas meet here (There is a 3rd admin_level=6 area that is not yet mapped)
- In the current rendering, the labels are too close together. There is almost no space between them.
- Adding `text-margin: 10` creates enough space. This can be done safely on these two layers, which are almost the last 2 in the project.mml (except for low-priority amenity points)
z16 Current
![z16-aso-tipo-jayawijaya-yahukimo-master](https://user-images.githubusercontent.com/42757252/51416755-3ea13800-1bbe-11e9-9f32-24e478e5ff20.png)
z16 After
![z16-asotipo-jayawijaya-yahukimo-after](https://user-images.githubusercontent.com/42757252/51446746-9a53f880-1d59-11e9-843e-285e748d316b.png)


**Central Luxembourg**
- Currently a couple of the labels are duplicated. This is fixed by these changes
https://www.openstreetmap.org/#map=16/49.6077/6.1190
Current z16
![central-luxembourg-z16 49 6077 6 1190](https://user-images.githubusercontent.com/42757252/51446778-ffa7e980-1d59-11e9-8720-3f7806c07167.png)
After
![central-luxembourg-z16 49 6077 6 1190](https://user-images.githubusercontent.com/42757252/51446781-06cef780-1d5a-11e9-8e34-3edca9e570a0.png)


**National Park Multipolygon at Spain/Andorra Border**
https://www.openstreetmap.org/#map=16/42.5607/1.4081
- This data is from the Andorra extract but it shows the national park across the border correctly 
- The border labels currently do not display on the smaller polygon because it is part of a multi polygon with a larger area, and only the largest polygon is labeled by default
- `text-largest-bbox-only: false` causes the labels to render along the border of the smaller polygon as well (at high enough zoom level so that it is >196,000 waypixels)

z15 Current rendering
![z15-border-park-master](https://user-images.githubusercontent.com/42757252/51446613-fcabf980-1d57-11e9-841c-9b291f5ee354.png)
z16 current
![z16-master-border-park](https://user-images.githubusercontent.com/42757252/51446614-003f8080-1d58-11e9-8abd-a824c3aa07f9.png)

z15 After
![andorra-spain-park-z15-after](https://user-images.githubusercontent.com/42757252/51446619-10eff680-1d58-11e9-9696-ab8929d2db90.png)
z16 After
![z16-spain-andorra-border-park-after](https://user-images.githubusercontent.com/42757252/51446626-16e5d780-1d58-11e9-862e-6362986d64a7.png)


**Boundary=administrative multi-polygon: Oecusse, East Timor**
https://www.openstreetmap.org/#map=16/-9.1772/124.4786
- This small enclave of East Timor is surrounded by Indonesia
- The border text labels do not currently render
Current z16
![z16-timor-border-master](https://user-images.githubusercontent.com/42757252/51446647-61ffea80-1d58-11e9-96ed-194b6f323cae.png)
After z16
![z16-oecusse-timor-border-after-16 -9 1772 124 4786](https://user-images.githubusercontent.com/42757252/51446649-63c9ae00-1d58-11e9-9c60-850e40e6156a.png)

z10 unchanged (to show shape of enclave):
![z10-oecusee-after-10 -9 2255 124 6056](https://user-images.githubusercontent.com/42757252/51446654-7512ba80-1d58-11e9-90d4-3dd7694179b9.png)