### PR TITLE
stop rendering shop=yes [ready for review]

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1513,7 +1513,7 @@ Layer:
                 'amenity_' || CASE WHEN amenity IN ('vending_machine') AND tags->'vending' IN ('excrement_bags', 'parking_tickets', 'public_transport_tickets') THEN amenity ELSE NULL END,
                 'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,
                 'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area IS NULL THEN tags->'emergency' ELSE NULL END,
-                'shop' || CASE WHEN shop IN ('no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
+                'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
                                                     'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',


### PR DESCRIPTION
fixes #3697

Originally only shop with their own icons were rendered.

Later popular shop values were also rendered - as dots without icons. This was deliberate decision to not render cases like shop=supermarkte

Since #2415 all shop values except 'no', 'vacant', 'closed', 'disused', 'empty' are rendered.

Given that any, even never used shop value is rendered and `shop=yes` is unreasonably popular it is desirable to encourage more specific shop tagging.

Dropping `shop=yes` may encourage using some new shop values and in some cases people will mistakenly create new tags duplicating existing ones,
but standard shop types are still encouraged by using icons.

shop tag currently has long tail of unusual shop types (with most tagged correctly - for example `shop=maps`, some shop like this really exist),
so data consumers need anyway some strategy for handling rare shop types.

`shop=yes` is currenly reported as a tagging mistake by decent validators (for example JOSM and Osmose).

Note that this is not deprecation of a tag but stopping to render a deprecated tag.
This tag was never considered as a sufficient for tagging shop type

Test rendering with links to the example places:

https://www.openstreetmap.org/way/237537359 and other now fixed objects, found using http://overpass-turbo.eu/s/H0Q

Before (this place has both node and area with `shop=yes`)
![Selection_002](https://user-images.githubusercontent.com/899988/54423355-c617ad00-4710-11e9-9fec-4d2ef058b67f.png)


After
![Selection_003](https://user-images.githubusercontent.com/899988/54423364-cfa11500-4710-11e9-9ee3-874c8d34921c.png)

