### PR TITLE
Changed rendering level of railway=disused

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2263,7 +2263,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'railway_disused'] {
-      [zoom >= 14 {
+      [zoom >= 14] {
         line-color: #aaa;
         line-width: 2;
         line-dasharray: 2,4;

--- a/roads.mss
+++ b/roads.mss
@@ -831,7 +831,7 @@
       }
     }
 
-    [feature = 'railway_disused'][zoom >= 15],
+    [feature = 'railway_disused'][zoom >= 14],
     [feature = 'railway_construction']['construction' != 'subway'],
     [feature = 'railway_miniature'][zoom >= 15],
     [feature = 'railway_INT-preserved-ssy'][zoom >= 14] {
@@ -1024,7 +1024,7 @@
       }
     }
 
-    [feature = 'railway_disused'][zoom >= 15],
+    [feature = 'railway_disused'][zoom >= 14],
     [feature = 'railway_construction']['construction' != 'subway'],
     [feature = 'railway_miniature'][zoom >= 15],
     [feature = 'railway_INT-preserved-ssy'][zoom >= 14] {
@@ -2263,7 +2263,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'railway_disused'] {
-      [zoom >= 15] {
+      [zoom >= 14 {
         line-color: #aaa;
         line-width: 2;
         line-dasharray: 2,4;


### PR DESCRIPTION
Fixes #2074

Changes proposed in this pull request:
- Move railway=disused rendering to z14+ to match level crossings

Currently level crossings over disused railways render without the railway, this looks odd and doesn't make sense.

Test rendering with links to the example places:

Before
![screenshot from 2019-02-20 17-09-46](https://user-images.githubusercontent.com/12086549/53110230-70e1e480-3532-11e9-9e5b-82b74c6c22c6.png)
![screenshot from 2019-02-20 17-00-27](https://user-images.githubusercontent.com/12086549/53110239-75a69880-3532-11e9-8212-356a67f88a41.png)
![screenshot from 2019-02-20 16-59-29](https://user-images.githubusercontent.com/12086549/53110294-8a832c00-3532-11e9-8459-aee33db74f95.png)

After

![screenshot from 2019-02-20 17-10-11](https://user-images.githubusercontent.com/12086549/53110314-91aa3a00-3532-11e9-9a52-3a6e63f42d82.png)
![screenshot from 2019-02-20 17-01-09](https://user-images.githubusercontent.com/12086549/53110317-9373fd80-3532-11e9-8c98-f5541167bff2.png)
![screenshot from 2019-02-20 16-59-45](https://user-images.githubusercontent.com/12086549/53110322-95d65780-3532-11e9-8ddb-c8c5558cb5d7.png)

