### PR TITLE
Reduce rendering priority of place=locality and raise initial zoom level to z16

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1769,6 +1769,26 @@
     text-placement: interior;
   }
 
+  [feature = 'place_locality'][zoom >= 16] {
+    text-name: "[name]";
+    text-size: 10;
+    text-fill: @placenames;
+    text-face-name: @book-fonts;
+    text-halo-fill: @standard-halo-fill;
+    text-halo-radius: @standard-halo-radius * 1.5;
+    text-wrap-width: 45; // 4.5 em
+    text-line-spacing: -0.8; // -0.08 em
+    text-margin: 7.0; // 0.7 em
+    [zoom >= 17] {
+      text-size: 12;
+      text-wrap-width: 60; // 5.0 em
+      text-line-spacing: -0.60; // -0.05 em
+      text-margin: 8.4; // 0.7 em
+      text-fill: @placenames-light;
+      text-halo-fill: white;
+    }
+  }
+
   [feature = 'amenity_pub'][zoom >= 18],
   [feature = 'amenity_restaurant'][zoom >= 18],
   [feature = 'amenity_food_court'][zoom >= 17],

--- a/placenames.mss
+++ b/placenames.mss
@@ -436,7 +436,6 @@
 
 #placenames-small::neighborhood {
   [place = 'neighbourhood'][zoom >= 15][zoom < 20],
-  [place = 'locality'][zoom >= 15],
   [place = 'isolated_dwelling'][zoom >= 15],
   [place = 'farm'][zoom >= 15] {
     text-name: "[name]";

--- a/project.mml
+++ b/project.mml
@@ -1394,7 +1394,7 @@ Layer:
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
-             OR (place IN ('suburb', 'quarter', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
+             OR (place IN ('suburb', 'quarter', 'neighbourhood', 'isolated_dwelling', 'farm')
                  OR (place IN ('square')
                      AND (leisure is NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden')))
              ) AND name IS NOT NULL
@@ -1404,10 +1404,9 @@ Layer:
               WHEN place = 'hamlet' THEN 5
               WHEN place = 'quarter' THEN 6
               WHEN place = 'neighbourhood' THEN 7
-              WHEN place = 'locality' THEN 8
-              WHEN place = 'isolated_dwelling' THEN 9
-              WHEN place = 'farm' THEN 10
-              WHEN place = 'square' THEN 11
+              WHEN place = 'isolated_dwelling' THEN 8
+              WHEN place = 'farm' THEN 9
+              WHEN place = 'square' THEN 10
             END ASC, length(name) DESC, name
         ) AS placenames_small
     properties:
@@ -1517,7 +1516,7 @@ Layer:
                                                       'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" ELSE NULL END,
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway ELSE NULL END,
-                'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
+                'place_' || CASE WHEN place IN ('island', 'islet', 'locality') THEN place ELSE NULL END,
                 'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
                               THEN historic ELSE NULL END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,

--- a/project.mml
+++ b/project.mml
@@ -1516,7 +1516,7 @@ Layer:
                                                       'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" ELSE NULL END,
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway ELSE NULL END,
-                'place_' || CASE WHEN place IN ('island', 'islet', 'locality') THEN place ELSE NULL END,
+                'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                 'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
                               THEN historic ELSE NULL END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
@@ -1531,7 +1531,8 @@ Layer:
                 'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
                 'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made ELSE NULL END,
                 'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic ELSE NULL END,
-                'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END
+                'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
+                'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place ELSE NULL END
               ) AS feature,
               access,
               CASE


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change place=locality initial zoom to z16
- Move place=locality to `amenity-points` layer instead of `placenames-small`

## Explanation
- The tag [place=locality](https://wiki.openstreetmap.org/wiki/Tag:place=locality) was developed in 2007 for tagging an "unpopulated location for which there is no extant feature to which the tag could be associated." 
- Most of the uses of this tag are from imports in the United States, from the GNIS database and similar public data sources. These are usually "former human settlements for which all taggable features are gone, but which still see use (and/or have value) as named locations. This is most frequent in the case of former hamlets, or for historical railroad stations or railroad junction locations."
- The wiki page for this tag advises that it should not be used when another tag is appropriate, such as another `place=*` tag, administrative boundaries, or natural features such as `natural=cape`.
- However, a review of tag use in Hawaii, Delaware, Andorra and Liechtenstein  shows that that the majority of uses of this tag are for features that could be described more precisely. See the discussion the [Tagging mailing list](https://lists.openstreetmap.org/pipermail/tagging/2019-April/044648.html).
- Many of these features are small and should not be shown at z15, or with priority over other features such as `amenity=hospital` or `place=isolated_dwelling`.
- Therefore, place=locality should be rendered in the `amenity-points` layer, similar to `place=island` and `place=islet`
- The initial zoom level should be changed from z15 to z16 to better represent the kind of features that are tagged, including crossroads within a hamlet, small squares, guideposts, forest clearings, etc.
- This will also encourage mappers to consider adding other tags which will render sooner or with a more specific rendering

## Test rendering with links to the example places:

Ka'awaloa, Hawaii - tagged as locality with a name only
https://www.openstreetmap.org/#map=16/19.4793/-155.9342
Before z15
![z15-ka-awaloa-before](https://user-images.githubusercontent.com/42757252/56259173-17023300-610d-11e9-8200-60561c04a5ad.png)
After
![z15-ka-awaloa-after](https://user-images.githubusercontent.com/42757252/56259199-284b3f80-610d-11e9-9610-95e4b6682f89.png)

z16 Before
![z16-ka-awaloa-before](https://user-images.githubusercontent.com/42757252/56259182-1a95ba00-610d-11e9-8c8a-a002fe183b56.png)
After (not rendered because the Park label has higher priority)
![z16-ka-awaloa-after](https://user-images.githubusercontent.com/42757252/56259216-39944c00-610d-11e9-83b4-091932d82377.png)

z17 Before
![z17-ka-awaloa-before](https://user-images.githubusercontent.com/42757252/56259174-18336000-610d-11e9-83a7-e7c28884cfd8.png)
After
![z17-ka-awaloa-after](https://user-images.githubusercontent.com/42757252/56259226-43b64a80-610d-11e9-9df6-c23c85e998ff.png)

Kawainui, Hawaii - tagged as locality and name only
https://www.openstreetmap.org/#map=17/19.82840/-155.09774
z15 Before
![z15-kawainui-before](https://user-images.githubusercontent.com/42757252/56259289-7eb87e00-610d-11e9-996b-1ccb3e69babd.png)
After

z16 Before
![z16-kawainui-before](https://user-images.githubusercontent.com/42757252/56259292-824c0500-610d-11e9-8772-5dfc07d58b16.png)
After
![z16--Kawainui-after](https://user-images.githubusercontent.com/42757252/56259324-95f76b80-610d-11e9-8e27-347661313b07.png)

z17 Before = After
![z17-Kawainui-after](https://user-images.githubusercontent.com/42757252/56259309-8bd56d00-610d-11e9-985a-8bcff7b05909.png)