### PR TITLE
Render name labels of bays and straits from z14 only, lakes from z5 only

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2521,7 +2521,6 @@
     }
   }
 
-  [feature = 'natural_bay'][zoom >= 14],
   [feature = 'natural_spring'][zoom >= 16] {
     text-name: "[name]";
     text-size: 10;
@@ -2532,9 +2531,7 @@
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;
-    [feature = 'natural_spring'] {
-      text-dy: 6;
-    }
+    text-dy: 6;
   }
 
   [feature = 'amenity_atm'][zoom >= 19],

--- a/project.mml
+++ b/project.mml
@@ -2035,7 +2035,7 @@ Layer:
           ORDER BY way_area DESC
         ) AS text_poly_low_zoom
     properties:
-      minzoom: 0
+      minzoom: 4
       maxzoom: 9
   - id: text-line
     geometry: linestring

--- a/project.mml
+++ b/project.mml
@@ -2012,8 +2012,7 @@ Layer:
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
               'military_' || CASE WHEN military IN ('danger_area') THEN military ELSE NULL END,
-              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
-                                                    'water', 'bay', 'strait') THEN "natural" ELSE NULL END,
+              'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water') THEN "natural" ELSE NULL END,
               'place_' || CASE WHEN place IN ('island') THEN place ELSE NULL END,
               'boundary_' || CASE WHEN (boundary = 'protected_area' AND tags->'protect_class' = '24') THEN 'aboriginal_lands'
                                   WHEN boundary IN ('aboriginal_lands', 'national_park')
@@ -2026,7 +2025,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (landuse IN ('forest', 'military', 'farmland')
               OR military IN ('danger_area')
-              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
+              OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water')
               OR "place" IN ('island')
               OR boundary IN ('aboriginal_lands', 'national_park')
               OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))

--- a/project.mml
+++ b/project.mml
@@ -243,7 +243,7 @@ Layer:
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS water_areas
     properties:
-      minzoom: 0
+      minzoom: 5
   - id: ocean-lz
     geometry: polygon
     class: ocean

--- a/water.mss
+++ b/water.mss
@@ -334,12 +334,10 @@
 .text-low-zoom[zoom < 10],
 #text-point[zoom >= 10] {
   [feature = 'natural_water'],
-  [feature = 'natural_bay'],
-  [feature = 'natural_strait'],
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
-    [zoom >= 0][way_pixels > 3000],
+    [zoom >= 5][way_pixels > 3000],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;
@@ -370,6 +368,7 @@
 }
 
 #text-point[zoom >= 14] {
