### PR TITLE
Differentiate rendering of minor buildings with lighter fill and lighter outline

### DIFF
--- a/buildings.mss
+++ b/buildings.mss
@@ -7,6 +7,10 @@
 @building-major-z15: darken(@building-major-fill, 5%);  // Lch(70, 9, 66)
 @building-major-z14: darken(@building-major-fill, 10%);  // Lch(66, 11, 65)
 
+@building-minor-fill: lighten(@building-fill, 2%);
+@building-minor-line: lighten(@building-line, 10%);
+@building-minor-low-zoom: @building-fill;
+
 @entrance-permissive: darken(@building-line, 15%);
 @entrance-normal: @building-line;
 
@@ -32,6 +36,27 @@
         [zoom >= 16] {
           polygon-fill: @building-major-fill;
         }
+      }
+    }
+    [building = 'barn'],
+    [building = 'carport'],
+    [building = 'cowshed'],
+    [building = 'construction'],
+    [building = 'farm_auxiliary'],
+    [building = 'garage'],
+    [building = 'garages'],
+    [building = 'ger'],
+    [building = 'greenhouse'],
+    [building = 'hut'],
+    [building = 'roof'],
+    [building = 'service'],
+    [building = 'shed'],
+    [building = 'slurry_tank'],
+    [building = 'stable'] {
+      polygon-fill: @building-minor-low-zoom;
+      [zoom >= 15] {
+        polygon-fill: @building-minor-fill;
+        line-color: @building-minor-line;
       }
     }
   }


### PR DESCRIPTION
Fixes #2532
Also see Issues #68 and #1207
See PRs #434, PR #490, #565, #568, #1153, #3426 

