### PR TITLE
Add rendering of "ref" for track roads

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1885,12 +1885,12 @@ Layer:
                     osm_id,
                     way,
                     COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential') THEN highway ELSE NULL END,
+                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') THEN highway ELSE NULL END,
                       CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
                     ) AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') OR aeroway IN ('runway', 'taxiway'))
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1903,6 +1903,7 @@ Layer:
               WHEN highway = 'tertiary' THEN 34
               WHEN highway = 'unclassified' THEN 33
               WHEN highway = 'residential' THEN 32
+              WHEN highway = 'track' THEN 30
               WHEN highway = 'runway' THEN 6
               WHEN highway = 'taxiway' THEN 5
               ELSE NULL

--- a/roads.mss
+++ b/roads.mss
@@ -3028,6 +3028,34 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 
+  [highway = 'track'] {
+    [zoom >= 15] {
+      text-name: "[refs]";
+      text-size: 8;
+      text-dy: 5;
+
+      [zoom >= 16] {
+        text-size: 9;
+        text-dy: 7;
+      }
+      [zoom >= 17] {
+        text-size: 11;
+        text-dy: 9;
+      }
+
+      text-clip: false;
+      text-fill: #222;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-margin: 10;
+      text-placement: line;
+      text-spacing: 760;
+      text-repeat-distance: @major-highway-text-repeat-distance;
+      text-vertical-alignment: middle;
+    }
+  }
+
   [highway = 'runway'],
   [highway = 'taxiway'] {
     [zoom >= 15] {


### PR DESCRIPTION
Related to #2052 

### Changes proposed in this pull request:
- Add rendering of "ref" codes and numbers for track roads, using a similar style as used for residential and unclassified roads

### Explanation
Track roads, tagged with highway=track, are used to access agricultural and forestry areas. Many of these small roads are unnamed, but in some areas it is common to use a reference number or string of letter and numbers to refer to such roads. For example, Forest Service roads in North America often have a ref, without a name, or sometimes both. 

Adding rendering of the ref will help with routing in these areas. The style of rendering is rather subtle, using the same style as the name text label rendering.

One issue is that the ref layer is rendered first, so if there is not space for both the name and the ref, the ref alone will be rendered.  But in practice, most track roads with refs are long, so this problem is much more common on highway=residential, which already has a ref rendering. If the ref is more commonly used than the name, this could be seen as a benefit. 

### Test rendering with links to the example places:

**Allotments in the city of Hamburg, Germany**
https://www.openstreetmap.org/#map=15/53.6185/9.9781
z15 Before
![z15-hamburg-ref-master](https://user-images.githubusercontent.com/42757252/51515794-6c091280-1e58-11e9-8db2-b51aee86d7ca.png)
z17 Before
![z17-hamburg-allotments-master](https://user-images.githubusercontent.com/42757252/51515799-6e6b6c80-1e58-11e9-9e0f-e28f5d8f6eb8.png)

z15 After
![hamburg-ref-track-15 53 6185 9 9782](https://user-images.githubusercontent.com/42757252/51513773-e3867400-1e4f-11e9-9bc0-43e5500b3446.png)
z17 After
![z17-hamburg-allotments](https://user-images.githubusercontent.com/42757252/51515814-7a572e80-1e58-11e9-9f04-c964730248f3.png)


**Well-mapped rural area in Maine, USA**
https://www.openstreetmap.org/#map=15/45.7108/-68.8079
z15 Before
![z15-pole-line-master](https://user-images.githubusercontent.com/42757252/51513489-6dcdd880-1e4e-11e9-81ef-8cf73ba33c70.png)
z17 Before
![pole-line-trail-master-z17](https://user-images.githubusercontent.com/42757252/51513515-92c24b80-1e4e-11e9-89a9-0285d1bdbb08.png)

z15 After
![z15-pole-line-trail-after-15 45 7108 -68 8079](https://user-images.githubusercontent.com/42757252/51513498-79b99a80-1e4e-11e9-95a7-600897a40229.png)
z17 After
![z17-pole-line-trail-17 45 69977 -68 79609-after](https://user-images.githubusercontent.com/42757252/51513510-8b02a700-1e4e-11e9-9456-060a752d87e6.png)
https://www.openstreetmap.org/#map=17/45.69977/-68.79609


**Old State Road, Maine**
https://www.openstreetmap.org/#map=18/45.80773/-68.90040
z18 Before
![old-state-road-master](https://user-images.githubusercontent.com/42757252/51513548-b1284700-1e4e-11e9-9b5a-15a606fac10d.png)
After
![z18-old-state-road-after-18 45 80773 -68 90040](https://user-images.githubusercontent.com/42757252/51513550-b2f20a80-1e4e-11e9-8c2a-95f16a532a87.png)


**Logan Pond Trail, Maine**
https://www.openstreetmap.org/#map=16/45.8244/-68.8615
z16 Current
![z16-logan-pond-master](https://user-images.githubusercontent.com/42757252/51513576-d4eb8d00-1e4e-11e9-8657-da9cf2d61cf9.png)
After
![z16-logan-pond-trail-after-16 45 8244 -68 8615](https://user-images.githubusercontent.com/42757252/51513591-e765c680-1e4e-11e9-96ad-bd7242ae7327.png)
