### PR TITLE
Add retail color fill for shop=mall areas

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -355,6 +355,7 @@
   }
 
   [feature = 'landuse_retail'],
+  [feature = 'shop_mall'],
   [feature = 'amenity_marketplace'] {
     [zoom >= 8] {
       polygon-fill: @built-up-lowzoom;

--- a/project.mml
+++ b/project.mml
@@ -90,7 +90,7 @@ Layer:
       table: |-
         (SELECT
             way, name, religion, way_pixels, is_building,
-            COALESCE(aeroway, amenity, wetland, power, landuse, leisure, man_made, "natural", tourism, highway, railway) AS feature
+            COALESCE(aeroway, amenity, wetland, power, landuse, leisure, man_made, "natural", shop, tourism, highway, railway) AS feature
           FROM (SELECT
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway ELSE NULL END)) AS aeroway,
@@ -103,6 +103,7 @@ Layer:
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
                                                     'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial',
                                                     'brownfield', 'landfill', 'construction', 'plant_nursery', 'religious') THEN landuse ELSE NULL END)) AS landuse,
+              ('shop_' || (CASE WHEN shop IN ('mall') AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL) THEN shop ELSE NULL END)) AS shop,
               ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'garden',
                                                     'golf_course', 'miniature_golf', 'sports_centre', 'stadium', 'pitch', 'ice_rink',
                                                     'track', 'dog_park', 'fitness_station') THEN leisure ELSE NULL END)) AS leisure,
@@ -127,6 +128,7 @@ Layer:
               OR man_made IN ('works', 'wastewater_plant','water_works')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'marsh', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')
               OR power IN ('station', 'sub_station', 'substation', 'generator')
+              OR shop IN ('mall')
               OR tourism IN ('camp_site', 'caravan_site', 'picnic_site')
               OR highway IN ('services', 'rest_area')
               OR railway = 'station')


### PR DESCRIPTION
### Fixes #2702 

## Changes proposed in this pull request:
- Add retail color fill for shop=mall areas
- But do not rendering shop=mall fill when underground=yes

## Explanation
Currently most malls are mapped with the same geometry as a building, or are tagged with landuse=retail. However, some malls area mapped as areas but lack either of these tags. These malls are labeled based on the size of the area, but there is no mapper feedback from this style about the shape of the area.

It would improve mapper feedback to render these areas, because you would see the shape of the mall as mapped, meaning there would be feedback on accuracy of the geometry.

However, there are some malls that are located underground, beneath streets, for example near subway stations. These should not be shown with the landuse fill color, because the mall does not represent the landuse of the area in this case.

### Test rendering with links to the example places:

**Before**
Citylink Singapore (location=underground) - unchanged
https://www.openstreetmap.org/#map=17/1.2923/103.8546
![z17-citylink-label-only](https://user-images.githubusercontent.com/42757252/56556531-37c9fd00-65d3-11e9-988d-60108d49355e.png)

z19 Esplanade Xchange - before (located underground but not tagged)
https://www.openstreetmap.org/#map=19/1.2931/103.8555
![z19-Esplanade-Xchange-before](https://user-images.githubusercontent.com/42757252/58450694-e91bff80-814a-11e9-86e5-e8adc183315f.png)

Diamond Run, z17 - mall mapped as an area; above ground
https://www.openstreetmap.org/#map=17/43.58043/-72.96340
![z17-diamond-run-before](https://user-images.githubusercontent.com/42757252/58450770-487a0f80-814b-11e9-8ed3-8ab37abef9d8.png)

Sicilia Outlet Village - outdoor outlet mall, with detailed mapping
https://www.openstreetmap.org/#map=17/37.573296/14.480978
![z17-sicilia-before](https://user-images.githubusercontent.com/42757252/58450826-a4449880-814b-11e9-96ea-e1f4a534e62c.png)


**After**
Citylink Singapore (location=underground) - unchanged
![z17-citylink-label-only](https://user-images.githubusercontent.com/42757252/56556531-37c9fd00-65d3-11e9-988d-60108d49355e.png)

z19 Esplanade Xchange after - fill rendered
![z19-esplanade-xchnange-mall-after-19:1 29310:103 85549](https://user-images.githubusercontent.com/42757252/58450724-0b158200-814b-11e9-89db-e34d18c04dcb.png)

Diamond Run z17
![z17-diamond-run-mall-fill](https://user-images.githubusercontent.com/42757252/56553059-19123900-65c8-11e9-8486-4fb7e8f744f2.png)

Sicilia Outlets z17
![z17-sicilia-fill](https://user-images.githubusercontent.com/42757252/56580405-7086c800-660d-11e9-9ba1-48f979d52b25.png)