### PR TITLE
Render administrative boundary text labels for relations only

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2188,6 +2188,7 @@ Layer:
           WHERE boundary = 'administrative'
             AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
+            AND osm_id < 0
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1288,6 +1288,7 @@ Layer:
             AND admin_level = '2'
             AND name IS NOT NULL
             AND way_area > 100*!pixel_width!::real*!pixel_height!::real
+            AND osm_id < 0
           ORDER BY way_area DESC
         ) AS country_names
     properties:
@@ -1331,6 +1332,7 @@ Layer:
             AND admin_level = '4'
             AND name IS NOT NULL
             AND way_area > 100*!pixel_width!::real*!pixel_height!::real
+            AND osm_id < 0
           ORDER BY way_area DESC
         ) AS state_names
     properties:


### PR DESCRIPTION
### Fixes #3761 and Fixes #2663

# Changes proposed in this pull request:
- Render text labels along borders of admin boundary relations only, not from closed ways
- Render name labels for country and province/state from relations only, not from closed ways

### Explanation:
- Currently the border lines are only rendered for borders mapped as relations (with `osm_id < 0`)
- But the text labels along the borders are rendered for both relations and closed ways, in the case when the closed way is also tagged with a key that is imported as a polygon, such as `place=island` or `landuse=residential`. 
- This commit adds a filter for "AND osm_id < 0" to the admin-text layer, so that the text labels do not appear in the rare occasions when an administrative boundary is mapped as a closed way instead of a relation

# Test renderings:

## Keaukaha Hawaiian Homeland, Hawaii USA
https://www.openstreetmap.org/way/146660105/
- closed way tagged landuse=residential + boundary=administrative + admin_level=5
z16 Before
![z16-keaukaha-closed-way-residential](https://user-images.githubusercontent.com/42757252/56628456-d5313980-6684-11e9-885e-0fafc32b0f21.png)
After
![z16-keaukaha-after](https://user-images.githubusercontent.com/42757252/56629036-0c084f00-6687-11e9-8c65-7088fea30175.png)

## Ilheus Das Cabras, Azores, Portugal
https://www.openstreetmap.org/way/157531901/
- closed ways tagged `natural=coastline`+ `place=islet` + `name=Ilheus das Cabras` + `boundary=administrative` + `admin_level=4` (the administrative boundary of the Azores province follows the coastline)
- This renders as if Ilheas das Cabras were the name of a province! The real province name also renders properly from a relation with `type=boundary` which has this way as a member. 
z16 Before
![z16-ilheus-das-cabras-before](https://user-images.githubusercontent.com/42757252/56628550-38bb6700-6685-11e9-9338-ffc3dc36e7f2.png)
After
![z16-ilheu-das-cabras-after](https://user-images.githubusercontent.com/42757252/56630717-32c98400-668d-11e9-8956-28640bcb33d5.png)

z18 Before
![z18-ilheus-das-cabras-before](https://user-images.githubusercontent.com/42757252/56629109-41ad3800-6687-11e9-8de9-888733f53709.png)
After
![z18-ilheus-das-cabras-after](https://user-images.githubusercontent.com/42757252/56630728-3957fb80-668d-11e9-9f86-8f3a5895f1e8.png)