### PR TITLE
Add tourism=yes as a linestring exception

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -39,6 +39,7 @@ local linestring_values = {
     man_made = {embankment = true, breakwater = true, groyne = true},
     natural = {cliff = true, tree_row = true, ridge = true, arete = true},
     power = {line = true, minor_line = true},
+    tourism = {yes = true},
     waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, wadi = true, weir = true}
 }
 


### PR DESCRIPTION
Fixes #3812 

### Changes proposed in this pull request:
- Add `tourism=yes` as a linestring exception in `openstreetmap-carto.lua`

### Explanation:
- Currently all features in the key `tourism=*` are imported as polygons when mapped as closed ways. This means that features tagged with the property `tourism=yes` are always imported as polygons when mapped as a closed way with a key such as `railway=` or `highway=*` which is normally a linestring. This tag is intended to say that a feature is "interesting to tourists", so it should not define an object as an area. By adding this tag to the list of linestring exceptions, it will not be imported as a polygon, unless the main feature tag on the object is a polygon feature.

This PR is submitted to the branch schema_changes, since it will require database reload to take effect.

I've tested the rendering by downloading the turntable mentioned in the issue and adding back tourism=yes, then reloading the database with this branch. Also note that the building in the northwest (upper left) is building=* with tourism=yes and this still renders properly

https://www.openstreetmap.org/map=18/-23.776/-46.301

**Before:**
![turntable-tourism-yes-before](https://user-images.githubusercontent.com/42757252/62405938-ddcbd100-b5de-11e9-9bd9-ad8eb84af202.png)

**After:** (plus database reloaded)
![turntable-tourism-yes-after](https://user-images.githubusercontent.com/42757252/62405906-8cbbdd00-b5de-11e9-9e12-afa534f593cd.png)