### PR TITLE
Render line for hedges without area=yes and only show fill with explicit area=yes

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -828,13 +828,13 @@
     [feature = 'barrier_hedge'][area = 'yes'] {
       polygon-fill: #aed1a0;
       [zoom >= 17] {
-        line-width: 2;
-      }
-      [zoom >= 18] {
         line-width: 1;
       }
+      [zoom >= 18] {
+        line-width: 0.6;
+      }
       [zoom >= 19] {
-        line-width: 0.5;
+        line-width: 0.4;
     }
   }
 }

--- a/landcover.mss
+++ b/landcover.mss
@@ -825,11 +825,16 @@
 }
 
 #area-barriers {
-  [zoom >= 16] {
-    line-color: #444;
-    line-width: 0.4;
-    [feature = 'barrier_hedge'] {
+    [feature = 'barrier_hedge'][area = 'yes'] {
       polygon-fill: #aed1a0;
+      [zoom >= 17] {
+        line-width: 2;
+      }
+      [zoom >= 18] {
+        line-width: 1;
+      }
+      [zoom >= 19] {
+        line-width: 0.5;
     }
   }
 }

--- a/project.mml
+++ b/project.mml
@@ -613,8 +613,8 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, COALESCE(historic, barrier) AS feature
-          FROM (SELECT way,
+            way, area, COALESCE(historic, barrier) AS feature
+          FROM (SELECT way, tags->'area' AS area,
             ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic


### PR DESCRIPTION
Fixes #971
Also related to #3453

### Changes proposed in this pull request:
1) Stop rendering the green fill for hedges on polygons unless they are also tagged with area=yes
2) Render standard green line for hedges on polygons when they are not tagged with area=yes
3) Adjust line width based on zoom level for hedges on polygons with area=yes

### Explanation:
Currently all closed ways tagged `barrier=hedge` will render with the dark green hedge fill color when they are imported as a polygon feature. This happens for closed ways tagged area=yes, relations with type=multipolygon or type=boundary, and for closed ways that are tagged with another polygon key like landuse=* or amenity=*. Unfortunately, many mappers add barrier=yes to other features like landuse=meadow to describe that there is a hedge around most of the meadow. In this case the meadow will often render like a solid hedge area, which is incorrect.

Also, hedges mapped correctly as areas currently have a wide green outline, just like those mapped as linear ways. This means that the hedge appears significantly wider than in reality, even at high zoom levels where we could show the exact width (and this is the main reason to map hedges as areas). 

This PR will only render the area fill for hedge features imported as polygons which also have area=yes. The wiki documentation and editors like iD recommend adding area=yes to hedge areas, since otherwise the tagging is ambiguous for this feature, like any other feature where a closed way can be either a linear feature or area. 

There may be a few properly mapped hedge multipolygons that may no longer be rendered after this change, but such tagging is uncommon. Currently 322 relations are tagged with barrier=hedge and area=yes, compared to 257 relations without area=yes, and 

There are currently # ways with `barrier=hedge`, and of these 30,177 have `area=yes`
Some also have another key such as "landuse", "amenity" etc which we import as polygons: there are 11,677 of these features, which are often currently being rendered incorrectly as hedge areas, since hedge areas are rendered above other landcover fill colors. 

106 features have "area=yes" and another polygon tag like "landuse", so these will still render as a hedge fill color, but this tagging should be discouraged.

So to summarize, as a result of this change:
Over 11,000 features currently incorrectly rendered as hedge fill because of another polygon key on the same way will now be correctly rendered
30,000 ways with area=yes will continue to render as now, but with an improved outline color and width in addition to the current fill color. 
250 multipolgyons lacking area=yes will be dropped from rendering
100 features with area=yes and another polygon key will continue to render with the fill.

The width of the polygon outline is also adjusted to be green like the fill and the width will now varry with different zoom levels, as I will show below.

## Test rendering with links to the example places:

https://www.openstreetmap.org/way/225683577/#map=17/51.1651/-0.04265
way 225683577
barrier=hedge
name=Long Acres Caravan & Camping
tourism=caravan_site

**Before**: 
![campsite-barrier-hedge](https://user-images.githubusercontent.com/42757252/55922479-419b4a00-5c3c-11e9-8879-2dcd62a2ced3.png)

**After** checking for "area=yes".
![z16-campground-hedges](https://user-images.githubusercontent.com/42757252/55936442-50502400-5c71-11e9-87e2-0939ff3acd68.png)