### PR TITLE
Check the generated road colours for drift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - CARTO=0.18.0 MAPNIK='3.0.0 3.0.12'
 install:
   - npm install carto@$CARTO
+  - pip install --user colormath
   - mkdir -p data/world_boundaries data/simplified-water-polygons-split-3857 data/ne_110m_admin_0_boundary_lines_land data/water-polygons-split-3857
   - touch data/simplified-water-polygons-split-3857/simplified_water_polygons.shp data/ne_110m_admin_0_boundary_lines_land/ne_110m_admin_0_boundary_lines_land.shp data/water-polygons-split-3857/water_polygons.shp
   - createdb -w -E utf8 -U postgres gis && psql -Xq -d gis -U postgres -w -c "CREATE EXTENSION postgis; CREATE EXTENSION hstore;"
@@ -33,8 +34,9 @@ script:
   - find symbols/ -name '*.svg' | xargs xmllint --noout
   # Check the Lua transforms
   - lua scripts/lua/test.lua
-  # Check the indexes file is up to date
+  # Check the indexes and road colours files are up to date
   - diff -qu <(scripts/indexes.py) indexes.sql
+  - diff -qu <(scripts/generate_road_colours.py) road-colors-generated.mss
   # Create the PostgreSQL tables
   # Because we're not processing any data, we don't need to use the tag transform script,
   # which the ancient verson of osm2pgsql on Travis' Ubuntu doesn't support


### PR DESCRIPTION
This catches when the generated road colours file has drifted out of sync with the source.

Part of #3830, but doesn't address all the generated code.