### PR TITLE
Create new layer for "ref" of minor roads and paths 

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1883,10 +1883,13 @@ Layer:
                 SELECT
                     osm_id,
                     way,
-                    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway ELSE NULL END AS highway,
+                    COALESCE(
+                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway ELSE NULL END,
+                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
+                    ) AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary')
+                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1897,6 +1900,8 @@ Layer:
               WHEN highway = 'primary' THEN 36
               WHEN highway = 'secondary' THEN 35
               WHEN highway = 'tertiary' THEN 34
+              WHEN highway = 'runway' THEN 6
+              WHEN highway = 'taxiway' THEN 5
               ELSE NULL
             END DESC NULLS LAST,
             height DESC,
@@ -2069,13 +2074,10 @@ Layer:
                 SELECT
                     osm_id,
                     way,
-                    COALESCE(
-                      CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway ELSE NULL END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
-                    ) AS highway,
+                    CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway ELSE NULL END AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('unclassified', 'residential', 'track') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE highway IN ('unclassified', 'residential', 'track')
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -2084,8 +2086,6 @@ Layer:
               WHEN highway = 'unclassified' THEN 33
               WHEN highway = 'residential' THEN 32
               WHEN highway = 'track' THEN 30
-              WHEN highway = 'runway' THEN 6
-              WHEN highway = 'taxiway' THEN 5
               ELSE NULL
             END DESC NULLS LAST,
             height DESC,

--- a/project.mml
+++ b/project.mml
@@ -2070,12 +2070,12 @@ Layer:
                     osm_id,
                     way,
                     COALESCE(
-                      CASE WHEN highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') THEN highway ELSE NULL END,
+                      CASE WHEN highway IN ('unclassified', 'residential', 'track') THEN highway ELSE NULL END,
                       CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
                     ) AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE (highway IN ('unclassified', 'residential', 'track') OR aeroway IN ('runway', 'taxiway'))
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -2084,11 +2084,6 @@ Layer:
               WHEN highway = 'unclassified' THEN 33
               WHEN highway = 'residential' THEN 32
               WHEN highway = 'track' THEN 30
-              WHEN highway = 'bridleway' THEN 10
-              WHEN highway = 'cycleway' THEN 10
-              WHEN highway = 'footway' THEN 10
-              WHEN highway = 'path' THEN 10
-              WHEN highway = 'steps' THEN 10
               WHEN highway = 'runway' THEN 6
               WHEN highway = 'taxiway' THEN 5
               ELSE NULL

--- a/project.mml
+++ b/project.mml
@@ -1883,13 +1883,10 @@ Layer:
                 SELECT
                     osm_id,
                     way,
-                    COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') THEN highway ELSE NULL END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
-                    ) AS highway,
+                    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway ELSE NULL END AS highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary', 'unclassified', 'residential', 'track') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary')
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1900,11 +1897,6 @@ Layer:
               WHEN highway = 'primary' THEN 36
               WHEN highway = 'secondary' THEN 35
               WHEN highway = 'tertiary' THEN 34
-              WHEN highway = 'unclassified' THEN 33
-              WHEN highway = 'residential' THEN 32
-              WHEN highway = 'track' THEN 30
-              WHEN highway = 'runway' THEN 6
-              WHEN highway = 'taxiway' THEN 5
               ELSE NULL
             END DESC NULLS LAST,
             height DESC,
@@ -2053,6 +2045,61 @@ Layer:
         ) AS railways_text_name
     properties:
       minzoom: 11
+  - id: roads-text-ref-minor
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            highway,
+            height,
+            width,
+            refs
+          FROM (
+            SELECT
+                osm_id,
+                way,
+                highway,
+                array_length(refs,1) AS height,
+                (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS width,
+                array_to_string(refs, E'\n') AS refs
+              FROM (
+                SELECT
+                    osm_id,
+                    way,
+                    COALESCE(
+                      CASE WHEN highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') THEN highway ELSE NULL END,
+                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway ELSE NULL END
+                    ) AS highway,
+                    string_to_array(ref, ';') AS refs
+                  FROM planet_osm_line
+                  WHERE (highway IN ('unclassified', 'residential', 'track', 'bridleway', 'cycleway', 'path', 'steps') OR aeroway IN ('runway', 'taxiway'))
+                    AND ref IS NOT NULL
+              ) AS p) AS q
+          WHERE height <= 4 AND width <= 11
+          ORDER BY
+            CASE
+              WHEN highway = 'unclassified' THEN 33
+              WHEN highway = 'residential' THEN 32
+              WHEN highway = 'track' THEN 30
+              WHEN highway = 'bridleway' THEN 10
+              WHEN highway = 'cycleway' THEN 10
+              WHEN highway = 'footway' THEN 10
+              WHEN highway = 'path' THEN 10
+              WHEN highway = 'steps' THEN 10
+              WHEN highway = 'runway' THEN 6
+              WHEN highway = 'taxiway' THEN 5
+              ELSE NULL
+            END DESC NULLS LAST,
+            height DESC,
+            width DESC,
+            refs,
+            osm_id
+        ) AS roads_text_ref_minor
+    properties:
+      minzoom: 15
   - id: text-poly-low-zoom
     class: text-low-zoom
     geometry: polygon

--- a/roads.mss
+++ b/roads.mss
@@ -3023,7 +3023,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-face-name: @book-fonts;
       text-placement: line;
       text-repeat-distance: @major-highway-text-repeat-distance;
-      text-halo-radius: 2;
+      text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-spacing: 760;
       text-clip: false;

