### PR TITLE
Reorder layers to render ocean and water areas above water lines and landcover

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -82,17 +82,6 @@
   ::upper-mid-zoom[zoom >= 12][zoom < 13],
   ::high-zoom[zoom >= 13] {
 
-  ::first {
-    [feature = 'wetland_mud'],
-    [feature = 'wetland_tidalflat'] {
-      [zoom >= 5] {
-        polygon-fill: @mud;
-        [way_pixels >= 4]  { polygon-gamma: 0.75; }
-        [way_pixels >= 64] { polygon-gamma: 0.3;  }
-      }
-    }
-  }
-
   [feature = 'leisure_swimming_pool'][zoom >= 14] {
     polygon-fill: @water-color;
     [zoom >= 17] {
@@ -718,6 +707,18 @@
 }
 
 #landcover-area-symbols {
+
+  ::first {
+    [natural = 'mud'],
+    [int_wetland = 'tidalflat'] {
+      [zoom >= 9] {
+        polygon-fill: @mud;
+        [way_pixels >= 4]  { polygon-gamma: 0.75; }
+        [way_pixels >= 64] { polygon-gamma: 0.3;  }
+      }
+    }
+  }
+
   [natural = 'sand'][zoom >= 5] {
     polygon-pattern-file: url('symbols/beach.png');
     polygon-pattern-alignment: global;

--- a/project.mml
+++ b/project.mml
@@ -281,7 +281,8 @@ Layer:
                     END
                 END
               END AS int_wetland,
-            tags->'leaf_type' AS leaf_type
+            tags->'leaf_type' AS leaf_type,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE ("natural" IN ('marsh', 'mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub', 'sand') OR landuse = 'forest')
             AND building IS NULL

--- a/project.mml
+++ b/project.mml
@@ -54,33 +54,6 @@ Stylesheet:
   - admin.mss
   - addressing.mss
 Layer:
-  - id: ocean-lz
-    geometry: polygon
-    class: ocean
-    <<: *extents
-    Datasource:
-      file: data/simplified-water-polygons-split-3857/simplified_water_polygons.shp
-      type: shape
-    properties:
-      maxzoom: 9
-  - id: ocean
-    geometry: polygon
-    class: ocean
-    <<: *extents
-    Datasource:
-      file: data/water-polygons-split-3857/water_polygons.shp
-      type: shape
-    properties:
-      minzoom: 10
-  - id: necountries
-    geometry: linestring
-    <<: *extents84
-    Datasource:
-      file: data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp
-      type: shape
-    properties:
-      minzoom: 1
-      maxzoom: 3
   - id: landcover-low-zoom
     geometry: polygon
     <<: *extents
@@ -176,6 +149,14 @@ Layer:
         ) AS landcover_line
     properties:
       minzoom: 14
+  - id: icesheet-poly
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      file: data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp
+      type: shape
+    properties:
+      minzoom: 5
   - id: water-lines-casing
     geometry: linestring
     <<: *extents
@@ -212,14 +193,29 @@ Layer:
     properties:
       minzoom: 8
       maxzoom: 11
-  - id: icesheet-poly
-    geometry: polygon
+  - id: water-lines
+    class: water-lines
+    geometry: linestring
     <<: *extents
     Datasource:
-      file: data/antarctica-icesheet-polygons-3857/icesheet_polygons.shp
-      type: shape
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            waterway,
+            name,
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
+            'no' AS bridge
+          FROM planet_osm_line
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+            AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
+          ORDER BY COALESCE(layer,0)
+        ) AS water_lines
     properties:
-      minzoom: 5
+      minzoom: 12
   - id: water-areas
     geometry: polygon
     <<: *extents
@@ -248,6 +244,24 @@ Layer:
         ) AS water_areas
     properties:
       minzoom: 0
+  - id: ocean-lz
+    geometry: polygon
+    class: ocean
+    <<: *extents
+    Datasource:
+      file: data/simplified-water-polygons-split-3857/simplified_water_polygons.shp
+      type: shape
+    properties:
+      maxzoom: 9
+  - id: ocean
+    geometry: polygon
+    class: ocean
+    <<: *extents
+    Datasource:
+      file: data/water-polygons-split-3857/water_polygons.shp
+      type: shape
+    properties:
+      minzoom: 10
   - id: landcover-area-symbols
     geometry: polygon
     <<: *extents
@@ -284,55 +298,19 @@ Layer:
       type: shape
     properties:
       minzoom: 5
-  - id: springs
-    geometry: point
+  - id: marinas-area
+    geometry: polygon
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            "natural"
-          FROM
-          (SELECT
-              ST_PointOnSurface(way) AS way,
-              "natural"
-            FROM planet_osm_polygon
-            WHERE way && !bbox!
-          UNION ALL
-          SELECT
-              way,
-              "natural"
-            FROM planet_osm_point
-            WHERE way && !bbox!
-            ) _
-          WHERE "natural" IN ('spring')
-        ) AS springs
+            way
+          FROM planet_osm_polygon
+          WHERE leisure = 'marina'
+        ) AS marinas_area
     properties:
       minzoom: 14
-  - id: water-lines
-    class: water-lines
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            waterway,
-            name,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
-            'no' AS bridge
-          FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
-            AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
-          ORDER BY COALESCE(layer,0)
-        ) AS water_lines
-    properties:
-      minzoom: 12
   - id: water-barriers-line
     geometry: linestring
     <<: *extents
@@ -363,17 +341,30 @@ Layer:
         ) AS water_barriers_poly
     properties:
       minzoom: 13
