### PR TITLE
Add rendering of "ref" on paths and create new layer for "ref" of minor roads and paths

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1888,13 +1888,10 @@ Layer:
                 SELECT
                     osm_id,
                     way,
-                    COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track', 'bridleway,' 'cycleway,' 'path,' 'steps') THEN highway ELSE NULL END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
-                    ) AS highway,
+                    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway ELSE NULL END AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track', 'bridleway,' 'cycleway,' 'path,' 'steps') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary')
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1905,16 +1902,6 @@ Layer:
               WHEN highway = 'primary' THEN 36
               WHEN highway = 'secondary' THEN 35
               WHEN highway = 'tertiary' THEN 34
-              WHEN highway = 'unclassified' THEN 33
-              WHEN highway = 'residential' THEN 32
-              WHEN highway = 'track' THEN 30
-              WHEN highway = 'bridleway' THEN 10
-              WHEN highway = 'cycleway' THEN 10
-              WHEN highway = 'footway' THEN 10
-              WHEN highway = 'path' THEN 10
-              WHEN highway = 'steps' THEN 10
-              WHEN highway = 'runway' THEN 6
-              WHEN highway = 'taxiway' THEN 5
               ELSE NULL
             END DESC NULLS LAST,
             height DESC,
@@ -2053,6 +2040,61 @@ Layer:
         ) AS railways_text_name
     properties:
       minzoom: 11
+  - id: roads-text-ref-minor
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            highway,
+            height,
+            width,
+            refs
+          FROM (
+            SELECT
+                osm_id,
+                way,
+                highway,
+                array_length(refs,1) AS height,
+                (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
+                array_to_string(refs, E'\n') AS refs
+              FROM (
+                SELECT
+                    osm_id,
+                    way,
+                    COALESCE(
+                      CASE WHEN highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') THEN highway ELSE NULL END,
+                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
+                    ) AS highway,
+                    string_to_array(ref, ';') AS refs
+                  FROM planet_osm_line
+                  WHERE (highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') OR aeroway IN ('runway', 'taxiway'))
+                    AND ref IS NOT NULL
+              ) AS p) AS q
+          WHERE height <= 4 AND width <= 11
+          ORDER BY
+            CASE
+              WHEN highway = 'unclassified' THEN 33
+              WHEN highway = 'residential' THEN 32
+              WHEN highway = 'track' THEN 30
+              WHEN highway = 'bridleway' THEN 10
+              WHEN highway = 'cycleway' THEN 10
+              WHEN highway = 'footway' THEN 10
+              WHEN highway = 'path' THEN 10
+              WHEN highway = 'steps' THEN 10
+              WHEN highway = 'runway' THEN 6
+              WHEN highway = 'taxiway' THEN 5
+              ELSE NULL
+            END DESC NULLS LAST,
+            height DESC,
+            width DESC,
+            refs,
+            osm_id
+        ) AS roads_text_ref_minor
+    properties:
+      minzoom: 15
   - id: text-poly-low-zoom
     class: text-low-zoom
     geometry: polygon

--- a/project.mml
+++ b/project.mml
@@ -1889,12 +1889,12 @@ Layer:
                     osm_id,
                     way,
                     COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') THEN highway ELSE NULL END,
+                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track', 'bridleway,' 'cycleway,' 'path,' 'steps') THEN highway ELSE NULL END,
                       CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
                     ) AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track', 'bridleway,' 'cycleway,' 'path,' 'steps') OR aeroway IN ('runway', 'taxiway'))
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1908,6 +1908,11 @@ Layer:
               WHEN highway = 'unclassified' THEN 33
               WHEN highway = 'residential' THEN 32
               WHEN highway = 'track' THEN 30
+              WHEN highway = 'bridleway' THEN 10
+              WHEN highway = 'cycleway' THEN 10
+              WHEN highway = 'footway' THEN 10
+              WHEN highway = 'path' THEN 10
+              WHEN highway = 'steps' THEN 10
               WHEN highway = 'runway' THEN 6
               WHEN highway = 'taxiway' THEN 5
               ELSE NULL

--- a/roads.mss
+++ b/roads.mss
@@ -3056,6 +3056,35 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
   }
 
