### PR TITLE
Show administrative boundary text labels from z11 to z16 based on admin_level

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -204,20 +204,30 @@ overlapping borders correctly.
   comp-op: darken;
 }
 
-#admin-text[zoom >= 16] {
-  text-name: "[name]";
-  text-face-name: @book-fonts;
-  text-fill: @admin-boundaries;
-  text-halo-radius: @standard-halo-radius;
-  text-halo-fill: @standard-halo-fill;
-  text-largest-bbox-only: false;
-  text-placement: line;
-  text-spacing: 750;
-  text-repeat-distance: 250;
-  text-margin: 10;
-  text-clip: true;
-  text-vertical-alignment: middle;
-  text-dy: -10;
+#admin-text[zoom >= 11][way_pixels >= 48000] {
+  [admin_level = '1'][way_pixels >= 360000],
+  [admin_level = '2'][way_pixels >= 360000],
+  [admin_level = '3'][way_pixels >= 196000],
+  [admin_level = '4'][way_pixels >= 196000],
+  [zoom >= 12][admin_level = '5'],
+  [zoom >= 13][admin_level = '6'],
+  [zoom >= 14][admin_level = '7'],
+  [zoom >= 15][admin_level = '8'],
+  [zoom >= 16] {
+    text-name: "[name]";
+    text-face-name: @book-fonts;
+    text-fill: @admin-boundaries;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-largest-bbox-only: false;
+    text-placement: line;
+    text-spacing: 750;
+    text-repeat-distance: 250;
+    text-margin: 10;
+    text-clip: true;
+    text-vertical-alignment: middle;
+    text-dy: -10;
+  }
 }
 
 #protected-areas-text[zoom >= 13][way_pixels > 192000] {

--- a/project.mml
+++ b/project.mml
@@ -2549,15 +2549,16 @@ Layer:
         (SELECT
             way,
             name,
-            admin_level
+            admin_level,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE boundary = 'administrative'
-            AND admin_level IN ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
+            AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:
-      minzoom: 16
+      minzoom: 11
   - id: protected-areas-text
     geometry: linestring
     <<: *extents


### PR DESCRIPTION
Related to #622
Also see #3649


## Changes proposed in this pull request:
- Render admin_level 1 to 4 text labels along the admin boundary lines from z11
- Redner admin_level 5 to 8 text labels along the border lines from z12 to z15 based on admin_level (5 at z12, 6 and z13, 7 at z14, 8 at z15), and admin_level 9 and 10 will continue to render at z16 and higher.
- Add a minimum way_pixels limit for admin 1 to 4 which are the same as largest central text label rendering. Thus the text labels will appear along the border lines when the total area is greater than 360,000 pixels for admin_level 1 and 2, and 196,000 way_pixels for admin_level 3 and 4. The limit is 48,000 way_pixels for higher admin_level, which have no other text labels.
- Remove unnecessary `admin_level IN ('0',` from query, as this level is not used. 


## Explanation:
- Border text labels are currently only shown along the administrative boundaries at z16 and higher. However, protected_areas such as National Parks, and aboriginal lands, have these text labels from z13. 
- It can be difficult to tell the admin_level of a border from the pattern, even for people with some experience with OSM, without the name of the area
- The French style shows these text labels along the borders at z11 for admin levels 1 to 4, at z13 for levels 5 and 6, and at z15 for the others.
- Showing these text labels will make it possible to recognize the borders sooner. This is particularly helpful for admin level 5 to 8, which do not have any label at their center, and which can take up quite large areas on the map in many countries. 
- Adding filtering by way_pixels will help prevent displaying the text labels on very small areas. (This is often found with admin_level 8 to 10 in some Asian countries, such as Japan and Indonesia). The limit is 48,000, or one zoom level sooner than the admin_level 4 border labels will be displayed for small areas. This is equivalent to 200 by 240 pixels or 100 by 480 pixels on-screen, that is, 5% to 10% of a typical window size. 


## Test renderings with links to the current rendering:

Dili, East Timor, z11
  Here we see one admin_level=4 with a central label (because it is less than 196000 way_pixels in area), while the others have no central label, but now do have labels along the border (>196k way_pixels) 
https://www.openstreetmap.org/#map=11/-8.6666/125.6661
![provinces-dili-11 -8 6666 125 6661](https://user-images.githubusercontent.com/42757252/52403003-092aa300-2b09-11e9-8ab3-ae3219332b53.png)

Oecusse, Enclave of East Timor in Indonesia, z11
https://www.openstreetmap.org/#map=z11/-9.3115/124.2749
![oecusse-z-11 -9 3115 124 2749](https://user-images.githubusercontent.com/42757252/52402993-00d26800-2b09-11e9-8533-5f9f055b2f93.png)

Andorra, z11
  No border labels are displayed at z11, because the admin_level=2 area is <360000 pixels
https://www.openstreetmap.org/#map=11/42.5096/1.5346
![z11-andorra-after](https://user-images.githubusercontent.com/42757252/52402835-a0432b00-2b08-11e9-8636-c581f86307ba.png)

Ashgabat, Turkmenistan, z11
https://www.openstreetmap.org/#map=11/37.9504/58.1925
![ashgabat-11 37 9504 58 1925-after](https://user-images.githubusercontent.com/42757252/52400135-9ec23480-2b01-11e9-83d2-5fadb05e0057.png)

Port Moresby, Papua New Guinea, z11
https://www.openstreetmap.org/#map=11/-9.5168/147.2635
![port-moresby-11 -9 5168 147 2635](https://user-images.githubusercontent.com/42757252/52400079-720e1d00-2b01-11e9-8d16-730a012a73a1.png)

Port Moresby, z12
![port-moresby-12 -9 4386 147 2552](https://user-images.githubusercontent.com/42757252/52400085-763a3a80-2b01-11e9-92ae-9ba5585d758b.png)

Liechtenstein, z13
https://www.openstreetmap.org/#map=13/47.2027/9.5424
![oberland-unterland-z-13 47 2027 9 5424](https://user-images.githubusercontent.com/42757252/52404276-f1085300-2b0b-11e9-8da6-0c50cd766e1d.png)

Yogyakarta, Indonesia, z14
![z14-yogyakarta-after-40k](https://user-images.githubusercontent.com/42757252/52406173-6e35c700-2b10-11e9-82d8-e21c77374a08.png)

Koutio, New Caledonia, z15
https://www.openstreetmap.org/#map=15/-22.2183/166.4791
![koutio-new-caledonia-15 -22 2183 166 4791-after](https://user-images.githubusercontent.com/42757252/52400125-94a03600-2b01-11e9-9bdc-620b9e255113.png)