### PR TITLE
Import railway=station as a polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased](https://github.com/gravitystorm/openstreetmap-carto/compare/v4.21.0...master)
 
-## [v4.21.0](https://github.com/gravitystorm/openstreetmap-carto/compare/v4.20.0...v4.21.0)
+## [v4.21.0](https://github.com/gravitystorm/openstreetmap-carto/compare/v4.20.0...v4.21.0) - 2019-05-01
 ## Major changes
 - Removed unused `world_boundaries-spherical.tgz` file from scripts
 

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2349,7 +2349,7 @@
   [feature = 'landuse_farmyard'],
   [feature = 'landuse_farmland'],
   [feature = 'landuse_greenhouse_horticulture'],
-  [feature = 'shop_mall'],
+  [feature = 'shop'][shop = 'mall'],
   [feature = 'landuse_retail'],
   [feature = 'landuse_industrial'],
   [feature = 'landuse_railway'],
@@ -2382,8 +2382,8 @@
   [feature = 'leisure_pitch'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
     [zoom >= 17][way_pixels <= 768000][is_building = 'no'],
-    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][feature = 'shop_mall'],
-    [zoom >= 17][way_pixels <= 768000][feature = 'shop_mall'] {
+    [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][shop = 'mall'],
+    [zoom >= 17][way_pixels <= 768000][shop = 'mall'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -2447,7 +2447,7 @@
       [feature = 'landuse_greenhouse_horticulture'] {
         text-fill: darken(@farmland, 50%);
       }
-      [feature = 'shop_mall'],
+      [feature = 'shop'][shop = 'mall'],
       [feature = 'landuse_retail'] {
         text-fill: darken(@retail, 50%);
       }
@@ -2801,89 +2801,7 @@
     }
   }
 
-  [feature = 'shop_art'],
-  [feature = 'shop_bag'],
-  [feature = 'shop_bakery'],
-  [feature = 'shop_beauty'],
-  [feature = 'shop_bed'],
-  [feature = 'shop_beverages'],
-  [feature = 'shop_bookmaker'],
-  [feature = 'shop_books'],
-  [feature = 'shop_carpet'],
-  [feature = 'shop_charity'],
-  [feature = 'shop_clothes'],
-  [feature = 'shop_coffee'],
-  [feature = 'shop_computer'],
-  [feature = 'shop_fashion'],
-  [feature = 'shop_convenience'],
-  [feature = 'shop_confectionery'],
-  [feature = 'shop_pastry'],
-  [feature = 'shop_chocolate'],
-  [feature = 'shop_copyshop'],
-  [feature = 'shop_deli'],
-  [feature = 'shop_doityourself'],
-  [feature = 'shop_dry_cleaning'],
-  [feature = 'shop_hardware'],
-  [feature = 'shop_hairdresser'],
-  [feature = 'shop_hifi'],
-  [feature = 'shop_houseware'],
-  [feature = 'shop_ice_cream'],
-  [feature = 'shop_interior_decoration'],
-  [feature = 'shop_butcher'],
-  [feature = 'shop_car'],
-  [feature = 'shop_car_repair'],
-  [feature = 'shop_car_parts'],
-  [feature = 'shop_cosmetics'],
-  [feature = 'shop_dairy'],
-  [feature = 'shop_bicycle'],
-  [feature = 'shop_fabric'],
-  [feature = 'shop_farm'],
-  [feature = 'shop_fishmonger'],
-  [feature = 'shop_florist'],
-  [feature = 'shop_garden_centre'],
-  [feature = 'shop_greengrocer'],
-  [feature = 'shop_pet'],
-  [feature = 'shop_photo'],
-  [feature = 'shop_photo_studio'],
-  [feature = 'shop_photography'],
-  [feature = 'shop_shoes'],
-  [feature = 'shop_gift'],
-  [feature = 'shop_electronics'],
-  [feature = 'shop_alcohol'],
-  [feature = 'shop_optician'],
-  [feature = 'shop_outdoor'],
-  [feature = 'shop_perfumery'],
-  [feature = 'shop_furniture'],
-  [feature = 'shop_kiosk'],
-  [feature = 'shop_massage'],
-  [feature = 'shop_medical_supply'],
-  [feature = 'shop_mobile_phone'],
-  [feature = 'shop_motorcycle'],
-  [feature = 'shop_music'],
-  [feature = 'shop_musical_instrument'],
-  [feature = 'shop_newsagent'],
-  [feature = 'shop_jewelry'],
-  [feature = 'shop_jewellery'],
-  [feature = 'shop_laundry'],
-  [feature = 'shop_chemist'],
-  [feature = 'shop_paint'],
-  [feature = 'shop_toys'],
-  [feature = 'shop_travel_agency'],
-  [feature = 'shop_seafood'],
-  [feature = 'shop_second_hand'],
-  [feature = 'shop_sports'],
-  [feature = 'shop_stationery'],
-  [feature = 'shop_tobacco'],
-  [feature = 'shop_tea'],
-  [feature = 'shop_ticket'],
-  [feature = 'shop_trade'],
-  [feature = 'shop_tyres'],
-  [feature = 'shop_variety_store'],
-  [feature = 'shop_video'],
-  [feature = 'shop_video_games'],
-  [feature = 'shop_wholesale'],
-  [feature = 'shop_wine'],
-  [feature = 'shop_other'] {
+  [feature = 'shop'][shop != 'mall'] {
     [way_pixels > 3000][zoom >= 17],
     [zoom >= 18] {
       text-name: "[name]";
@@ -2896,10 +2814,10 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
       text-placement: interior;
-      [feature = 'shop_car_repair'] {
+      [shop = 'car_repair'] {
         text-fill: @amenity-brown;
       }
-      [feature = 'shop_massage'] {
+      [shop = 'massage'] {
         text-fill: @leisure-green;
       }
     }

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -44,7 +44,8 @@ local linestring_values = {
 -- Objects with any of the following key/value combinations will be treated as polygon
 local polygon_values = {
     highway = {services = true, rest_area = true},
-    junction = {yes = true}
+    junction = {yes = true},
+    railway = {station = true}
 }
 
 -- The following keys will be deleted

--- a/project.mml
+++ b/project.mml
@@ -2094,10 +2094,11 @@ Layer:
       table: |-
         (SELECT
             name,
-            way,
+            ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE building IS NOT NULL
+          WHERE way && !bbox!
+            AND building IS NOT NULL
             AND building NOT IN ('no')
             AND name IS NOT NULL
           ORDER BY way_area DESC

--- a/project.mml
+++ b/project.mml
@@ -1473,7 +1473,21 @@ Layer:
           FROM
           (SELECT -- This subselect allows filtering on the feature column
               way,
-              name,
+              CONCAT(
+                name,
+                E'\n' || CONCAT( -- by doing this with a || if both the ele and height branches are null, this entire expression is null and only name is used
+                  CASE
+                    WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
+                      AND ("natural" IN ('peak', 'volcano', 'saddle')
+                        OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
+                        OR amenity = 'shelter')
+                    THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') ELSE NULL END,
+                  CASE
+                    WHEN (tags ? 'height') AND tags->'height' ~ '^\d{1,3}(\.\d+)?$'
+                      AND waterway = 'waterfall'
+                    THEN CONCAT(ROUND((tags->'height')::NUMERIC)::TEXT, U&'\00A0', 'm') ELSE NULL END
+                  )
+                ) AS name,
               COALESCE(
                 'aeroway_' || CASE WHEN aeroway IN ('gate', 'apron', 'helipad', 'aerodrome') THEN aeroway ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('alpine_hut', 'apartment', 'artwork', 'camp_site', 'caravan_site', 'chalet', 'gallery', 'guest_house',

--- a/project.mml
+++ b/project.mml
@@ -2165,7 +2165,7 @@ Layer:
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
-                 OR "natural" = 'strait')
+                 OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL or tunnel != 'culvert')
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)

--- a/water.mss
+++ b/water.mss
@@ -314,6 +314,7 @@
       }
     }
   }
+  [natural = 'bay'][zoom >= 14],
   [natural = 'strait'][zoom >= 14] {
     text-name: "[name]";
     text-size: 10;


### PR DESCRIPTION
Fixes #3303

Changes proposed in this pull request:
- Import the tag `railway=station` as a polygon feature
- This will allow closed ways tagged with `railway=station` to render properly as POIs or areas. Currently an `area=yes` tag or double-tagging with `public_transport` is needed for proper import.
- Database reload is required before any changes are visible, so this PR should be merged to the schema_changes branch, which will be made public when the next database reload is ready