### PR TITLE
Restrict rendering of natural=cape to nodes, change font to standard

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1790,8 +1790,6 @@
 /* Note that .text is also used in water.mss */
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
-  [feature = 'natural_cape'][zoom >= 4][way_pixels > 3000][way_pixels < 800000],
-  [feature = 'natural_cape'][zoom >= 16][way_pixels < 800000],
   [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels < 800000],
   [feature = 'place_island'][zoom >= 16][way_pixels < 800000],
   [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels < 800000],
@@ -2065,13 +2063,10 @@
   [feature = 'natural_cape'][zoom >= 14] {
     text-name: "[name]";
     text-fill: #000;
-    text-size: @landcover-font-size;
-    text-wrap-width: @landcover-wrap-width-size;
-    text-line-spacing: @landcover-line-spacing-size;
-    text-size: @landcover-font-size-big;
-    text-wrap-width: @landcover-wrap-width-size-big;
-    text-line-spacing: @landcover-line-spacing-size-big;
-    text-face-name: @oblique-fonts;
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;

--- a/project.mml
+++ b/project.mml
@@ -2071,7 +2071,7 @@ Layer:
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
-                                                    'water', 'bay', 'strait', 'cape') THEN "natural" ELSE NULL END,
+                                                    'water', 'bay', 'strait') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN (boundary = 'protected_area' AND tags->'protect_class' = '24') THEN 'aboriginal_lands'
                                   WHEN boundary IN ('aboriginal_lands', 'national_park')
@@ -2084,7 +2084,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')
               OR military IN ('danger_area')
-              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait', 'cape')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
               OR "place" IN ('island')
               OR boundary IN ('aboriginal_lands', 'national_park')
               OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
@@ -2152,7 +2152,7 @@ Layer:
               'communications_tower', 'telescope', 'chimney', 'crane', 'storage_tank', 'silo', 'wastewater_plant', 'water_works')
                                         AND (tags->'location' NOT IN ('roof', 'rooftop') OR (tags->'location') IS NULL)) THEN man_made ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'marsh', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
-                                                    'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier', 'strait', 'cape') THEN "natural" ELSE NULL END,
+                                                    'grassland', 'scrub', 'beach', 'shoal', 'reef', 'glacier', 'strait') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')


### PR DESCRIPTION
Partial fix for #3634

### Changes proposed in this pull request:
- Remove rendering of natural=cape polygons (Nodes will continue to be rendered as at present)
- Change cape name label text to use standard font, rather than landcover font

### Explanation:
- [According to the wiki](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dcape), a cape is the extreme point of land that projects out into a body of water, such as a sea or lake. 
- [Taginfo confirms](https://taginfo.openstreetmap.org/tags/?key=natural&value=cape) that 12 ,747 capes are mapped as nodes, and only 148 as ways, 355 as relations.
- The recently approved tag "natural=peninsula" is available to tag areas of land that are mainly surrounded by water. From the [wiki](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dpeninsula):

> "The tag natural=cape refers to a coastal extreme point, that is the tip of a land area that projects into water. In contrast, natural=peninsula refers to a land area that projects into water and that is nearly surrounded by water."

- Currently the natural=cape name label is rendered with an italic landcover-style font, which is the same as is used for islands. The font is changed to the standard font to be more appropriate for a point feature. 

### Test rendering with links to the example places:

**Kolkas rags, Latvia** - mapped as node
https://www.openstreetmap.org/#map=14/57.7488/22.6323
z14 Current
![z14-kolkas-rags-cape-before](https://user-images.githubusercontent.com/42757252/55043563-2ba55b00-507a-11e9-8afd-91e87c79ea76.png)

z14 After
![z14-kolkas-rags-after](https://user-images.githubusercontent.com/42757252/55043581-3eb82b00-507a-11e9-82d3-4ed3dfb4478e.png)

**Castle Neck** - mapped as a closed way
https://www.openstreetmap.org/#map=15/42.6744/-70.7476
z15 Current
![z15-castle-neck-cape-before](https://user-images.githubusercontent.com/42757252/55043584-41b31b80-507a-11e9-8473-ec91f0db38b0.png)

z15 After
![z15-castle-neck-cape-after](https://user-images.githubusercontent.com/42757252/55043588-44157580-507a-11e9-95ab-73f9b29779aa.png)