### PR TITLE
Render lines and labels only on route=ferry ways, not relations

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -640,6 +640,7 @@ Layer:
             way
           FROM planet_osm_line
           WHERE route = 'ferry'
+            AND osm_id > 0
         ) AS ferry_routes
     properties:
       minzoom: 8
@@ -2543,6 +2544,7 @@ Layer:
             name
           FROM planet_osm_line
           WHERE route = 'ferry'
+            AND osm_id > 0
             AND name IS NOT NULL
         ) AS ferry_routes_text
     properties:


### PR DESCRIPTION
Only render route=ferry label and dashed line on ways with positive osm_id in database, i.e. real ways, not relations.

Fixes #3726, platforms on route=ferry relations are not rendered with labels and lines any more.

Test rendering with links to the example places:

Before
![ferry-platform](https://user-images.githubusercontent.com/3215/54877940-09b79880-4e2e-11e9-92ba-fc5de2c49f0b.png)

After
![fixed-ferry-route](https://user-images.githubusercontent.com/3215/54877993-bd208d00-4e2e-11e9-8b67-ca9e1e96d667.png)
