### PR TITLE
Change from land polygons to ocean polygons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
   - CARTO=0.18.0 MAPNIK='3.0.0 3.0.12'
 install:
   - npm install carto@$CARTO
-  - mkdir -p data/world_boundaries data/simplified-land-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/land-polygons-split-3857
-  - touch data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/land-polygons-split-3857/land_polygons.shp
+  - mkdir -p data/world_boundaries data/simplified-water-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/water-polygons-split-3857
+  - touch data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/water-polygons-split-3857/water_polygons.shp
   - createdb -w -E utf8 -U postgres gis && psql -Xq -d gis -U postgres -w -c "CREATE EXTENSION postgis; CREATE EXTENSION hstore;"
 script:
   # We're using pipes in the checks, so fail if any part fails

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,9 +49,9 @@ This script downloads necessary files, generates and populates the *data* direct
 You can also download them manually at the following paths:
 
 * [`world_bnd_m.shp`, `places.shp`, `world_boundaries_m.shp`](https://planet.openstreetmap.org/historical-shapefiles/world_boundaries-spherical.tgz)
-* [`simplified_land_polygons.shp`](http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip) (updated daily)
+* [`simplified_water_polygons.shp`](http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip) (updated daily)
 * [`ne_110m_admin_0_boundary_lines_land.shp`](http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip)
-* [`land_polygons.shp`](http://data.openstreetmapdata.com/land-polygons-split-3857.zip) (updated daily)
+* [`water_polygons.shp`](http://data.openstreetmapdata.com/water-polygons-split-3857.zip) (updated daily)
 * [`icesheet_polygons.shp`](http://data.openstreetmapdata.com/antarctica-icesheet-polygons-3857.zip)
 * [`icesheet_outlines.shp`](http://data.openstreetmapdata.com/antarctica-icesheet-outlines-3857.zip)
 

--- a/project.mml
+++ b/project.mml
@@ -54,19 +54,21 @@ Stylesheet:
   - admin.mss
   - addressing.mss
 Layer:
-  - id: world
+  - id: ocean-lz
     geometry: polygon
+    class: ocean
     <<: *extents
     Datasource:
-      file: data/simplified-land-polygons-complete-3857/simplified_land_polygons.shp
+      file: data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp
       type: shape
     properties:
       maxzoom: 9
-  - id: coast-poly
+  - id: ocean
     geometry: polygon
+    class: ocean
     <<: *extents
     Datasource:
-      file: data/land-polygons-split-3857/land_polygons.shp
+      file: data/water-polygons-split-3857/water_polygons.shp
       type: shape
     properties:
       minzoom: 10

--- a/scripts/get-shapefiles.py
+++ b/scripts/get-shapefiles.py
@@ -47,11 +47,11 @@ settings = {
     },
 
     2: {
-        'directory': 'simplified-land-polygons-complete-3857',
-        'url': 'http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip',  # noqa
+        'directory': 'simplified-water-polygons-complete-3857',
+        'url': 'http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip',  # noqa
         'type': 'zip',
-        'shp_basename': ['simplified_land_polygons'],
-        'long_opt': '--simplified-land'
+        'shp_basename': ['simplified_water_polygons'],
+        'long_opt': '--simplified-water'
     },
 
     3: {
@@ -63,11 +63,11 @@ settings = {
     },
 
     4: {
-        'directory': 'land-polygons-split-3857',
-        'url': 'http://data.openstreetmapdata.com/land-polygons-split-3857.zip',  # noqa
+        'directory': 'water-polygons-split-3857',
+        'url': 'http://data.openstreetmapdata.com/water-polygons-split-3857.zip',  # noqa
         'type': 'zip',
-        'shp_basename': ['land_polygons'],
-        'long_opt': '--land-polygons'
+        'shp_basename': ['water_polygons'],
+        'long_opt': '--water-polygons'
     },
 
     5: {

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -12,9 +12,7 @@
 }
 
 .ocean {
-  [zoom >= 0] {
-    polygon-fill: @water-color;
-  }
+  polygon-fill: @water-color;
 }
 
 #icesheet-poly {

--- a/shapefiles.mss
+++ b/shapefiles.mss
@@ -11,22 +11,9 @@
   }
 }
 
-#world {
-  [zoom >= 0][zoom < 10] {
-    polygon-fill: @land-color;
-    polygon-simplify: 0.4;
-    [zoom < 8] {
-      line-color: darken(@water-color,20%);
-      line-simplify: 0.4;
-      line-width: 0.5;
-      line-offset: 0.5;
-    }
-  }
-}
-
-#coast-poly {
-  [zoom >= 10] {
-    polygon-fill: @land-color;
+.ocean {
+  [zoom >= 0] {
+    polygon-fill: @water-color;
   }
 }
 

--- a/style.mss
+++ b/style.mss
@@ -1,5 +1,5 @@
 Map {
-  background-color: @water-color;
+  background-color: @land-color;
 }
 
 @water-color: #aad3df;


### PR DESCRIPTION
Fixes #1982 
Reverts #3065
See similar previous PR #2066 which was reverted due to #2101  
Also see #2507
Related to solving several issues including #621, #1547, #1781, #2013, #2025, #2609, #2688, #3695, and PR #3670

### Changes proposed in this pull request:
- Change from rendering  land polygons on an ocean-color background to rendering ocean polygons on a land-color background
- Remove outline from low-zoom coastlines

## Explanation

It is beneficial to render the oceans (that is, all water outside of the openstreetmap coastline) as polygons, rather than the present situation where the continents and islands are rendered as polygons. While this PR does not make any changes in the layering of land and water, with the introduction of water polygons it will become possible to move the oceans above water lines and landcover, which will be helpful in cases where these will show over the ocean. This will allow solving several issues related to mud flats, mangroves, wetlands and areas of parkland at the coast. It also makes it possible to use different colors for rivers and lakes, if desired. It also makes it easier to render maritime borders less prominently

Previously this same change was made in PR #2066 which had to be reverted due to an issue with the simplified water polygons that was seen on a few specific server setups. However, it appears that this issue may no longer be present with current software versions and the current simplified water polygons available from openstreetmapdata.com; see the discussion in issue #2101. Therefore we are attempting to implement ocean polygons using the current

Unfortunately it isn't possible to render a simplified coastline outline, as in PR #3065 and currently, from the simplified water polygons. This could be done by starting to use the generalized polygon files which are also available at openstreetmapdata.com, however this PR is attempting to make the smallest change possible. If the maintainers and contributors agree that a generalized outline is desirable at z0 to z7, I can easier add this feature now or in a separate PR by using the shapefiles at http://openstreetmapdata.com/data/generalized-coastlines

## Test rendering:

Before:
![z3-europe-land-polygons-master](https://user-images.githubusercontent.com/42757252/53294709-797e3780-381e-11e9-97e8-373e74bcb221.png)

After
![z3-europe-ocean-polygons-after](https://user-images.githubusercontent.com/42757252/53294711-7e42eb80-381e-11e9-820c-83e2bc9eac54.png)

- Rendering is same as current rendering at z8 and higher. The only difference is reverting #3065 which simplified the coastline and added a blue outline at z0 to z7