### PR TITLE
Render landuse with grass color from z5 instead of z10

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -359,7 +359,7 @@
   [feature = 'natural_grassland'][zoom >= 5],
   [feature = 'landuse_meadow'][zoom >= 5],
   [feature = 'landuse_grass'][zoom >= 5],
-  [feature = 'landuse_village_green'][zoom >= 10] {
+  [feature = 'landuse_village_green'][zoom >= 5] {
     polygon-fill: @grass;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }

--- a/landcover.mss
+++ b/landcover.mss
@@ -358,7 +358,7 @@
 
   [feature = 'natural_grassland'][zoom >= 5],
   [feature = 'landuse_meadow'][zoom >= 5],
-  [feature = 'landuse_grass'][zoom >= 10],
+  [feature = 'landuse_grass'][zoom >= 5],
   [feature = 'landuse_village_green'][zoom >= 10] {
     polygon-fill: @grass;
     [way_pixels >= 4]  { polygon-gamma: 0.75; }

--- a/project.mml
+++ b/project.mml
@@ -91,13 +91,13 @@ Layer:
           FROM (SELECT
               way,
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial',
-                                                    'meadow', 'grass', 'vineyard', 'orchard') THEN landuse ELSE NULL END)) AS landuse,
+                                                    'meadow', 'grass', 'village_green', 'vineyard', 'orchard') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
               way_area
             FROM planet_osm_polygon
-            WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'grass', 'vineyard', 'orchard')
+            WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'grass', 'village_green', 'vineyard', 'orchard')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL

--- a/project.mml
+++ b/project.mml
@@ -91,13 +91,13 @@ Layer:
           FROM (SELECT
               way,
               ('landuse_' || (CASE WHEN landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial',
-                                                    'meadow', 'vineyard', 'orchard') THEN landuse ELSE NULL END)) AS landuse,
+                                                    'meadow', 'grass', 'vineyard', 'orchard') THEN landuse ELSE NULL END)) AS landuse,
               ('natural_' || (CASE WHEN "natural" IN ('wood', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub') THEN "natural" ELSE NULL END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" IN ('mud') THEN "natural" ELSE tags->'wetland' END) ELSE NULL END)) AS wetland,
               way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
               way_area
             FROM planet_osm_polygon
-            WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'vineyard', 'orchard')
+            WHERE (landuse IN ('forest', 'farmland', 'residential', 'commercial', 'retail', 'industrial', 'meadow', 'grass', 'vineyard', 'orchard')
               OR "natural" IN ('wood', 'wetland', 'mud', 'sand', 'scree', 'shingle', 'bare_rock', 'heath', 'grassland', 'scrub'))
               AND way_area > 0.01*!pixel_width!::real*!pixel_height!::real
               AND building IS NULL


### PR DESCRIPTION
Fixes #3696

Change proposed in this pull request:
- Add landuse=grass to the landcover-low-zoom layer and render it from z5 instead of z10

This allows large grassy areas, such as in the Netherlands, to be visible at low zoom. 

https://www.openstreetmap.org/#map=9/52.0322/4.7873
z9 before
![z9-master](https://user-images.githubusercontent.com/5209216/53681795-d8482300-3cee-11e9-9897-f784c7844c43.png)

z9 after
![z9-new](https://user-images.githubusercontent.com/5209216/53681799-dbdbaa00-3cee-11e9-933c-3c34d7f0a071.png)

https://www.openstreetmap.org/#map=8/52.0322/4.7873
z8 before
![z8-master](https://user-images.githubusercontent.com/5209216/53681804-e4cc7b80-3cee-11e9-8241-150f1534e050.png)

z8 after
![z8-new](https://user-images.githubusercontent.com/5209216/53681805-e72ed580-3cee-11e9-86ec-d70e17ad2c77.png)

