### PR TITLE
Lighten major buildings fill and outline

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -4,7 +4,8 @@
 
 @building-major-fill: darken(@building-fill, 10%);  // Lch(75, 8, 67)
 @building-major-line: darken(@building-major-fill, 15%);  // Lch(61, 13, 65)
-@building-major-low-zoom: darken(@building-major-fill, 5%);  // Lch(70, 9, 66)
+@building-major-z15: darken(@building-major-fill, 5%);  // Lch(70, 9, 66)
+@building-major-z14: darken(@building-major-fill, 10%);  // Lch(66, 11, 65)
 
 @entrance-permissive: darken(@building-line, 15%);
 @entrance-normal: @building-line;
@@ -24,10 +25,13 @@
     [aerialway = 'station'],
     [building = 'train_station'],
     [public_transport = 'station'] {
-      polygon-fill: @building-major-low-zoom;
+      polygon-fill: @building-major-z14;
       [zoom >= 15] {
-        polygon-fill: @building-major-fill;
+        polygon-fill: @building-major-z15;
         line-color: @building-major-line;
+        [zoom >= 16] {
+          polygon-fill: @building-major-fill;
+        }
       }
     }
   }


### PR DESCRIPTION
Related to #3071
Related to #2532
Related to #3589 
Also see discussion in #3426 

### Changes proposed in this pull request:
- Lighten major-building-fill color: currently it is 20% darker than `@building`. With this PR it will be changed to 10% darker
- Lighten major-building-outline color: currently this is 25% darker than `@major-building-fill`. With this PR it will be changed to 15% darker.

### Explanation:
- The dark major-building-fill color is fine for black icons, such as those used for place_of_worship, but it does not work will with brown, purple and orange icons
- The brown squares for building entrances are the same color as `@building-outline`, currently 15% darker than `@building`, so this is lighter than the major building color. 
- The new color for major-buildings-fill is significantly lighter. Due to the way that `darken` works in the HSL color space, this also means that the color is less saturated and the hue is more similar to `@building` as well. 
- With these changes, icons are better visible in train stations and airports. The one issue is places of worship are not as visible at z15 and z14, however this may be preferable.

### Test rendering with links to the example places:

**Hamburg Airport**
https://www.openstreetmap.org/#map=17/53.63323/10.00529
- Also see the churches nearby on lower zoom levels
z19 Before
![z19-terminal-master](https://user-images.githubusercontent.com/42757252/51815945-9dc22380-2307-11e9-991b-b28c8c9dd4a2.png)
After
![terminal-z19-after-19 53 63323 10 00529](https://user-images.githubusercontent.com/42757252/51815999-dc57de00-2307-11e9-8b5f-4a802775441c.png)

z17 Before
![z17-terminal-master](https://user-images.githubusercontent.com/42757252/51815946-9ef35080-2307-11e9-8181-d074b11dfab2.png)
After
![terminal-z17-after-17 53 63323 10 00529](https://user-images.githubusercontent.com/42757252/51815995-d82bc080-2307-11e9-9193-0c0b850c5d08.png)

z15 Before
![z15-hamburg-airport-master](https://user-images.githubusercontent.com/42757252/51815949-a581c800-2307-11e9-90d1-ae475c63f682.png)
After
![z15-airport-after](https://user-images.githubusercontent.com/42757252/51816003-e11c9200-2307-11e9-8e2c-65efcbdc4eea.png)

**Hamburg train station and downtown churches**
https://www.openstreetmap.org/#map=16/53.5477/10.0028

z18 Before
![z18-hamburg-station-master](https://user-images.githubusercontent.com/42757252/51815955-b0d4f380-2307-11e9-8eb8-8717fa522089.png)
After
![z18-train-station](https://user-images.githubusercontent.com/42757252/51816007-eda0ea80-2307-11e9-801a-eafe8ce7f799.png)

z16 Before
![z16-hamburg-station-master](https://user-images.githubusercontent.com/42757252/51815980-c9450e00-2307-11e9-9749-5b149bbb4f46.png)
After
![z16-train-station-after](https://user-images.githubusercontent.com/42757252/51816010-f1cd0800-2307-11e9-8e00-150ac278749f.png)

z14 Before
![z14-hamburg-station-master](https://user-images.githubusercontent.com/42757252/51815988-d19d4900-2307-11e9-820f-ec051e8cc6fe.png)
After
![z14-hamburg-station-after](https://user-images.githubusercontent.com/42757252/51816013-f5f92580-2307-11e9-82d3-a7ac023e97c2.png)