-  - id: marinas-area
-    geometry: polygon
+  - id: springs
+    geometry: point
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way
-          FROM planet_osm_polygon
-          WHERE leisure = 'marina'
-        ) AS marinas_area
+            way,
+            "natural"
+          FROM
+          (SELECT
+              ST_PointOnSurface(way) AS way,
+              "natural"
+            FROM planet_osm_polygon
+            WHERE way && !bbox!
+          UNION ALL
+          SELECT
+              way,
+              "natural"
+            FROM planet_osm_point
+            WHERE way && !bbox!
+            ) _
+          WHERE "natural" IN ('spring')
+        ) AS springs
     properties:
       minzoom: 14
   - id: piers-poly
@@ -1152,6 +1143,15 @@ Layer:
         ) AS aeroways
     properties:
       minzoom: 11
+  - id: necountries
+    geometry: linestring
+    <<: *extents84
+    Datasource:
+      file: data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp
+      type: shape
+    properties:
+      minzoom: 1
+      maxzoom: 3
   - id: admin-low-zoom
     geometry: linestring
     <<: *extents


### PR DESCRIPTION
**Fixes** #426, #1473, #1547 and #2609
Related to issues #1781, #2013, #2025, #2688, #3707 and PR #3670 as a necessary step in the solution.
Continuation of PR #3694
Partially reverts #3189

## Changes proposed in this pull request:
- Move ocean and water above landcover
- Icesheet polygons are moved before water lines, which are now before water-areas, and ocean polygons are after these. Landcover is now first.
- Also, springs are moved above water-barriers, marinas are moved below water-barriers, and `necountries` is moved to immediately before admin-low-zoom
- Natural=mud is rendered in the `landcover-area-symbols` layer, above all the water bodies

### Explanation
- This PR is the first application of the switch to water (ocean/marine) polygons instead of land polygons. The layering changes follow the order used in the `alternative-colors` stylesheet by @imagico

- By moving the ocean and water areas above the water lines, it is now possible to use different colors for linear water features (such as rivers and streams), seas, lakes and rivers.

- The landcover fill color is now rendered below all types of water. This means that natural areas and areas with `landuse` and `amenity` which extend over water (such as golf courses, parks, schools etc) will be rendered properly. This solves #1547, #2013 and #3707 by not rendering the fill color for wetlands, rock, and beaches over the water, but the pattern will still show.

- Marinas are moved before water barriers because the barriers should be shown over the area outline, as is done for tourism areas and protected areas on land. 

- Springs are moved up above water features so that they will render properly when under a stream or river. The icon is the same as that introduced in PR #3189 but the layering changes are reverted.

- `necountries`, the z1 to z3 country borders, sourced from Natural Earth, are moved immediately before the `admin-low-zoom` layer. This makes sure that the borders are rendered over the water areas at all zoom levels.

- The semi-transparent mud color fill is moved from the main landcover layer to  landcover-area-symbols, which remains above all of the water areas, so that it will render properly over all water areas (If it were not changed, then all areas of mud over seas and water would render as they currently do over natural=water (only the wetland pattern would show); this is also a reasonable option)

In the future it will be possible to solve #2013 and #2025 by adding a fill color for wetland=reedbed and wetland=mangroves. These do not have a fill color currently, because they often grow over water areas. But after this PR the fill color can be rendered below the water, so it will only show on the land. 

## Test renderings with links to the example places:

### Before
z10 Zeeland - current 
https://openstreetmap.org/#map=10/51.5079/3.6996
(mud is over the sea in the south, but under the natural=water in the north)
![z10-zeeland-current](https://user-images.githubusercontent.com/42757252/55663278-22c14000-5857-11e9-9781-8eb2e31eeb55.png)
z12 - current
![z12-zeeland-before](https://user-images.githubusercontent.com/42757252/55663287-2fde2f00-5857-11e9-90fe-f3386ec25f78.png)

z9 North Wales - current 
https://openstreetmap.org/#map=9/53.2258/-3.6090
(the sand banks, covered at low tide, show up the same as beaches)
![z9-north-wales-current](https://user-images.githubusercontent.com/42757252/55663291-3371b600-5857-11e9-99b8-be3bc8fba64a.png)
z13
![z13-wales-salisbury-current](https://user-images.githubusercontent.com/42757252/55663289-31a7f280-5857-11e9-8ddd-a2354c58e226.png)

z14 Newborough forest - current 
https://openstreetmap.org/#map=14/53.1682/-4.3945
 - the spring is under the stream, the marsh is over the sea
![z14-newborough-current](https://user-images.githubusercontent.com/42757252/55663297-3f5d7800-5857-11e9-8916-f5c3890c0a59.png)


### After
z10 Zeeland - after 
(mud areas are the same over the sea and over natural=water)
![z10-zeeland-after-mud-over](https://user-images.githubusercontent.com/42757252/55663302-47b5b300-5857-11e9-8bb7-3140484e0b01.png)
z12 - after
![z12-zeeland-after-mud-over](https://user-images.githubusercontent.com/42757252/55663303-4be1d080-5857-11e9-9d62-2d302e578765.png)

z9 North Wales after 
(sand banks are covered, but the pattern still shows the location)
![z9-north-wales-after](https://user-images.githubusercontent.com/42757252/55663307-569c6580-5857-11e9-87ef-9aae56c5346b.png)
z13 after
![z13-north-wales-after-salisburybanks](https://user-images.githubusercontent.com/42757252/55663311-5ef4a080-5857-11e9-9e03-2ae6e4271aeb.png)

z14 Newborough after - the spring is now over the stream, and the part of the marsh outside of the coastline is distinct
![z14-newborough-after-spring-over-marsh-under](https://user-images.githubusercontent.com/42757252/55663318-8a778b00-5857-11e9-83b7-7307792e2f78.png)