### PR TITLE
Add rendering for straits mapped as linear ways

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2510,27 +2510,8 @@ Layer:
         ) AS addresses
     properties:
       minzoom: 17
-  - id: water-lines-text-lowzoom
-    geometry: linestring
-    class: water-lines-text
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            name,
-            "natural"
-          FROM planet_osm_line
-          WHERE "natural" = 'strait'
-            AND name IS NOT NULL
-        ) AS water_lines_text_lowzoom
-    properties:
-      minzoom: 5
-      maxzoom: 12
   - id: water-lines-text
     geometry: linestring
-    class: water-lines-text
     <<: *extents
     Datasource:
       <<: *osm2pgsql

--- a/project.mml
+++ b/project.mml
@@ -2510,8 +2510,27 @@ Layer:
         ) AS addresses
     properties:
       minzoom: 17
+  - id: water-lines-text-lowzoom
+    geometry: linestring
+    class: water-lines-text
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            name,
+            "natural"
+          FROM planet_osm_line
+          WHERE "natural" = 'strait'
+            AND name IS NOT NULL
+        ) AS water_lines_text_lowzoom
+    properties:
+      minzoom: 5
+      maxzoom: 12
   - id: water-lines-text
     geometry: linestring
+    class: water-lines-text
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -2521,13 +2540,15 @@ Layer:
             waterway,
             lock,
             name,
+            "natural",
             tags-> 'lock_name' AS lock_name,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+                 OR "natural" = 'strait')
             AND (tunnel IS NULL or tunnel != 'culvert')
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)

--- a/water.mss
+++ b/water.mss
@@ -314,24 +314,22 @@
       }
     }
   }
-}
-
-.water-lines-text {
-    [natural = 'strait'][zoom >= 5] {
-      text-name: "[name]";
+  [natural = 'strait'][zoom >= 13] {
+    text-name: "[name]";
+    text-size: 10;
+    text-face-name: @oblique-fonts;
+    text-fill: @water-text;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-max-char-angle-delta: 15;
+    text-spacing: 400;
+    text-placement: line;
+    [zoom >= 14] {
       text-size: 12;
-      text-face-name: @oblique-fonts;
-      text-fill: @water-text;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-spacing: 800;
-      text-placement: line;
-      text-repeat-distance: 400;
-      text-min-path-length: 100;
-      text-margin: 5;
-      [zoom >= 14] { text-size: 15; }
     }
   }
+}
+
 
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
@@ -342,6 +340,7 @@
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
     [zoom >= 0][way_pixels > 3000],
+    [zoom >= 13][feature = 'natural_strait'],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;
@@ -361,6 +360,9 @@
         text-size: 19;
         text-wrap-width: 95; // 5.0 em
         text-line-spacing: -0.95; // -0.05 em
+      }
+      [feature = 'natural_strait'][zoom >= 14] {
+        text-size: 12;
       }
       text-fill: @water-text;
       text-face-name: @oblique-fonts;

--- a/water.mss
+++ b/water.mss
@@ -316,6 +316,23 @@
   }
 }
 
+.water-lines-text {
+    [natural = 'strait'][zoom >= 5] {
+      text-name: "[name]";
+      text-size: 12;
+      text-face-name: @oblique-fonts;
+      text-fill: @water-text;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-spacing: 800;
+      text-placement: line;
+      text-repeat-distance: 400;
+      text-min-path-length: 100;
+      text-margin: 5;
+      [zoom >= 14] { text-size: 15; }
+    }
+  }
+
 .text-low-zoom[zoom < 10],
 .text[zoom >= 10] {
   [feature = 'natural_water'],

--- a/water.mss
+++ b/water.mss
@@ -314,7 +314,7 @@
       }
     }
   }
-  [natural = 'strait'][zoom >= 13] {
+  [natural = 'strait'][zoom >= 14] {
     text-name: "[name]";
     text-size: 10;
     text-face-name: @oblique-fonts;
@@ -324,7 +324,7 @@
     text-max-char-angle-delta: 15;
     text-spacing: 400;
     text-placement: line;
-    [zoom >= 14] {
+    [zoom >= 15] {
       text-size: 12;
     }
   }
@@ -340,7 +340,6 @@
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
     [zoom >= 0][way_pixels > 3000],
-    [zoom >= 13][feature = 'natural_strait'],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;
@@ -361,14 +360,30 @@
         text-wrap-width: 95; // 5.0 em
         text-line-spacing: -0.95; // -0.05 em
       }
-      [feature = 'natural_strait'][zoom >= 14] {
-        text-size: 12;
-      }
       text-fill: @water-text;
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: interior;
+    }
+  }
+}
+
+#text-point[zoom >= 14] {
+  [feature = 'natural_strait'] {
+    text-name: "[name]";
+    text-size: 10;
+    text-wrap-width: 25; // 2.5 em
+    text-line-spacing: -1.5; // -0.15 em
+    text-fill: @water-text;
+    text-face-name: @oblique-fonts;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: point;
+    [zoom >= 15] {
+      text-size: 12;
+      text-wrap-width: 37; // 3.1 em
+      text-line-spacing: -1.6; // -0.13 em
     }
   }
 }


### PR DESCRIPTION
Partial fix for #3634 and related to #804
Follow up of #3438

### Changes proposed in this pull request:
- Add rendering for natural=strait mapped as a linear way

### Explanation:
- Nodes and polygons (closed ways / multipolygons) tagged with natural=strait area currently rendered, since #3438. However, many straits are tagged as linear ways, and these are not yet rendered.
- The current PR renders the text label for the name of a strait as soon as the way is longer than 100 pixels. This is similar to the standard for rendering name labels at >3000 waypixels, but somewhat stricter. 
- The name label is repeated after 800 pixels, so that there will usually be one label on the screen at zoom levels where the way is long relative to the screen size.
- A similar font style is used as with the name labels for straits, bays and lakes, with a larger font used at z14 and above.

### Test rendering with links to the example places:

**Bering Strait**, between Alaska and Russia
https://www.openstreetmap.org/#map=9/65.7046/-169.0192
z7 before = after (unchanged because the way is less than 100 pixels long at this zoom level)
![z7-bering-strait-after](https://user-images.githubusercontent.com/42757252/55049897-88604000-5091-11e9-9476-d9488e02ec0e.png)

z8 before
![z8-bering-strait-before](https://user-images.githubusercontent.com/42757252/55051385-38d14280-5098-11e9-9756-fd751941a78f.png)

z8 after
![z8-bering-strait-after](https://user-images.githubusercontent.com/42757252/55049965-dc6b2480-5091-11e9-8f8c-50f9cd9e70f8.png)

z9 before
![z9-bering-strait-before](https://user-images.githubusercontent.com/42757252/55051386-38d14280-5098-11e9-9d9a-74c7552dc4d6.png)

z9 after
![z9-bering-strait-after](https://user-images.githubusercontent.com/42757252/55051382-37077f00-5098-11e9-8cd5-327317002e6d.png)

z10 before
![z10-bering-strait-before](https://user-images.githubusercontent.com/42757252/55051399-3ff85080-5098-11e9-92a8-65466ba56101.png)

z10 after
![z10-berign-strait-after](https://user-images.githubusercontent.com/42757252/55049918-98781f80-5091-11e9-8f8d-532d00968d78.png)