+  [feature = 'natural_bay'],
   [feature = 'natural_strait'] {
     text-name: "[name]";
     text-size: 10;


### PR DESCRIPTION
Fixes #3634 and #3705
Reverts #3438 and #3144
Related to discussion of `way_area` based name label rendering in #3284 and #2700, also see #2702

## Changes proposed in this pull request:
- Stop using `way_area` to set zoom level and text size for natural=bay and natural=strait text labels
- Render name labels for straits and bays at z14 and above
- Do not render text labels for lakes, reservoirs or docks before z5

## Explanation

- Since #3438 and #3144, natural=strait and natural=bay have been rendered identically to lakes (natural=water and landuse=reservoir) when mapped as an area (closed way or multipolygon relation). Depending on the `way_area`, they will render as soon as z0 in theory, and in practice there is currently a bay rendered on z3. 
- This led to issue #3634, which recommends that natural area labels should not be shown at z4 and below.

- The mapping of bays and straits as areas is controversial, because the non-coastline borders of these features are not verifiable by mappers, and the coastline is already contained in the database. Also, mapping large bays or straits with multipolygons relations can lead to difficult to manage relations with many hundreds of members. 
- Because of this, some mappers have taken to mapping a bay or strait with a rough outline that does not follow the coastline. This is encouraged by the current rendering, because these features are only shown as a text label with the name, and there is no mapper feedback about the shape or borders of the area in the map rendering.
- See also: https://www.openstreetmap.org/user/imagico/diary/43957 [Warning, dark humor]
- Recently a text label rendering was added for straits mapped as linear ways in #3733

- We recently stopped rendering tourism=attraction based on `way_area` because of this same problem, in PR #3603
- Previous to PR #3732  natural=capes mapped as an area were rendered based on `way_area`, but this has now been removed.
- Bays, straits, and malls are the only 3 features that currently have text labels that are rendered based on `way_area` without an outline or area fill rendering.

- This PR will fix #3634 and #3705 by limiting natural=water, landuse=reservoir, landuse=basin and waterway=dock rendering to no sooner than z5. Even the largest lakes in the world do not need text labels before this zoom level, and natural=water is being abused to map marine water areas for label rendering.
- The initial zoom level will be set to z14 for all straits mapped as nodes, ways or areas and all bays mapped as nodes and areas. This level has previously been tested and deemed an acceptable initial zoom level in PR #3733 .

(The PR author plans to submit another PR to add rendering for bays (specifically fjords) mapped as linear ways similar to #3732, and an additional PR to limit the rendering of malls to no sooner than z13 (where the retail landuse fill color is shown) and add a fill or outline in retail color, which should finish resolving the`way_area` based text labels issue.)

While many of us would like to see bays and straits rendered at low zoom levels in this style (the author included), we have a responsibility to support good mapping by providing appropriate feedback. Therefore in the short term this PR is the best solution.

@imagico has suggested a script could be written that would calculate the correct initial zoom level based on a node and the position of the coastline. This would allow us to restore the rendering of bays and straits at low zoom levels, and not only for areas but also for nodes. It would also make it possible to render seas in a consistent fashion, which is not currently possible because these are mapped as nodes. However, there is not yet a volunteer to implement this. [EDITED]

## Test renderings:

**Yam Bay, Hawaii** - mapped as an oval-shaped closed way rather than straight across from the ends of the bay; this causes it to render 1 zoom level sooner than otherwise:
z13 before
![z13-yam-bay-before](https://user-images.githubusercontent.com/42757252/56287955-a7b23080-6158-11e9-98a8-f377bb455957.png)
After
![z13-yam-bay-after](https://user-images.githubusercontent.com/42757252/56288039-d7f9cf00-6158-11e9-94cb-9c5975b6e996.png)

z14 before
![z14-yam-bay-before](https://user-images.githubusercontent.com/42757252/56288041-daf4bf80-6158-11e9-927d-88361178faea.png)
after
![z14-yam-bay-after](https://user-images.githubusercontent.com/42757252/56288050-e0520a00-6158-11e9-9c60-560edfbdb10b.png)

z15 before
![z15-yam-bay-before](https://user-images.githubusercontent.com/42757252/56288070-ecd66280-6158-11e9-9dc8-2e5490b8b8f2.png)
after
![z15-yam-bay-after](https://user-images.githubusercontent.com/42757252/56288095-f8c22480-6158-11e9-928c-c4fac45b4993.png)

**Waioka Bay, Hawaii**
- I was surpised to find that "Waioka Pond", a very small "bay", currently renders at z14. This is because the initial zoom was set to z14 in amenity-points.mss, which overrides the `way_area` based filtering which should have prevented rendering until later. So the current `way_area` adjustment only shows labels sooner, never later.
z13 unchanged
![z13-waioka-bay-after](https://user-images.githubusercontent.com/42757252/56287906-8c472580-6158-11e9-9c96-1328c97fc653.png)
z14 Before
![z14-waioka-bay-before](https://user-images.githubusercontent.com/42757252/56287760-2c507f00-6158-11e9-8702-555f0d53ead8.png)
After
![z14-waioka-bay-after](https://user-images.githubusercontent.com/42757252/56287795-425e3f80-6158-11e9-83fc-31c62aa3ea2a.png)

z16 Before
![z16-waioka-bay-before](https://user-images.githubusercontent.com/42757252/56287895-86514480-6158-11e9-91b6-0b9f50bb6de5.png)
z16 After
![z16-waioka-bay-after](https://user-images.githubusercontent.com/42757252/56287920-96692400-6158-11e9-82da-22a905b88080.png)


**Shelikof Strait, Alaska**
z6 Before
![z6-shelikof-strait-before](https://user-images.githubusercontent.com/42757252/56287718-1773eb80-6158-11e9-80b9-d938224a0e70.png)
after
![z6-strait-after](https://user-images.githubusercontent.com/42757252/56287723-1a6edc00-6158-11e9-9575-87ce2afc3f42.png)