+  [highway = 'bridleway'],
+  [highway = 'cycleway'],
+  [highway = 'footway'],
+  [highway = 'path'],
+  [highway = 'steps'] {
+    [zoom >= 16] {
+      text-name: "[refs]";
+      text-fill: #222;
+      text-size: 9;
+      text-clip: false;
+      text-dy: 7;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-margin: 10;
+      text-placement: line;
+      text-repeat-distance: @major-highway-text-repeat-distance;
+      text-spacing: 760;
+      text-vertical-alignment: middle;
+      [highway = 'steps'] {
+        text-repeat-distance: @minor-highway-text-repeat-distance;
+      }
+      [zoom >= 17] {
+        text-size: 11;
+        text-dy: 9;
+      }
+    }
+  }
+
   [highway = 'runway'],
   [highway = 'taxiway'] {
     [zoom >= 15] {

--- a/roads.mss
+++ b/roads.mss
@@ -3015,8 +3015,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 16] {
         text-size: 9;
       }
-      [zoom >= 18] {
-        text-size: 10;
+      [zoom >= 17] {
+        text-size: 11;
       }
 
       text-fill: #000;

--- a/roads.mss
+++ b/roads.mss
@@ -3023,7 +3023,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-placement: line;
       text-repeat-distance: @major-highway-text-repeat-distance;
-      text-halo-radius: 2;
+      text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 760;
       text-clip: false;
@@ -3072,7 +3072,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-margin: 10;
       text-placement: line;
       text-repeat-distance: @major-highway-text-repeat-distance;
       text-spacing: 760;

--- a/roads.mss
+++ b/roads.mss
@@ -3003,7 +3003,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
   }
+}
 
+#roads-text-ref-minor {
   [highway = 'unclassified'],
   [highway = 'residential'] {
     [zoom >= 15] {


### PR DESCRIPTION
Closes Issue #2052
Follow-up to PR #3654

### Changes proposed in this pull request:

1) Add rendering of "ref" numbers for paths (highway= bridleway, cycleway, footway, path, steps)

2)  Move aeroways, minor roads, tracks and paths "ref" to a later layer, after name labels are rendered

3) Minor changes:
- Change text-halo to standard size highway=unclassified/residential refs and aeroway refs
- Change residential / unclassified road "ref" size to 11 point at z17, to be the same size as the name text labels at this zoom level and higher. 

### Explanation

**1) Map users have requested rendering for the "ref" (reference numbers) for paths**
- Some paths are unnamed, but have a ref
- Other have both a name and a ref number, which can be useful for following longer routes
- This is most common with long-distance footways and cycleways, but can sometimes be found for other paths as well

**2) The minor roads, aeroways, and tracks with text-based ref labels currently render in the same layer as the shields for major roads.** 
- This means that the ref text is rendered before the name label, and can block the name from rendering when spaces is limited.
- Major road shields render much sooner than the ref text labels of minor roads and paths, which are not shown until z15 or z16.
- Major road shields are usually more important than the name; the number of a motorway is used more often, but for minor roads, such as residential streets, the name is more useful and should be shown with higher priority
- Changing residential, unclassified and paths to a later layer will fix this rendering. Aeroways "ref" text labels are also moved to this new layer because they are also rendered only at z15 and higher, though this does not change the cartography because they do not have a rendering for names

**3) The "ref" labels rendering for residential/unclassified roads needs minor adjustments**
- At z17, the "name" text label increases to 11pt font size, but the ref does not change size till z18 currently. This should be adjusted so that the "ref" label is the same size as the name label, as at z15 and z16.
- The halo needs to be changed to standard size. Right now it is 2 pixels wide, which would overlap with the casing at certain zoom levels. 

### Test rendering with links to the example places:

