### PR TITLE
Stop label rendering for too big areas

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1744,10 +1744,10 @@
 /* Note that these layers are also used in water.mss */
 .text-low-zoom[zoom < 10],
 #text-point[zoom >= 10] {
-  [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels < 800000],
-  [feature = 'place_island'][zoom >= 16][way_pixels < 800000],
-  [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels < 800000],
-  [feature = 'place_islet'][zoom >= 17][way_pixels < 800000] {
+  [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels <= 768000],
+  [feature = 'place_island'][zoom >= 16][way_pixels <= 768000],
+  [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels <= 768000],
+  [feature = 'place_islet'][zoom >= 17][way_pixels <= 768000] {
     text-name: "[name]";
     text-fill: #000;
     text-size: @landcover-font-size;
@@ -2184,8 +2184,8 @@
   }
 
   [feature = 'leisure_swimming_pool'][is_building = 'no'] {
-    [zoom >= 14][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 14][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2239,8 +2239,8 @@
   [feature = 'leisure_nature_reserve'],
   [feature = 'boundary_aboriginal_lands'],
   [feature = 'boundary_protected_area'] {
-    [zoom >= 8][way_pixels > 3000][is_building = 'no'],
-    [zoom >= 17] {
+    [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2278,8 +2278,8 @@
   }
 
   [feature = 'military_danger_area'][is_building = 'no'] {
-    [zoom >= 9][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 9][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2303,8 +2303,8 @@
   }
 
   [feature = 'landuse_garages'][is_building = 'no'] {
-    [zoom >= 13][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 13][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2380,10 +2380,10 @@
   [feature = 'leisure_dog_park'],
   [feature = 'leisure_ice_rink'],
   [feature = 'leisure_pitch'] {
-    [zoom >= 10][way_pixels > 3000][is_building = 'no'],
-    [zoom >= 17][is_building = 'no'],
-    [zoom >= 10][way_pixels > 3000][feature = 'shop_mall'],
-    [zoom >= 17][feature = 'shop_mall'] {
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][feature = 'shop_mall'],
+    [zoom >= 17][way_pixels <= 768000][feature = 'shop_mall'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2648,8 +2648,8 @@
   }
 
   [feature = 'leisure_marina'][zoom >= 15] {
-    [zoom >= 10][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3024,8 +3024,8 @@
   [feature = 'power_generator'][is_building = 'no']["generator:source" != 'wind'][zoom >= 10],
   [feature = 'power_sub_station'][is_building = 'no'][zoom >= 13],
   [feature = 'power_substation'][is_building = 'no'][zoom >= 13]{
-    [way_pixels > 3000],
-    [zoom >= 17] {
+    [way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3052,8 +3052,8 @@
   [feature = 'natural_shingle'][zoom >= 9],
   [feature = 'natural_bare_rock'],
   [feature = 'natural_sand'] {
-    [zoom >= 8][way_pixels > 3000][is_building = 'no'],
-    [zoom >= 17][is_building = 'no'] {
+    [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels <= 768000][is_building = 'no'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3084,8 +3084,8 @@
   }
 
   [feature = 'aeroway_apron'][is_building = 'no'] {
-    [zoom >= 10][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3110,8 +3110,8 @@
 
   [feature = 'highway_services'][is_building = 'no'],
   [feature = 'highway_rest_area'][is_building = 'no'] {
-    [zoom >= 10][way_pixels > 3000],
-    [zoom >= 17] {
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3135,9 +3135,9 @@
   }
 
   [feature = 'natural_glacier'][is_building = 'no'] {
-    [zoom >= 8][way_pixels > 10000],
-    [zoom >= 10][way_pixels > 750],
-    [zoom >= 17] {
+    [zoom >= 8][way_pixels > 10000][way_pixels <= 768000],
+    [zoom >= 10][way_pixels > 750][way_pixels <= 768000],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;

--- a/roads.mss
+++ b/roads.mss
@@ -2672,7 +2672,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #bridge-text  {
   [man_made = 'bridge'] {
-    [zoom >= 12][way_pixels > 62.5] {
+    [zoom >= 12][way_pixels > 62.5][way_pixels <= 64000] {
       text-name: "[name]";
       text-size: 10;
       text-wrap-width: 30; // 3 em

--- a/water.mss
+++ b/water.mss
@@ -339,7 +339,7 @@
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
-    [zoom >= 0][way_pixels > 3000],
+    [zoom >= 0][way_pixels > 3000][way_pixels <= 768000],
     [zoom >= 17] {
       text-name: "[name]";
       text-size: 10;


### PR DESCRIPTION
Fixes #1082

For various areas, we start label rendering not at a fixed zoom level, but based on the area of the feature. Bigger features get rendered yet on earlier zoom levels.

Furthermore, the size of the label usually gets bigger when the zoom level raises and so the feature occupies more space on the screen.

Since a while, we want to stop label rendering for very big areas that cover the hole screen because the label is quite useless at this scale. However this was not possible in the past because of a bug in our software stack. The bug has been fixed, so now we can do this. (See #1028)

Changes proposed in this pull request:
- Stop label rendering for too big landcover areas.
- Unify the thresholds of islands/islets with the other landcover features: 750, 3000, 12000, 48000, 192000, 768000 (always factor 4 between the steps). [Bridge thresholds follow a different logic and still have their own threshold set.

Test rendering with links to the example places:

(Left: After / Right: Before)
![w1](https://user-images.githubusercontent.com/6830724/56670372-3e737580-66a2-11e9-96bb-bb28b9a004b5.png)
![w2](https://user-images.githubusercontent.com/6830724/56670373-3f0c0c00-66a2-11e9-9b5c-2d3feddb14eb.png)
![w3](https://user-images.githubusercontent.com/6830724/56670375-3f0c0c00-66a2-11e9-918a-b29330d51cf8.png)
![w5](https://user-images.githubusercontent.com/6830724/56670377-3fa4a280-66a2-11e9-95b3-4e6ac442aeff.png)
