### PR TITLE
Reduce saturation of pitch outline color 

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -63,7 +63,7 @@
 
 // --- Sports ---
 
-@pitch: #aae0cb; // also track
+@pitch: #aae0cb;           // Lch(85,22,168) also track
 @track: @pitch;
 @stadium: @leisure; // also sports_centre
 @golf_course: #b5e3b5;
@@ -684,7 +684,7 @@
     polygon-fill: @track;
     [zoom >= 15] {
       line-width: 0.5;
-      line-color: saturate(darken(@track, 30%), 20%);
+      line-color: desaturate(darken(@track, 20%), 10%);
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -694,7 +694,7 @@
     polygon-fill: @pitch;
     [zoom >= 15] {
       line-width: 0.5;
-      line-color: saturate(darken(@pitch, 30%), 20%);
+      line-color: desaturate(darken(@pitch, 20%), 10%);
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }


### PR DESCRIPTION
Related to #3651 and #3517 

### Changes proposed in this pull request:
- Change the pitch outline color to be the pitch color, darkened 20% and desaturated 10%
- Also changes track outline color in the same way.  (The track and track outline colors are the same as the pitch and pitch outline colors currently)

### Explanation:
- In #3651 and #3517, it's been suggested that the pitch outline is not harmonious with the pitch background color.
- The current pitch outline is 30% darker and 20% more saturated than the pitch color (`#aae0cb` or  Lch(85,22,168). This is a much higher chroma than the pitch background color, so the outline does not appear to be based on the same color. 
- Examining the outline colors for other features, such as residential, commercial and industrial land, shows than most are 15 darker and just slightly higher chroma (in Lch). So a more appropriate color for pitch and track outlines would be  Lch 70,28,168 - 15 points darker than @pitch, and slightly higher chroma:  `#74b9a0`
- Some testing showed that desaturate(darken(@pitch, 20%), 10%) results in an outline color very similar to `#74b9a0` - yes, this is still higher chroma than @pitch, even with desaturate 10%.

### Test rendering with links to the example places:

https://www.openstreetmap.org/#map=17/40.55731/-122.34847
Before
![pitches-master-17 40 55732 -122 34847](https://user-images.githubusercontent.com/42757252/51802090-8c3a3680-2289-11e9-95b6-2304f7be8910.png)

After (Darken20%, desaturate 10%)
![pitches-darken20-desat10-17 40 55731 -122 34847](https://user-images.githubusercontent.com/42757252/51802092-94927180-2289-11e9-9252-6c83998cef86.png)

Compare to earlier test with hard-coded `#74b9a0` for pitch outline:
![pitches-master-17 40 55732 -122 34847](https://user-images.githubusercontent.com/42757252/51802104-c4da1000-2289-11e9-98ea-31df2c60b491.png)

Other examples (after PR):
https://www.openstreetmap.org/#map=16/40.5941/-122.3924
![parkpitches-darken20-desat10-16 40 5941 -122 3924](https://user-images.githubusercontent.com/42757252/51802109-d0c5d200-2289-11e9-98d0-ebc670a8bc45.png)

https://www.openstreetmap.org/#map=16/40.5902/-122.4029.png
![landcolor-darken20-desat10-16 40 5902 -122 4029](https://user-images.githubusercontent.com/42757252/51802108-d02d3b80-2289-11e9-9b5b-c1648282fef3.png)