### PR TITLE
[WIP] Render Golf Course Features

### DIFF
--- a/golf.mss
+++ b/golf.mss
@@ -3,6 +3,8 @@
 Coloring specific to golf and golf courses.
 derived from https://raw.githubusercontent.com/imagico/osm-carto-alternative-colors/master/golf.mss
 
+Inspired by the French rendering style and @cquest
+
 */
 
 /* Pinning most grass/plant features relative to grass (natural) and pitch (sporting) */

--- a/golf.mss
+++ b/golf.mss
@@ -1,0 +1,100 @@
+/*
+
+Coloring specific to golf and golf courses.
+derived from https://raw.githubusercontent.com/imagico/osm-carto-alternative-colors/master/golf.mss
+
+*/
+
+/* Pinning most grass/plant features relative to grass (natural) and pitch (sporting) */
+/* The desire is to "move with" changes of these other colors without looking out of place */
+/* Use @water-color for water hazards */
+
+#landcover[zoom >= 14] {
+  [feature = 'golf_rough'] {
+    polygon-fill: darken(@grass, 60%); // Darkest color, rendered lowest
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  [feature = 'golf_fairway'],
+  [feature = 'golf_driving_range'] {
+    polygon-fill: darken(@grass, 45%); // Typical green grass
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  [feature = 'golf_water_hazard'],
+  [feature = 'golf_lateral_water_hazard'] {
+    polygon-fill: @water-color;
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  [feature = 'golf_green'] {
+    polygon-fill: darken(@grass, 30%);  // Manicured sports turf
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  [feature = 'golf_bunker'] {
+    polygon-fill: @sand; // Typically filled with sand
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+  [feature = 'golf_tee'] {
+    polygon-fill: darken(@grass, 45%); // Distinctive from rough, fairway, green
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+  }
+}
+
+#golf-lines[zoom >= 16] {
+  [golf = 'path'][geo = 'line'] {
+    line-color: darken(@pitch, 15%); // Probably a grass trail
+    line-width: 2.0;
+    [name != ''] {
+      text-placement: line;
+      text-name: "[name]";
+      text-face-name: @book-fonts;
+      text-halo-radius: 1;
+      text-halo-fill: fadeout(white, 30%);
+    }
+  }
+  [golf = 'cartpath'][geo = 'line'] {
+    line-color: grey;
+    line-width: 2.0;
+    [name != ''] {
+      text-placement: line;
+      text-name: "[name]";
+      text-face-name: @book-fonts;
+      text-halo-radius: 1;
+      text-halo-fill: fadeout(white, 30%);
+    }
+  }
+  [golf = 'hole'][geo = 'line'] {
+    line-color: black;
+    line-width: 0.5;
+    [name != ''] {
+      text-placement: line;
+      text-name: "[name]";
+      text-face-name: @book-fonts;
+      text-halo-radius: 1;
+      text-halo-fill: fadeout(white, 30%);
+    }
+  }
+  [golf = 'hole'][geo='point'],
+  [golf='pin'] {
+    point-file: url('symbols/golf_pin.svg');
+    [ref != ''] {
+      text-fill: #444;
+      text-name: "[ref]";
+      text-face-name: @book-fonts;
+      text-dy: -10;
+      text-halo-radius: 1;
+      text-halo-fill: fadeout(white, 30%);
+    }
+  }
+  [golf = 'out_of_bounds'] {
+    line-color: white;
+    line-width: 1.5;
+    line-cap: round;
+    line-dasharray: 1,8;
+  }
+}
+

--- a/landcover.mss
+++ b/landcover.mss
@@ -66,7 +66,7 @@
 @pitch: #aae0cb;           // Lch(85,22,168) also track
 @track: @pitch;
 @stadium: @leisure; // also sports_centre
-@golf_course: #b5e3b5;
+@golf_course: rgba(222,246,192,0.4);
 
 #landcover-low-zoom[zoom < 10],
 #landcover[zoom >= 10] {

--- a/project.mml
+++ b/project.mml
@@ -53,6 +53,7 @@ Stylesheet:
   - aerialways.mss
   - admin.mss
   - addressing.mss
+  - golf.mss
 Layer:
   - id: world
     geometry: polygon
@@ -70,6 +71,32 @@ Layer:
       type: shape
     properties:
       minzoom: 10
+  - id: golf-lines
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way, geo, golf, ref, name
+          FROM
+            (SELECT
+                way, tags->'golf' AS golf, name, ref, 0 AS prio, 'polygon' AS geo
+              FROM planet_osm_polygon
+              WHERE (tags->'golf') IS NOT NULL AND way && !bbox!
+            UNION ALL
+            SELECT
+                p.way, p.tags->'golf' AS golf, p.name, coalesce(p.ref,l.ref) AS ref, 0 AS prio, 'point' AS geo
+              FROM planet_osm_point p LEFT JOIN planet_osm_line l ON (ST_Intersects(p.way, l.way) AND (l.tags->'golf') IS NOT NULL)
+              WHERE p.tags ? 'golf' AND p.way && !bbox!
+            UNION ALL
+            SELECT
+                way, tags->'golf' AS golf, name, ref, 1 AS prio, 'line' AS geo
+              FROM planet_osm_line WHERE (tags->'golf') IS NOT NULL AND way && !bbox!
+            ) AS golf
+          ORDER BY prio
+        ) AS golf_lines
+    properties:
+      minzoom: 16
   - id: necountries
     geometry: linestring
     <<: *extents84
@@ -114,11 +141,19 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, name, religion, way_pixels, is_building,
-            COALESCE(aeroway, amenity, wetland, power, landuse, leisure, man_made, "natural", tourism, highway, railway) AS feature
+            way,
+            name,
+            religion,
+            way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
+            is_building,
+            feature
           FROM (SELECT
+              way, name, religion, way_area, is_building, layer, prio,
+              COALESCE(aeroway, golf, amenity, wetland, power, landuse, leisure, man_made, "natural", tourism, highway, railway) AS feature
+            FROM (SELECT
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
+              ('golf_' || (CASE WHEN (tags->'golf') IN ('rough', 'fairway', 'driving_range', 'water_hazard', 'lateral_water_hazard', 'green', 'bunker', 'tee') THEN tags->'golf' ELSE NULL END)) AS golf,
               ('amenity_' || (CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
                                                     'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
                                                     'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space', 'bus_station',
@@ -142,10 +177,11 @@ Layer:
               CASE WHEN religion IN ('christian', 'jewish', 'muslim') THEN religion ELSE 'INT-generic'::text END AS religion,
               way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
               CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building,
-              way_area
+              way_area, layer, 0 AS prio
             FROM planet_osm_polygon
             WHERE (landuse IS NOT NULL
               OR leisure IS NOT NULL
+              OR (tags->'golf') IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'taxi', 'university', 'college', 'school', 'hospital', 'kindergarten',
                              'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
@@ -159,7 +195,16 @@ Layer:
               OR railway = 'station')
               AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ) AS landcover
-          ORDER BY way_area DESC, feature
+          UNION ALL -- this is only needed because closed ways with a golf0* tag are by default not treated as polygons
+          SELECT
+              way, COALESCE(name, '') AS name,
+              'INT-generic'::text AS religion, 0 AS way_area, 'no' AS is_building, layer,
+              (CASE WHEN (tags->'golf') = 'rough' THEN 1 WHEN (tags->'golf') = 'fairway' THEN 10 WHEN (tags->'golf') = 'driving_range' THEN 10 WHEN (tags->'golf') = 'green' THEN 20 WHEN (tags->'golf') = 'bunker' THEN 30 ELSE 40 END) AS prio,
+              ('golf_' || (CASE WHEN (tags->'golf') IN ('rough', 'fairway', 'driving_range', 'water_hazard', 'lateral_water_hazard', 'green', 'bunker', 'tee') THEN tags->'golf' ELSE NULL END)) AS feature
+            FROM planet_osm_line
+            WHERE (tags->'golf') IS NOT NULL
+        ) AS landcover_all
+        ORDER BY COALESCE(layer,0), prio, way_area DESC
         ) AS features
     properties:
       minzoom: 10

--- a/symbols/golf_pin.svg
+++ b/symbols/golf_pin.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   height="23"
+   width="9">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       y="0"
+       x="0"
+       height="23"
+       width="9"
+       id="rect4159"
+       style="stroke:none;fill:none;visibility:hidden" />
+    <path
+       id="rect7"
+       d="M 4 1 L 4 10.773438 A 2.107161 0.75 0 0 0 2.3925781 11.5 A 2.107161 0.75 0 0 0 4.5 12.25 A 2.107161 0.75 0 0 0 6.6074219 11.5 A 2.107161 0.75 0 0 0 5 10.773438 L 5 4 L 9 2.5566406 L 5 1 L 4 1 z "
+       style="fill:#000000;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #3650 #661 

Changes proposed in this pull request:
- Add golf.mss for specific coloring of golf course features (no new colors, just referencing existing)
- Support golf ways as closed polygons

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=18/36.17554/-115.28420
https://www.openstreetmap.org/#map=17/48.67095/9.41785
https://www.openstreetmap.org/#map=16/40.1428/-83.1404

Before
![currentgolfcourse](https://user-images.githubusercontent.com/230240/52267486-fdaf6000-28ed-11e9-9e7b-7adbc7c378e1.PNG)

After
![proposedgolfcourse](https://user-images.githubusercontent.com/230240/52267493-030caa80-28ee-11e9-8b6a-848f690cf993.PNG)

@Adamant36 @jeisenbe @imagico Here's how far I got.

There's some issues with laying, I can't figure exactly why the line:
`ORDER BY COALESCE(layer,0), prio, way_area DESC`
isn't working as expected.

Two changes I see that need to be resolved before merging:

- [ ] The change of golf-course with an alpha is planned to be reverted, but if the alpha transparency isn't used, it covers all of the golf features.
- [ ] Line features are rendering behind the way areas.

Mostly I took @imagico 's fork and made it as vanilla/compatible as possible:
https://github.com/imagico/osm-carto-alternative-colors/commit/181360550f12bfdc3589d706e89ae60ae28edbfc#diff-2d6c6d06f63a6fab47286addedefc335

@imagico Are there any licensing needs for the assets (pin svg)/code snippets borrowed from your fork?