**highway=unclassified with name and ref** - Basilicata, Italy 
https://www.openstreetmap.org/#map=17/40.3776321/15.7281581
Before z17
![via-chiusululle-unclassified-master](https://user-images.githubusercontent.com/42757252/52036343-55596e80-2570-11e9-92ba-d9ae1d158950.png)
z18
![z18-via-chiusululle-master](https://user-images.githubusercontent.com/42757252/52036353-5b4f4f80-2570-11e9-8191-8d5a7b4ec879.png)
After z17
![chiusululle-z17-after](https://user-images.githubusercontent.com/42757252/52040702-a0c54a00-257b-11e9-9b31-d594436d84b5.png)
z18
![chiusululle-z18-after](https://user-images.githubusercontent.com/42757252/52040720-a6bb2b00-257b-11e9-9baa-e369050e3a22.png)


**highway=residential with name and ref** - Basilicata, Italy 
https://www.openstreetmap.org/#map=17/40.1412792/16.0893142
Before z17
![via-vittorio-res-z17-master](https://user-images.githubusercontent.com/42757252/52036418-74f09700-2570-11e9-9150-b7f89441fcb0.png)
z18
![via-vitorio-z18-master](https://user-images.githubusercontent.com/42757252/52036426-77eb8780-2570-11e9-9e24-bddfaf3357c9.png)
After z17
![z17-via-vittorio-after](https://user-images.githubusercontent.com/42757252/52036435-7cb03b80-2570-11e9-9cd9-256760bfc710.png)
z18
![via-vittori-z18-after](https://user-images.githubusercontent.com/42757252/52040731-ae7acf80-257b-11e9-8a78-e0b4b13777dc.png)


**highway=path with name and ref** - Basilicata, Italy 
https://www.openstreetmap.org/#map=16/40.4133/15.6249
Before z16
![z16-sentiero-master](https://user-images.githubusercontent.com/42757252/52036488-8b96ee00-2570-11e9-8593-1ab069405b3b.png)
After z16
![z16-sentiero-refs-after-16-n40 4133-e15 624916](https://user-images.githubusercontent.com/42757252/52036492-8f2a7500-2570-11e9-8d23-5be02b0ddaf7.png)

**highway=path with name and ref** - Montenegro
https://www.openstreetmap.org/#map=1616/42.6710/19.6521
Before z16
![ref355-master](https://user-images.githubusercontent.com/42757252/52036531-9cdffa80-2570-11e9-9ecb-f95381ca9018.png)
After z16
![path-ref355-after-16 42 6710 19 6521](https://user-images.githubusercontent.com/42757252/52036505-981b4680-2570-11e9-95c6-1bf7a5ab7373.png)

**highway=footway with ref** - Brussels, Belgium
https://www.openstreetmap.org/#map=19/50.85126/4.33989
Before z19
![r20-master](https://user-images.githubusercontent.com/42757252/52036548-a5d0cc00-2570-11e9-9bd9-b0b477da166b.png)
After z19
![r20-footway-ref-after-19 50 85126 4 33989](https://user-images.githubusercontent.com/42757252/52036549-a8332600-2570-11e9-9a49-7b7cd94403df.png)

**highway=cycleway with ref** - Brussels, Belgium
https://www.openstreetmap.org/#map=17/50.87994/4.29554
Before z17
![n9f-master](https://user-images.githubusercontent.com/42757252/52036622-bed97d00-2570-11e9-9383-d7f0ea30db6a.png)
After z17
![n9f-cycleway-ref-after-17 50 87994 4 29554](https://user-images.githubusercontent.com/42757252/52036586-b719d880-2570-11e9-83fd-ec29204276b1.png)

**highway=cycleway with ref** - Brussels, Belgium
https://www.openstreetmap.org/#map=18/50.86575/4.36460
Before z18
![n277-master](https://user-images.githubusercontent.com/42757252/52036633-c39e3100-2570-11e9-98a3-10ae2a2cb88d.png)
After z18
![n277-cycleway-ref-after-18 50 86575 4 36460](https://user-images.githubusercontent.com/42757252/52036636-c6008b00-2570-11e9-9c88-c6a11b81d46a.png)

**highway=bridleway with ref** - Canada
https://www.openstreetmap.org/#map=16/52.8965/-118.1050
Before z16
![bridleway-refs-master](https://user-images.githubusercontent.com/42757252/52036651-cd279900-2570-11e9-93e7-a69fad87da6a.png)
After z16
![bridleways-path-ref-after-16 52 8965 -118 1050](https://user-images.githubusercontent.com/42757252/52036658-cf89f300-2570-11e9-8d4a-96c1e31f9e47.png)

**highway=steps with ref** (and path with ref) - Germany
https://www.openstreetmap.org/#map=19/47.45867/11.12463
Before z19
![kalbersteig-master](https://user-images.githubusercontent.com/42757252/52036694-d6186a80-2570-11e9-90ae-f7d33ef809d6.png)
After z19
![z19-kalbersteig-steps-path-19 47 45867 11 12463](https://user-images.githubusercontent.com/42757252/52036700-da448800-2570-11e9-9c0f-2494e3936601.png)