### PR TITLE
Create groundskeeping.svg

### DIFF
--- a/symbols/shop/groundskeeping.svg
+++ b/symbols/shop/groundskeeping.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="20" height="20" version="1.1" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g transform="translate(0 -291.71)">
+  <path transform="translate(0 291.71)" d="m2.2031 2.4023l-0.23047 0.1875c-0.025742 0.021124-0.032704 0.061257-0.015625 0.089844l6.7637 11.32h-2.7207v3h1.5586a2.2222 2.0773 0 0 0 0.75195 1.4824l0.43164 0.2793a2.2222 2.0773 0 0 0 2.9375 -0.76367 2.2222 2.0773 0 0 0 0.31641 -0.99805h2.0156a1.9002 1.8196 0 0 0 0.63476 1.5469l0.10352 0.082031a1.9002 1.8196 0 0 0 2.6426 -0.32226 1.9002 1.8196 0 0 0 0.39648 -1.3066h1.2109v-3h-4.0059v-1h1.0059v-2h-6v2h1v1h-1.7988l-6.9199-11.584c-0.017079-0.028586-0.052383-0.034796-0.078125-0.013672z"/>
+ </g>
+</svg>


### PR DESCRIPTION
This is my first attempt at a pull request, so If something is not correct, please correct me.
I created a new tag and a wiki page for it. 
The tag is:  shop=groundskeeping
 Should be on taginfo with the next update. And I created this icon to go with it.  I would like to get it into the project.  Thank you.
![groundskeeping](https://user-images.githubusercontent.com/48363841/54165998-0fc27800-4431-11e9-9bd6-b524378ebf52.png)
