### PR TITLE
Add sports_centre (@stadium) fill color for leisure=water_park areas

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -107,7 +107,7 @@ Layer:
               ('shop_' || (CASE WHEN shop IN ('mall') AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL) THEN shop END)) AS shop,
               ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'garden',
                                                     'golf_course', 'miniature_golf', 'sports_centre', 'stadium', 'pitch', 'ice_rink',
-                                                    'track', 'dog_park', 'fitness_station') THEN leisure END)) AS leisure,
+                                                    'track', 'dog_park', 'fitness_station', 'water_park') THEN leisure END)) AS leisure,
               ('man_made_' || (CASE WHEN man_made IN ('works', 'wastewater_plant', 'water_works') THEN man_made END)) AS man_made,
               ('natural_' || (CASE WHEN "natural" IN ('beach', 'shoal', 'heath', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub') THEN "natural" END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" = 'mud' THEN "natural" ELSE tags->'wetland' END) END)) AS wetland,

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -663,6 +663,7 @@
   }
 
   [feature = 'leisure_sports_centre'],
+  [feature = 'leisure_water_park'],
   [feature = 'leisure_stadium'] {
     [zoom >= 10] {
       polygon-fill: @stadium;


### PR DESCRIPTION
Fixes #1490

## Changes proposed in this pull request:
- Add sports_centre (`@stadium`, =`@leisure` currently) fill color for `leisure=water_park` polygons

## Explanation:
- According to the wiki, water parks should be mapped as an area; [taginfo confirms](https://taginfo.openstreetmap.org/tags/?key=leisure&value=water_park) that over 75% are mapped in this way.
- The current rendering is identical to the rendering of `leisure=swimming_area` and `leisure=sports_centre` + `sport=swimming`, except that the area of the feature is not shown
- The previous discussion in #3748 showed that the tag leisure=water_park is not only used for large theme-park-like tourist attractions, but also for smaller local recreational areas with 1 or 2 pools, plus water slides, therefore rendering the same as zoos and theme parks is not appropriate.

## Test rendering with links to the example places:

**Piscine de Beaufort, Luxembourg** - swimming / water recreating area near campgrounds
z17 before
![z17-beaufort-before](https://user-images.githubusercontent.com/42757252/58382077-6c7d0a00-8000-11e9-8522-4fdcba28231f.png)
z17 after
![z17-piscine-de-beaufort-fill-after](https://user-images.githubusercontent.com/42757252/63434335-d79f7680-c45f-11e9-9cac-fa00da4c86a0.png)

**Wild Wild Wet, Singapore** - a proper water park, part of a retail mall
https://www.openstreetmap.org/#map=17/1.37794/103.95416
Before z17
![z17-wild-wild-wet-before](https://user-images.githubusercontent.com/42757252/56141349-9e4d8a80-5fd7-11e9-99f6-4bfac90443b9.png)
After z17
![z17-wild-wild-wet-sportscentre-fill-water-park](https://user-images.githubusercontent.com/42757252/63434122-6cee3b00-c45f-11e9-8853-e147594452da.png)

Wet n' Wild Hawaii 
https://www.openstreetmap.org/#map=18/21.33557/-158.08670
- this is double-tagged as a theme park, hence the outline. 
Before z15
![z15-wet-wild-hawaii-before](https://user-images.githubusercontent.com/42757252/56255746-f338f000-6100-11e9-9616-66c77645b8bb.png)

After z15
![z15-wet-n-wild-hawaii-fill-after](https://user-images.githubusercontent.com/42757252/63434040-416b5080-c45f-11e9-8a31-5a02810ba860.png)

After z18
![z18-wet-n-wild-hawaii-fill-after](https://user-images.githubusercontent.com/42757252/63434046-44664100-c45f-11e9-8903-0e3a1ea5ee54.png)


**Water Works, Science Centre, Singapore**
https://www.openstreetmap.org/#map=18/1.33345/103.73657
This is a small water-play / science area in the outdoor courtyard of the Science Centre.
before z18
![18-water-works-before](https://user-images.githubusercontent.com/42757252/56141680-3d728200-5fd8-11e9-8753-3ea403a77ee4.png)
after z18
![z18-water-works-leisure-fill](https://user-images.githubusercontent.com/42757252/63434241-ae7ee600-c45f-11e9-8bb2-619e141e43ce.png)