### PR TITLE
Drop 'highway=steps' from z=13

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -646,7 +646,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 14][access != 'no'],
         [zoom >= 15] {
           line-width: @steps-width-z14 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }

--- a/roads.mss
+++ b/roads.mss
@@ -118,7 +118,6 @@
 @track-width-z13:                 0.5;
 @track-grade1-width-z13:          0.5;
 @track-grade2-width-z13:          0.5;
-@steps-width-z13:                 0.7;
 
 @secondary-width-z14:             5;
 @tertiary-width-z14:              5;
@@ -127,6 +126,7 @@
 @pedestrian-width-z14:            3;
 @road-width-z14:                  2;
 @service-width-z14:               2;
+@steps-width-z14:                 0.7;
 
 @motorway-width-z15:             10;
 @motorway-link-width-z15:         7.8;
@@ -639,7 +639,7 @@
       #bridges {
         [zoom >= 14][access != 'no'],
         [zoom >= 15] {
-          line-width: @steps-width-z13 + 2 * (@paths-background-width + @paths-bridge-casing-width);
+          line-width: @steps-width-z14 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
           line-color: @bridge-casing;
           line-join: round;
@@ -648,7 +648,7 @@
       #tunnels {
         [zoom >= 13][access != 'no'],
         [zoom >= 15] {
-          line-width: @steps-width-z13 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
+          line-width: @steps-width-z14 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
           line-color: @tunnel-casing;
           line-dasharray: 4,2;
@@ -945,19 +945,19 @@
       #bridges {
         [zoom >= 14][access != 'no'],
         [zoom >= 15] {
-          line-width: @steps-width-z13 + 2 * @paths-background-width;
+          line-width: @steps-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * @paths-background-width; }
           line-color: @steps-casing;
           line-join: round;
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 14][access != 'no'],
         [zoom >= 15] {
           line-color: @steps-casing;
           line-cap: round;
           line-join: round;
-          line-width: @steps-width-z13 + 2 * @paths-background-width;
+          line-width: @steps-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * @paths-background-width; }
         }
       }
@@ -1808,7 +1808,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_steps'] {
-      [zoom >= 13][access != 'no'],
+      [zoom >= 14][access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @steps-casing;
@@ -1820,7 +1820,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line/line-color: @steps-fill;
         [access = 'no'] { line/line-color: @steps-fill-noaccess; }
         line/line-dasharray: 2,1;
-        line/line-width: @steps-width-z13;
+        line/line-width: @steps-width-z14;
         [zoom >= 15] { line/line-width:  @steps-width-z15; }
       }
     }


### PR DESCRIPTION
Fixes #3808

### Changes proposed in this pull request
- Drop steps from z13

### Description

Footway rendering was dropped with #3467, steps should likewise be dropped. For future reference, if more cleanup/adjustments happens to z13:
>When taking the current status of z13 otherwise as a given removing steps would be an improvement. But i like to point out that #3467 (and to some extent already #747) left z13 and the whole zoom level progression in a fairly inconsistent state with several contradicting design ideas being thrown together. I have my doubts that in the long term a z13 design and a zoom level progression with no footways (and accordingly no steps) at z13 makes a lot of sense. #3467 did not really present a vision how this is supposed to work outside European urban settings and even there it has its problems.

>So yes, removing the steps from z13 would be consequential in the current situation but it should not prejudice the long term strategy for z13 and around.

_Originally posted by @imagico in https://github.com/gravitystorm/openstreetmap-carto/issues/3808#issuecomment-503034693_

### Test rendering with links to the example places

#### Before

![steps-ex-old](https://user-images.githubusercontent.com/14207079/61680747-9df01a00-acbf-11e9-8656-bb333f0cb257.png)

([Vitória, Espírito Santo, Brasil](https://www.openstreetmap.org/#map=13/-20.3090/-40.3167)) - thanks @LucFreitas for the excellent example location

#### After

![steps-ex-new](https://user-images.githubusercontent.com/14207079/61680752-a21c3780-acbf-11e9-93f4-a0750b71650b.png)