### PR TITLE
Do not render neighborhood names on z20+ anymore

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -435,21 +435,19 @@
 }
 
 #placenames-small::neighborhood {
-  [place = 'locality'],
-  [place = 'neighbourhood'],
-  [place = 'isolated_dwelling'],
-  [place = 'farm'] {
-    [zoom >= 15] {
-      text-name: "[name]";
-      text-size: 10;
-      text-fill: @placenames;
-      text-face-name: @book-fonts;
-      text-halo-fill: @standard-halo-fill;
-      text-halo-radius: @standard-halo-radius * 1.5;
-      text-wrap-width: 45; // 4.5 em
-      text-line-spacing: -0.8; // -0.08 em
-      text-margin: 7.0; // 0.7 em
-    }
+  [place = 'neighbourhood'][zoom >= 15][zoom < 20],
+  [place = 'locality'][zoom >= 15],
+  [place = 'isolated_dwelling'][zoom >= 15],
+  [place = 'farm'][zoom >= 15] {
+    text-name: "[name]";
+    text-size: 10;
+    text-fill: @placenames;
+    text-face-name: @book-fonts;
+    text-halo-fill: @standard-halo-fill;
+    text-halo-radius: @standard-halo-radius * 1.5;
+    text-wrap-width: 45; // 4.5 em
+    text-line-spacing: -0.8; // -0.08 em
+    text-margin: 7.0; // 0.7 em
     [zoom >= 16] {
       text-size: 12;
       text-wrap-width: 60; // 5.0 em


### PR DESCRIPTION
We have yet few rules for z20. This would add another one.

Changes proposed in this pull request:
- Do not render neighborhood names on z20+ anymore

Test rendering with links to the example places:

Before
![01](https://user-images.githubusercontent.com/6830724/55683280-44e1bd80-593e-11e9-961f-0b73c28cc927.png)

After
![02](https://user-images.githubusercontent.com/6830724/55683282-4b703500-593e-11e9-882b-ab0a5ba98f5a.png)

The screenshot is from Ivory Coast, which is low latitude. I think the typical neighborhood is yet as big at z20 that we can stop the label rendering there.

