### PR TITLE
Add text label rendering for natural=bay mapped as linear way

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2150,7 +2150,7 @@ Layer:
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
-                 OR "natural" = 'strait')
+                 OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL or tunnel != 'culvert')
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)

--- a/water.mss
+++ b/water.mss
@@ -314,6 +314,7 @@
       }
     }
   }
+  [natural = 'bay'][zoom >= 14],
   [natural = 'strait'][zoom >= 14] {
     text-name: "[name]";
     text-size: 10;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Render name labels for natural=bay mapped as linear ways, using same style as natural=strait

## Explanation
- Currently we render name labels for natural=bay mapped as an area or as a node. However, there are almost 400 bays mapped as linear ways, especially in areas with fjords such as Norway, Greenland and Chile. Many of these bays are long, narrow and curving, so it is reasonable that some mappers like to map these as linear ways.
- Recently we added rendering for straits mapped as linear ways in PR #3733 - this new PR will complete the rendering for bays as well, using the same style as that used for straits in the former PR
- 99% of the bays mapped as ways could be rendered as early as z13, but the initial zoom level is set at z14 to be consistent with the current rendering of bay nodes. 

## Test rendering with links to the example places:

Chile: https://www.openstreetmap.org/#map=14/-42.2631/-72.4470
Before z14
![z14-before-chile](https://user-images.githubusercontent.com/42757252/56458842-83f42200-63c6-11e9-89b1-9cf8db714a1d.png)

After z14
![z14-fiordo-cahuelmo](https://user-images.githubusercontent.com/42757252/56458817-4099b380-63c6-11e9-88b6-2b55086dadbb.png)
After z15
![z15-fiordo-cahuelmo](https://user-images.githubusercontent.com/42757252/56458819-41324a00-63c6-11e9-816e-15b03211d422.png)

Norway: https://www.openstreetmap.org/#map=14/59.0483/5.6642
Before z14 - straits render (mapped as linear ways), but not the bay
![z14-norway-before](https://user-images.githubusercontent.com/42757252/56458855-a128f080-63c6-11e9-87e6-9f0736577ed8.png)
After
![z14-svinavika-bay-after](https://user-images.githubusercontent.com/42757252/56458858-a4bc7780-63c6-11e9-8891-b08e3a00ba61.png)