### PR TITLE
Source water & icesheet shapefiles from osmdata.openstreetmap.de

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
   - CARTO=0.18.0 MAPNIK='3.0.0 3.0.12'
 install:
   - npm install carto@$CARTO
-  - mkdir -p data/world_boundaries data/simplified-water-polygons-complete-3857 data/ne_110m_admin_0_boundary_lines_land data/water-polygons-split-3857
-  - touch data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/water-polygons-split-3857/water_polygons.shp
+  - mkdir -p data/world_boundaries data/simplified-water-polygons-split-3857 data/ne_110m_admin_0_boundary_lines_land data/water-polygons-split-3857
+  - touch data/simplified-water-polygons-split-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/water-polygons-split-3857/water_polygons.shp
   - createdb -w -E utf8 -U postgres gis && psql -Xq -d gis -U postgres -w -c "CREATE EXTENSION postgis; CREATE EXTENSION hstore;"
 script:
   # We're using pipes in the checks, so fail if any part fails

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,11 +49,11 @@ This script downloads necessary files, generates and populates the *data* direct
 You can also download them manually at the following paths:
 
 * [`world_bnd_m.shp`, `places.shp`, `world_boundaries_m.shp`](https://planet.openstreetmap.org/historical-shapefiles/world_boundaries-spherical.tgz)
-* [`simplified_water_polygons.shp`](http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip) (updated daily)
+* [`simplified_water_polygons.shp`](https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip) (updated daily)
 * [`ne_110m_admin_0_boundary_lines_land.shp`](http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip)
-* [`water_polygons.shp`](http://data.openstreetmapdata.com/water-polygons-split-3857.zip) (updated daily)
-* [`icesheet_polygons.shp`](http://data.openstreetmapdata.com/antarctica-icesheet-polygons-3857.zip)
-* [`icesheet_outlines.shp`](http://data.openstreetmapdata.com/antarctica-icesheet-outlines-3857.zip)
+* [`water_polygons.shp`](https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip) (updated daily)
+* [`icesheet_polygons.shp`](https://osmdata.openstreetmap.de/download/antarctica-icesheet-polygons-3857.zip)
+* [`icesheet_outlines.shp`](https://osmdata.openstreetmap.de/download/antarctica-icesheet-outlines-3857.zip)
 
 The repeated www.naturalearthdata.com in the Natural Earth shapefiles is correct.
 

--- a/project.mml
+++ b/project.mml
@@ -59,7 +59,7 @@ Layer:
     class: ocean
     <<: *extents
     Datasource:
-      file: data/simplified-water-polygons-complete-3857/simplified_water_polygons.shp
+      file: data/simplified-water-polygons-split-3857/simplified_water_polygons.shp
       type: shape
     properties:
       maxzoom: 9

--- a/scripts/get-shapefiles.py
+++ b/scripts/get-shapefiles.py
@@ -47,8 +47,8 @@ settings = {
     },
 
     2: {
-        'directory': 'simplified-water-polygons-complete-3857',
-        'url': 'http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip',  # noqa
+        'directory': 'simplified-water-polygons-split-3857',
+        'url': 'https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip',  # noqa
         'type': 'zip',
         'shp_basename': ['simplified_water_polygons'],
         'long_opt': '--simplified-water'
@@ -64,7 +64,7 @@ settings = {
 
     4: {
         'directory': 'water-polygons-split-3857',
-        'url': 'http://data.openstreetmapdata.com/water-polygons-split-3857.zip',  # noqa
+        'url': 'https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip',  # noqa
         'type': 'zip',
         'shp_basename': ['water_polygons'],
         'long_opt': '--water-polygons'
@@ -72,7 +72,7 @@ settings = {
 
     5: {
         'directory': 'antarctica-icesheet-polygons-3857',
-        'url': 'http://data.openstreetmapdata.com/antarctica-icesheet-polygons-3857.zip',  # noqa
+        'url': 'https://osmdata.openstreetmap.de/download/antarctica-icesheet-polygons-3857.zip',  # noqa
         'type': 'zip',
         'shp_basename': ['icesheet_polygons'],
         'long_opt': '--icesheet-polygons'
@@ -80,7 +80,7 @@ settings = {
 
     6: {
         'directory': 'antarctica-icesheet-outlines-3857',
-        'url': 'http://data.openstreetmapdata.com/antarctica-icesheet-outlines-3857.zip',  # noqa
+        'url': 'https://osmdata.openstreetmap.de/download/antarctica-icesheet-outlines-3857.zip',  # noqa
         'type': 'zip',
         'shp_basename': ['icesheet_outlines'],
         'long_opt': '--icesheet-outlines'


### PR DESCRIPTION
### Changes proposed in this pull request:

- All links and references to openstreetmapdata.com are changed to the new source of shapefiles, hosted at osmdata.openstreetmap.de
- The file `simplified-water-polygons-complete` is now `simplified-water-polygons-split`

### Results

The rendering is unchanged after manually downloading the new water and icesheet shapefiles. 

The script 'get-shapefiles.py' appears to begin downloading the shapefiles properly. However, I did not complete the download via the script, due to the amount of bandwidth required.

 I have not tested the changes to the `.travis.yml` file. 