--- a/roads.mss
+++ b/roads.mss
@@ -3015,8 +3015,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 16] {
         text-size: 9;
       }
-      [zoom >= 18] {
-        text-size: 10;
+      [zoom >= 17] {
+        text-size: 11;
       }
 
       text-fill: #000;

--- a/roads.mss
+++ b/roads.mss
@@ -3003,7 +3003,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
   }
+}
 
+#roads-text-ref-minor {
   [highway = 'unclassified'],
   [highway = 'residential'] {
     [zoom >= 15] {

--- a/roads.mss
+++ b/roads.mss
@@ -3012,7 +3012,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 750;
       text-clip: false;
       text-placement: line;
-      text-face-name: @book-fonts;
+      text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-repeat-distance: @minor-highway-text-repeat-distance;
@@ -3035,7 +3035,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
 
       text-fill: #000;
-      text-face-name: @book-fonts;
+      text-face-name: @oblique-fonts;
       text-placement: line;
       text-repeat-distance: @major-highway-text-repeat-distance;
       text-halo-radius: @standard-halo-radius;
@@ -3062,7 +3062,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
       text-clip: false;
       text-fill: #222;
-      text-face-name: @book-fonts;
+      text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-margin: 10;

--- a/roads.mss
+++ b/roads.mss
@@ -3003,6 +3003,21 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
   }
+  [highway = 'runway'],
+  [highway = 'taxiway'] {
+    [zoom >= 15] {
+      text-name: "[refs]";
+      text-size: 10;
+      text-fill: #333;
+      text-spacing: 750;
+      text-clip: false;
+      text-placement: line;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @minor-highway-text-repeat-distance;
+    }
+  }
 }
 
 #roads-text-ref-minor {
@@ -3055,22 +3070,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 760;
       text-repeat-distance: @major-highway-text-repeat-distance;
       text-vertical-alignment: middle;
-    }
-  }
-
-  [highway = 'runway'],
-  [highway = 'taxiway'] {
-    [zoom >= 15] {
-      text-name: "[refs]";
-      text-size: 10;
-      text-fill: #333;
-      text-spacing: 750;
-      text-clip: false;
-      text-placement: line;
-      text-face-name: @book-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-repeat-distance: @minor-highway-text-repeat-distance;
     }
   }
 }


### PR DESCRIPTION
Partially replaces PR #3663
Follow-up to PR #3654

### Changes proposed in this pull request:

1) Move unclassified, residential and track highways, and aeroways "ref" to a later layer, after name labels are rendered

2) Change text-halo to standard size for highway=unclassified/residential refs and aeroway refs

3) Change residential / unclassified road "ref" size to 11 point at z17, to be the same size as the name text labels at this zoom level and higher. 

### Explanation

**1) The minor roads, aeroways, and tracks with text-based ref labels currently render in the same layer as the shields for major roads.** 

- The ref text is rendered before the name label, and can block the name from rendering when spaces is limited.
- Major road shields render much sooner than the ref text labels of minor roads, which are not shown until z15 or z16.
- Major road shields are usually more important than the name; the number of a motorway is used more often, but for minor roads, such as residential streets, the name is more useful and should be shown with higher priority
- Changing residential, unclassified and tracks to a later layer will fix this rendering. Aeroways "ref" text labels are also moved to this new layer because they are also rendered only at z15 and higher, though this does not change the cartography because they do not have a rendering for names

**2) The "ref" labels rendering for residential/unclassified roads needs minor adjustments**
 At z17, the "name" text label increases to 11pt font size, but the ref does not change size till z18 currently. This should be adjusted so that the "ref" label is the same size as the name label, as at z15 and z16.

**3) The "ref" halo needs to be changed to standard size.**
 Right now it is 2 pixels wide, which would overlap with the casing at certain zoom levels. 

### Test rendering with links to the example places:

**highway=unclassified with name and ref** - Basilicata, Italy 
https://www.openstreetmap.org/#map=17/40.3776321/15.7281581
Before z17
![via-chiusululle-unclassified-master](https://user-images.githubusercontent.com/42757252/52036343-55596e80-2570-11e9-92ba-d9ae1d158950.png)
z18
![z18-via-chiusululle-master](https://user-images.githubusercontent.com/42757252/52036353-5b4f4f80-2570-11e9-8191-8d5a7b4ec879.png)
After z17
![chiusululle-z17-after](https://user-images.githubusercontent.com/42757252/52040702-a0c54a00-257b-11e9-9b31-d594436d84b5.png)
z18
![chiusululle-z18-after](https://user-images.githubusercontent.com/42757252/52040720-a6bb2b00-257b-11e9-9baa-e369050e3a22.png)


**highway=residential with name and ref** - Basilicata, Italy 
https://www.openstreetmap.org/#map=17/40.1412792/16.0893142
Before z17
![via-vittorio-res-z17-master](https://user-images.githubusercontent.com/42757252/52036418-74f09700-2570-11e9-9150-b7f89441fcb0.png)
z18
![via-vitorio-z18-master](https://user-images.githubusercontent.com/42757252/52036426-77eb8780-2570-11e9-9e24-bddfaf3357c9.png)
After z17
![z17-via-vittorio-after](https://user-images.githubusercontent.com/42757252/52036435-7cb03b80-2570-11e9-9cd9-256760bfc710.png)
z18
![via-vittori-z18-after](https://user-images.githubusercontent.com/42757252/52040731-ae7acf80-257b-11e9-8a78-e0b4b13777dc.png)