### PR TITLE
Add healthcare tag to lua transformations as a polygon key

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -14,6 +14,7 @@ local polygon_keys = {
     'building',
     'building:part',
     'harbour',
+    'healthcare',
     'historic',
     'landuse',
     'leisure',


### PR DESCRIPTION
Fixes #3639
Related to #1981 and #2938

Changes proposed in this pull request:
- Add "healthcare" to list of keys imported as polygons (when mapped as a closed way)
- This will make it possible to render healthcare objects properly, after the next database reload

Test rendering with links to the example places:
- N/A: does not change rendering currently

EDIT: this should be merged to the `schema_changes` branch, not to `master`. Not sure if I can change this?