### PR TITLE
Reduce way_pixels limit to >750 for protected_area boundaries

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -241,7 +241,7 @@ overlapping borders correctly.
 }
 
 #protected-areas {
-  [way_pixels > 3000] {
+  [way_pixels > 750] {
     [zoom >= 8][zoom < 10] {
       ::fill {
         opacity: 0.05;


### PR DESCRIPTION
### Changes proposed in this pull request:
- Renders national_park, nature_reserve, protected area, and aboriginal_lands boundaries at >750 waypixels instead of >3000.
- This causes the boundary outline to render 1 zoom level sooner than the name label for these areas. The text label renders at >3000 waypixels.
- This is also the same limit that is used for tourism areas, such as zoos and amusement parks, with outlines. (Military areas and police stations currently render with > 900 waypixels, similar to the number in this PR.)

### Explanation
- Currently, boundaries for protected areas, national parks, nature reserves and aboriginal_lands are only shown when the polygon is rather large: 3000 square pixels, approximately. For example, a 31 by 101 pixel rectangle will render, but a 30 by 90 pixel polygon would not show the borders at that zoom level.
- 3000 square pixels is also the same limit used to show the text label, because it should usually be large enough the fit the name within the area (though this depends on the shape of the area and the length of the name). This means that the area is not visible until it suddenly appears at a moderately large size, with a name. 
- Previously, tourism areas (zoos and theme parks) were changed to render at 750 way_pixels; this is 1/4 of 3000, so it is 1 zoom level sooner. For example, a 25 x 30 pixel polygon is 750 pixels square. This means the outline normally appears one zoom level before the name (if there is a name). See #2835
- It's logical to render this boundary lines with the same rules, so that the area will be shown one zoom level sooner than the name. 

### Test rendering with links to the example places:

**Lake Gilles, South Australia**
https://www.openstreetmap.org/#map=9/-33.0317/136.9267
Before: z8
![z8-gilles-master](https://user-images.githubusercontent.com/42757252/51983144-470d4300-24db-11e9-94b4-a80557e4d497.png)
z9
![z9-gilles-master-s33 0294-e136 9240](https://user-images.githubusercontent.com/42757252/51983151-4a083380-24db-11e9-9a53-90d175f6c4d6.png)

After: z8
![z8-gilles-750px](https://user-images.githubusercontent.com/42757252/51983162-4ffe1480-24db-11e9-9119-4a309ba5eb72.png)
z9
![z9-lake-gilles-750px](https://user-images.githubusercontent.com/42757252/51983169-53919b80-24db-11e9-9e08-52454a191ad9.png)


**Singapore**
https://www.openstreetmap.org/#map=13/1.3804/103.8138
z12 Before
![z12-singapore-protected-master](https://user-images.githubusercontent.com/42757252/51983181-5f7d5d80-24db-11e9-9805-9711006eae42.png)
z12 After
![z12-singapore-protected-after](https://user-images.githubusercontent.com/42757252/51983188-64421180-24db-11e9-88bb-63eddb076752.png)

Sungei Buloh
z13 Before
![z13-sugei-buloh-master](https://user-images.githubusercontent.com/42757252/51983197-6ad08900-24db-11e9-8c64-fb69cacfbdcc.png)
After: z13
![z13-sungei-buloh-after](https://user-images.githubusercontent.com/42757252/51983207-7623b480-24db-11e9-9b0b-074dd4289c89.png)
z14 same
![z14-sungei-buloh](https://user-images.githubusercontent.com/42757252/51983217-7d4ac280-24db-11e9-8cf3-0b2f2784574b.png)

Chestnut Nature Park (left)
z13 Before
![z13-central-water-master](https://user-images.githubusercontent.com/42757252/51983200-71f79700-24db-11e9-9f6d-cf02e6bea19f.png)
After z13
![z13-central-water-master](https://user-images.githubusercontent.com/42757252/51983200-71f79700-24db-11e9-9f6d-cf02e6bea19f.png)
z14 same
![z14-chestnut-nature-park](https://user-images.githubusercontent.com/42757252/51983221-82a80d00-24db-11e9-95fe-7f24c8d0fc9c.png)