## Changes proposed in this pull request:
- Render minor buildings different than other buildings, by using a 10% lighter outline, and a 2% lighter fill color at z15 and higher. At z14 the outline is not used, but the fill color will be 4% lighter than other buildings at this zoom level. 
- The list of "minor buildings" initially includes: huts & yurts, garages, farm buildings, service buildings and sheds, roofs and under-construction buildings. (See #3426 for previous discussion)

### Initial list of minor buildings:
This list of values for the key "building" is based off of tags that have more than 9000 uses in the database, according to  [Taginfo](https://taginfo.openstreetmap.org/keys/building#values)

- barn 
- carport
- cowshed (9 ,159 uses)
- construction
- farm_auxiliary    [building = 'construction'],
- garage
- garages
- ger _[aka "yurt"]_
- greenhouse
- hut
- roof
- service
- shed
- slurry_tank
- stable

## Discussion
- Rendering sheds, garages, greenhouses and farm buildings differently than most buildings has previously been discussed and changed several times in this style over the past 4 years. Most recently it has been discussed in issue #2532 and in PR #3426
- "Major buildings", currently including train stations, airports, and places of worship, are currently rendered darker than other buildings.
- In the past, some buildings were rendered lighter, however the list was not very consistent. At that time most buildings, including building=yes, were rendered much darker than in the current style
- Recently there has been new discussion of improving the building rendering. By rendering some values of building=* with a subtle difference, this should reward mappers who provide more information than simply "building=yes". Because the change in fill and outline color is small, the new minor buildings style is still clearly a type of building, and sufficiently different than other sheds of brown, such as bare_earth and mud. 
- The new rendering is higher contrast with landuse=construction than the current rendering; this improves the contrast between building=construction and a landuse=construction background, especially at z14

It was considered to remove rendering of minor-buildings from z14, however, since farm buildings (like barns) are included in the list of minor buildings and these can be fairly large, they should still be shown. 

### Color comparison
- Mud: at z14, the minor-building-lowzoom color is the same as the current `@building-fill` `#d9d0c9`;  - Lch(84, 5, 68) which has a deltaE of Δ: 4.7 with mud over land - `#e6dcd1`. 
At z15, the `minor-buildings-fill` color is `#ddd5cf` - LCH(86, 4, 67) with Δ: 3.7 to mud `#e6dcd1`.
However at this level the outline color will be shown in `#cec3ba` - LCH(79, 6, 69) which has Δ: 8.9 to mud, so there should not be a risk of confusion.
- Quarry is `#c5c3c3` Lch(79,1,19) with Δ: 5.9 to `@minor-building-fill` `#d9d0c9`, 
and Δ: 7.8 to  `@minor-building-line` `#cec3ba`
- Construction (and brownfield) `#c7c7b4` - LCH(80, 10, 109) has Δ: 6.7 with `@minor-building-line` and Δ: 9.6 with `@minor-building-fill`. This is improved from the current Δ: 6.9 with building-fill-low-zoom
- Residential `#e0dfdf` has Δ: 11.3 with `@minor-building-line` and  Δ: 5.1 with `@minor-building-fill`, (versus  Δ: 5.3 with `@building-fill`)
- Place_of_worship / landuse=religious color is `#d0d0d0`, with Δ: 7.5 to `@minor-building-line` and  Δ: 4.8 to `@minor-building-fill`, (versus  Δ: 5.0 with current `@building-fill`)
- Landuse=garages `#dfddce` has Δ: 9.6 with `@minor-building-line` and  Δ: 5.6 with `@minor-building-fill`, compared to Δ: 4.8 with the current `@building-fill` and Δ: 8.6 with current `@building-low-zoom`

### Other values considered

- static_caravan (used 112, 365 times)
- cabin (132, 994 times)
- collapsed (79, 688)
- ruins (50,549)
- hangar (46,671)
- storage_tank (26, 478)
- silo (11, 220)

These are debatable. 
"Collapsed" and "ruins" should perhaps not be rendered as a building at all. 
"Static_caravans" (aka mobile homes) are similar to houses, but also similar to huts, as are cabins.
Hangars and storage_tanks are large, fairly solid structures, but are not intended for human use. 

There are other values in use with fewer than 10,000 occurrences which might be considered in the future, but for this PR the list has been limited to building values with nearly 10,000 or more uses.

It has also been considered to render building=roof and building=greenhouse with transparency, but this can be considered again in another PR.


## Test renderings with links to the example places:

Luxembourg, building=construction on landuse=construction at center
(Also at the lower zoom levels a building=construction on landuse=commercial is seen, and some building=garage, but quite small)
https://www.openstreetmap.org/#map=14/49.4984/6.1234
z14 Before
![z14-construction-buildings-luxembourg-master](https://user-images.githubusercontent.com/42757252/52603518-7ee89300-2eaa-11e9-9271-8d41976b5dd8.png)
After
![z14-construction-buildings-luxembourg](https://user-images.githubusercontent.com/42757252/52603524-827c1a00-2eaa-11e9-906d-dba288d27d40.png)

z15 Before
![z15-construction-buildings-luxembourg-master](https://user-images.githubusercontent.com/42757252/52604611-e43e8300-2eae-11e9-924b-46efb7d8bb72.png)
After
![z15-construction-buildings-luxembourg](https://user-images.githubusercontent.com/42757252/52604614-e86aa080-2eae-11e9-946e-f2fc16ba0230.png)

z17 Before
![z17-construction-buildings-luxembourg-master](https://user-images.githubusercontent.com/42757252/52604621-ed2f5480-2eae-11e9-9633-24eb400655e4.png)
After
![z17-construction-buildings-luxembourg](https://user-images.githubusercontent.com/42757252/52604628-f4566280-2eae-11e9-8b09-622e9b04fba7.png)


Lohbrugge - residential with garages
https://www.openstreetmap.org/#map=14/53.5093/10.2326.png
z14 before
![z14-lohbrugge-master-14 53 5093 10 2326](https://user-images.githubusercontent.com/42757252/52604768-970ee100-2eaf-11e9-9ccf-0ad46a6cd5c3.png)
after
![z14-lohbrugge-minor-after](https://user-images.githubusercontent.com/42757252/52604788-a9891a80-2eaf-11e9-945a-8f3056e16a3c.png)

z15 before
![z15-lohbrugge-master](https://user-images.githubusercontent.com/42757252/52604796-b0b02880-2eaf-11e9-9e4d-19f4ccc71570.png)
after
![z15-lohbrugge-minor-2-10](https://user-images.githubusercontent.com/42757252/52604802-b6a60980-2eaf-11e9-94cd-8b4609625c60.png)

z17 before
![z17-lohbrugge-master](https://user-images.githubusercontent.com/42757252/52604804-bad22700-2eaf-11e9-8bd9-42b188a0ce1b.png)
after
![z17-lohbrugge-minor-2-10](https://user-images.githubusercontent.com/42757252/52604814-c3c2f880-2eaf-11e9-86ec-46457987550e.png)


Carports 
https://www.openstreetmap.org/#map=18/53.48582/10.17360.png
z18 before
![z18-carports-master-18 53 48582 10 17360](https://user-images.githubusercontent.com/42757252/52604841-e5bc7b00-2eaf-11e9-93ed-6fad73244b46.png)
after
![z18-carports-2-10](https://user-images.githubusercontent.com/42757252/52604851-ebb25c00-2eaf-11e9-9123-ba126ab30093.png)


Farmyard
z14 Before
![z14-farm-master](https://user-images.githubusercontent.com/42757252/52604938-1d2b2780-2eb0-11e9-981b-0f8fbb657760.png)
after
![z14-farm-after](https://user-images.githubusercontent.com/42757252/52604958-2caa7080-2eb0-11e9-819c-2c001b2b3288.png)

z15 Before
![z15-farm-master](https://user-images.githubusercontent.com/42757252/52604939-1e5c5480-2eb0-11e9-9398-aebe4e765476.png)
after
![15-farm-2-10](https://user-images.githubusercontent.com/42757252/52604968-3207bb00-2eb0-11e9-86e7-9c7b98ab8270.png)

z16 Before
![z16-farm-master](https://user-images.githubusercontent.com/42757252/52604941-1f8d8180-2eb0-11e9-8a8e-0feb5ace3969.png)
after
![z16-farm-2-10](https://user-images.githubusercontent.com/42757252/52604984-4055d700-2eb0-11e9-9f61-c0d22cb88d90.png)