### PR TITLE
roads-text-ref-low-zoom: remove unused SQL CASE conditions in ORDER BY

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1803,11 +1803,6 @@ Layer:
               WHEN highway = 'trunk' THEN 37
               WHEN highway = 'primary' THEN 36
               WHEN highway = 'secondary' THEN 35
-              WHEN highway = 'tertiary' THEN 34
-              WHEN highway = 'unclassified' THEN 33
-              WHEN highway = 'residential' THEN 32
-              WHEN highway = 'runway' THEN 6
-              WHEN highway = 'taxiway' THEN 5
               ELSE NULL
             END DESC NULLS LAST,
             height DESC,


### PR DESCRIPTION
The WHERE clause in the inner SELECT restricts the possible values of highway to 'motorway', 'trunk', 'primary' and 'secondary'. Therefore, 'tertiary', 'unclassified', 'residential', 'runway' and 'taxiway' will
not occur as values of highway.

Changes proposed in this pull request:
- no visual changes, just code cleanup

Test rendering with links to the example places:

Before
![master-z11](https://user-images.githubusercontent.com/3611273/52626511-a09a4800-2eb3-11e9-8ed4-ec8b632cf1bb.png)

After

![remove-unused-sql-roads-text-ref-low-zoom-z11](https://user-images.githubusercontent.com/3611273/52626512-a09a4800-2eb3-11e9-9259-1df005a3a68a.png)