### PR TITLE
Import "allotments" as a polygon key

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -9,6 +9,7 @@ local polygon_keys = {
     'abandoned:landuse',
     'abandoned:power',
     'aeroway',
+    'allotments',
     'amenity',
     'area:highway',
     'building',


### PR DESCRIPTION
Related to #432

Changes proposed in this pull request:
- Import "allotments" as a polygon feature by adding it to the list of polygon_keys in the lua transformations file
- This will import closed ways tagged as "allotments=plot" properly as a polygon rather than a linestring, which makes it possible to render the ref numbers for plots (see #432) or plot outlines
- Current rendering is unchanged

Should be merged to the `schema_changes` branch, which will be merged to master at the time of the next database reload