### PR TITLE
Import barrier=toll_booth closed ways as polygons

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -46,6 +46,7 @@ local linestring_values = {
 
 -- Objects with any of the following key/value combinations will be treated as polygon
 local polygon_values = {
+    barrier = {toll_booth = true},
     highway = {services = true, rest_area = true},
     junction = {yes = true},
     railway = {station = true}


### PR DESCRIPTION
Fixes #3244

Changes proposed in this pull request:
- Import the tag `barrier=toll_booth` as a polygon when mapped as a closed way
- This allows rendering toll booth that are mapped as areas, an option that is allowed by the wiki documentation and supported in iD and perhaps in other editors
- This PR should be merged to the `schema_changes` branch, which can then be merged to master when the next database reload is planned.