### PR TITLE
[WIP] Borders rework

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #6b516b;
+@admin-boundaries-level2: #6b516b;
 @admin-boundaries-level3: #764f76;
 @admin-boundaries-level4: #814d81;
 @admin-boundaries-level5: #8c4c8c;
@@ -26,7 +26,7 @@ overlapping borders correctly.
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-level2;
       line-width: 1.2;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;

--- a/admin.mss
+++ b/admin.mss
@@ -213,7 +213,7 @@ overlapping borders correctly.
 #admin-text[zoom >= 16] {
   text-name: "[name]";
   text-face-name: @book-fonts;
-  text-fill: @admin-boundaries;
+  text-fill: @admin-boundaries-level5;
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;
   text-placement: line;

--- a/admin.mss
+++ b/admin.mss
@@ -1,4 +1,10 @@
-@admin-boundaries: #ac46ac;
+@admin-boundaries: #6b516b;
+@admin-boundaries-level3: #764f76;
+@admin-boundaries-level4: #814d81;
+@admin-boundaries-level5: #8c4c8c;
+@admin-boundaries-level6: #964a96;
+@admin-boundaries-level7-8: #a148a1;
+@admin-boundaries-level9-10: #ac46ac;
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;
@@ -59,7 +65,7 @@ overlapping borders correctly.
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-level3;
       line-width: 0.6;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
@@ -83,7 +89,7 @@ overlapping borders correctly.
       background/line-width: 0.4;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-level4;
       line-join: bevel;
       line-width: 0.4;
       line-simplify: @admin-simplify;
@@ -140,7 +146,7 @@ overlapping borders correctly.
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
-    line-color: @admin-boundaries;
+    line-color: @admin-boundaries-level5;
     line-width: 2;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
@@ -154,7 +160,7 @@ overlapping borders correctly.
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
-    line-color: @admin-boundaries;
+    line-color: @admin-boundaries-level6;
     line-width: 2;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
@@ -170,7 +176,7 @@ overlapping borders correctly.
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-level7-8;
       line-width: 1.5;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
@@ -192,7 +198,7 @@ overlapping borders correctly.
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-level9-10;
       line-width: 2;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;

--- a/placenames.mss
+++ b/placenames.mss
@@ -1,7 +1,7 @@
 @placenames: #222;
 @placenames-light: #777777;
 @country-labels: darken(@admin-boundaries, 15%);
-@state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
+@state-labels: desaturate(darken(@admin-boundaries-level4, 5%), 20%);
 
 .country {
   [zoom >= 3][zoom < 5][way_pixels > 1000], 

--- a/placenames.mss
+++ b/placenames.mss
@@ -1,6 +1,6 @@
 @placenames: #222;
 @placenames-light: #777777;
-@country-labels: darken(@admin-boundaries, 15%);
+@country-labels: darken(@admin-boundaries-level2, 15%);
 @state-labels: desaturate(darken(@admin-boundaries-level4, 5%), 20%);
 
 .country {

--- a/placenames.mss
+++ b/placenames.mss
@@ -35,11 +35,10 @@
       text-line-spacing: -0.7; // -0.05 em
     }
     text-fill: @country-labels;
-    text-face-name: @book-fonts;
+    text-face-name: @bold-fonts;
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
     text-placement: interior;
-    text-character-spacing: 0.5;
   }
 }
 

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -7,7 +7,7 @@
     [zoom >= 3] {
       line-width: 0.4;
     }
-    line-color: @admin-boundaries;
+    line-color: @admin-boundaries-level2;
   }
 }
 


### PR DESCRIPTION
This is a technical replacement for #3553, it should also make easier to catch up with the current state of proposed changes and includes changes from #3652.

Fixes #3489.
Closes #3526.
Related to #621 and #3102.
Related to #3563

Changes proposed in this pull request:
- use color palette from much darker for level 2 (`#ac46ac` +75% of grey =  `#6b516b`) to the current `#ac46ac` for levels 9+10 (using @vholten patches)
- render country names in bold
- render admin names along the lines with medium color from the palette (level 5 - `#8c4c8c`)

I believe this is minimal set of changes to make sense. Further ideas for border improvements dropped from this PR:
- moving state labels into medium font to make them more distinct
- inserting level 5 pattern (`-...-...`), which in turn gives us possibility to use dots (maybe for example with some spacing, like: `... ... ...`) to render admin levels 11 and 12

# Names rendering

Countries and states - basically the same as in previous PR

![screenshot_2019-02-03 openstreetmap carto kosmtik](https://user-images.githubusercontent.com/5439713/52173115-79d66600-277d-11e9-9757-deeb0cd9e9f6.png)

All labels on lines (z16+) - this shade of violet is less magenta, but still is recognizable and different from other violet and blue objects:

Before/After https://www.openstreetmap.org/#map=17/52.32949/20.92530

![screenshot_2019-02-03 openstreetmap carto kosmtik 1](https://user-images.githubusercontent.com/5439713/52173155-ac349300-277e-11e9-9d86-98bad74c32ba.png)
![screenshot_2019-02-03 openstreetmap carto kosmtik 2](https://user-images.githubusercontent.com/5439713/52173156-adfe5680-277e-11e9-84ed-7c3e032526fa.png)

# Borders rendering

level 2, 4 and 6 - https://www.openstreetmap.org/#map=11/54.3842/19.7208

![screenshot_2019-02-03 openstreetmap carto kosmtik 3](https://user-images.githubusercontent.com/5439713/52173207-cfac0d80-277f-11e9-9fa1-35065bb5e561.png)

level 8 and 9 - https://www.openstreetmap.org/#map=19/51.63551/20.94475

![screenshot_2019-02-03 openstreetmap carto kosmtik 4](https://user-images.githubusercontent.com/5439713/52173333-ba84ae00-2782-11e9-852d-b3eec8637087.png)
