### PR TITLE
Increase "office=" initial zoom to z18 and move deprecated values to z19

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1325,7 +1325,7 @@
   }
 
   // office points
-  [feature = 'office'][zoom >= 17] {
+  [feature = 'office'][zoom >= 18] {
     marker-width: 4;
     [zoom >= 18] {
       marker-width: 6;
@@ -2844,63 +2844,43 @@
   }
 
   [feature = 'office'] {
-    // potentially larger offices
-    [zoom >= 17] {
-      [office = 'administrative'],
-      [office = 'adoption_agency'],
-      [office = 'educational_institution'],
-      [office = 'employment_agency'],
-      [office = 'energy_supplier'],
-      [office = 'financial'],
-      [office = 'government'],
-      [office = 'newspaper'],
-      [office = 'ngo'],
-      [office = 'political_party'],
-      [office = 'quango'],
-      [office = 'religion'],
-      [office = 'research'],
-      [office = 'tax'],
-      [office = 'telecommunication'],
-      [office = 'water_utility'],
-      {
-        text-name: "[name]";
-        text-size: @standard-font-size;
-        text-wrap-width: @standard-wrap-width;
-        text-line-spacing: @standard-line-spacing-size;
-        text-dy: 8;
-        text-fill: @office;
-        text-face-name: @standard-font;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: rgba(255, 255, 255, 0.6);
-        text-placement: interior;
-      }
-    }
-
-    // other documented office types
     [zoom >= 18] {
       [office = 'accountant'],
+      [office = 'adoption_agency'],
       [office = 'advertising_agency'],
       [office = 'architect'],
       [office = 'association'],
       [office = 'charity'],
       [office = 'company'],
+      [office = 'educational_institution'],
+      [office = 'employment_agency'],
+      [office = 'energy_supplier'],
       [office = 'estate_agent'],
+      [office = 'financial'],
       [office = 'forestry'],
       [office = 'foundation'],
+      [office = 'government'],
       [office = 'guide'],
       [office = 'insurance'],
       [office = 'it'],
       [office = 'lawyer'],
       [office = 'logistics'],
       [office = 'moving_company'],
+      [office = 'newspaper'],
+      [office = 'ngo'],
       [office = 'notary'],
-      [office = 'physician'],
+      [office = 'political_party'],
       [office = 'private_investigator'],
       [office = 'property_management'],
+      [office = 'quango'],
+      [office = 'religion'],
+      [office = 'research'],
       [office = 'surveyor'],
+      [office = 'tax'],
       [office = 'tax_advisor'],
-      [office = 'therapist'],
-      [office = 'travel_agent'] {
+      [office = 'telecommunication'],
+      [office = 'travel_agent'],
+      [office = 'water_utility'] {
         text-name: "[name]";
         text-size: @standard-font-size;
         text-wrap-width: @standard-wrap-width;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1326,10 +1326,7 @@
 
   // office points
   [feature = 'office'][zoom >= 18] {
-    marker-width: 4;
-    [zoom >= 18] {
-      marker-width: 6;
-    }
+    marker-width: 6;
     marker-line-width: 0;
     marker-placement: interior;
     marker-clip: false;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2853,6 +2853,7 @@
       [office = 'charity'],
       [office = 'company'],
       [office = 'educational_institution'],
+      [office = 'diplomatic'],
       [office = 'employment_agency'],
       [office = 'energy_supplier'],
       [office = 'estate_agent'],


### PR DESCRIPTION
### Related to #3794

## Changes proposed in this pull request:
- Increase `office=` initial zoom to z18 for documented values
- Remove `office=physician`, `office=therapist`, and `office=administrative` from the list of documented values that are rendered at z18

### Explanation

In issue #3794 it is noted that "the office dots render before or at the same level as the buildings and the building name gets "covered" at z17, where most office= names are not yet rendered. 

This PR moves the initial rendering of the dot marker from z17 to z18, and all frequently-used, documented values will have a name label rendered at z18. Currently a small subset are rendered at z17.

The three deprecated tags office=physician, office=therapist, office=administrative were removed from the explict list of documented values which are rendered at z18, but they will still render at z19.

The subset of office values that currently rendered at z17 will now render at z18. The dot markers were removed from z17.

After this PR, dots will still be shown for shops and restaurants at z17, but the office dots will not be shown at this level. This is reasonable, because while a concentration of shop/restaurant dots can be helpful to find an area for shopping or eating, a concentration of unspecified offices without names is not helpful to the general map user.

## Test rendering with links to the example places:


Singapore Parliament House, z17 - before
https://www.openstreetmap.org/#map=17/1.2880/103.8497
![z17-parliament-house-office-before](https://user-images.githubusercontent.com/42757252/58798768-76c18880-863e-11e9-85fd-7b256795cbe6.png)

z17 after - Parliament House building name visible
![z17-parliament-office-after](https://user-images.githubusercontent.com/42757252/58798848-bb4d2400-863e-11e9-9b82-bba300b5be75.png)

z18 is unchanged:
![z18-parliament-office-after](https://user-images.githubusercontent.com/42757252/58798853-bd16e780-863e-11e9-8f81-ad4938a98e4d.png)

Telok Ayer, Singapore z17 - before
![z17-telok-ayer-before-office](https://user-images.githubusercontent.com/42757252/58798688-33671a00-863e-11e9-97a2-ccf37d992189.png)
z18 before
![z18-telok-ayer-office-before](https://user-images.githubusercontent.com/42757252/58798733-5db8d780-863e-11e9-93ce-4b86b2e8db46.png)

z17 after - building name visible (The Octogon)
![z17-telok-ayer-singapore-office-after](https://user-images.githubusercontent.com/42757252/58798748-64474f00-863e-11e9-94a7-b5bc82d3b94e.png)
z18 after
![z18-telok-ayer-singapore-office-after](https://user-images.githubusercontent.com/42757252/58798754-690c0300-863e-11e9-8ab6-b7b5174201cc.png)
