### PR TITLE
Render only specific values of barrier and historic=citywalls on polygons

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -621,11 +621,16 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, barrier AS feature
+            way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
-            ('barrier_' || barrier) AS barrier
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
+            ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_polygon
-            WHERE barrier IS NOT NULL
+            WHERE (barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
+              OR historic = 'citywalls')
+              AND building IS NULL
           ) AS features
         ) AS area_barriers
     properties:


### PR DESCRIPTION
Fixes #3742

## Changes proposed in this pull request:
-  Select only specific values of barrier for rendering from the polygon geometries, matching the same list used for line-barriers 
- Start rendering historic=citywalls from polygon geometries for consistency with rendering of barrier=city_wall
- Stop rendering barriers on polygons where building is not NULL

## Explanation:
- Currently all values of the key barrier are selected when mapped as polygons. 
- - This includes all relations of type=multipolgyon and all closed ways tagged with area=yes or with any of the keys that are considered a polygon, such as "building", "amenity", "tourism", etc.
- - All values are picked, including barrier=no and barrier=nonsene
- historic=citywalls is rendered on line geometries, but not on polygon geometry. This is a problem if a feature is mapped as a closed way and double-tagged with historic=citywalls and tourism=attraction; the feature will be imported as a polygon, even though editors and mappers think of this as a linear feature.
- Buildings do not need rendering of walls; our standard building rendering already suggests that there are walls around the outline of a building. In particular, "building=no" should not result in area fill rendering when tagged along with "barrier=hedge"

## Test renderings:

Amenity=community_centre + barrier=no (probably meant to describe wheelchair accessibility?)
https:/www.openstreetmap.org/way/392903881/#map=18/53.28442/-3.80404
Before
![](https://user-images.githubusercontent.com/42757252/55965627-eb68ee00-5cb1-11e9-9b16-924e6e357748.png)

After
![](https://user-images.githubusercontent.com/42757252/55966765-fb81cd00-5cb3-11e9-86a5-add88a8131a8.png)

Test area
Before
![barriers-test-before](https://user-images.githubusercontent.com/42757252/56006894-a5dc0d80-5d11-11e9-8164-6c5282dc22d1.png)
After
![barrier-test-after](https://user-images.githubusercontent.com/42757252/56006896-a8d6fe00-5d11-11e9-9b71-5e61c61c0a79.png)