### PR TITLE
Remove polygon fill rendering for barrier=hedge

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -845,18 +845,7 @@
   }
 }
 
-#area-barriers {
-  [zoom >= 16] {
-    line-color: #444;
-    line-width: 0.4;
-    [feature = 'barrier_hedge'] {
-      polygon-fill: #aed1a0;
-    }
-  }
-}
-
-#line-barriers,
-#area-barriers {
+#barriers {
   [zoom >= 16] {
     line-width: 0.4;
     line-color: #444;

--- a/project.mml
+++ b/project.mml
@@ -581,28 +581,29 @@ Layer:
       table: |-
         (SELECT
             way, COALESCE(historic, barrier) AS feature
-          FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
-            ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
-            FROM
-              (SELECT
-                  way,
-                  historic,
-                  barrier,
-                  waterway
-                FROM planet_osm_polygon
-                WHERE way && !bbox!
-              UNION ALL
-              SELECT
-                  way,
-                  historic,
-                  barrier,
-                  waterway
-                FROM planet_osm_line
-                WHERE way && !bbox!
-              ) _
-            WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+          FROM
+            (SELECT way,
+              ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                    'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
+              ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
+              FROM
+                (SELECT
+                    way,
+                    historic,
+                    barrier,
+                    waterway
+                  FROM planet_osm_polygon
+                  WHERE way && !bbox!
+                UNION ALL
+                SELECT
+                    way,
+                    historic,
+                    barrier,
+                    waterway
+                  FROM planet_osm_line
+                  WHERE way && !bbox!
+                ) _
+              WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))

--- a/project.mml
+++ b/project.mml
@@ -585,21 +585,27 @@ Layer:
             ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
-            FROM planet_osm_line
+            FROM
+              (SELECT
+                  way,
+                  historic,
+                  barrier,
+                  waterway
+                FROM planet_osm_polygon
+                WHERE way && !bbox!
+              UNION ALL
+              SELECT
+                  way,
+                  historic,
+                  barrier,
+                  waterway
+                FROM planet_osm_line
+                WHERE way && !bbox!
+              ) _
             WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
-          UNION ALL
-          SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
-            ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
-            FROM planet_osm_polygon
-            WHERE (barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
-              OR historic = 'citywalls')
-              AND building IS NULL
           ) AS features
         ) AS line_barriers
     properties:

--- a/project.mml
+++ b/project.mml
@@ -573,7 +573,7 @@ Layer:
         ) AS tourism_boundary
     properties:
       minzoom: 10
-  - id: line-barriers
+  - id: barriers
     geometry: linestring
     <<: *extents
     Datasource:
@@ -590,6 +590,16 @@ Layer:
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
+          UNION ALL
+          SELECT way,
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
+            ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
+            FROM planet_osm_polygon
+            WHERE (barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
+              OR historic = 'citywalls')
+              AND building IS NULL
           ) AS features
         ) AS line_barriers
     properties:
@@ -608,27 +618,6 @@ Layer:
     properties:
       cache-features: true
       minzoom: 13
-  - id: area-barriers
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way, COALESCE(historic, barrier) AS feature
-          FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
-            ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
-            FROM planet_osm_polygon
-            WHERE (barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
-              OR historic = 'citywalls')
-              AND building IS NULL
-          ) AS features
-        ) AS area_barriers
-    properties:
-      minzoom: 16
   - id: ferry-routes
     geometry: linestring
     <<: *extents


### PR DESCRIPTION
Follow-up to closed PR #3834
Fixes #971
Also see discussion in about walls mapped as areas (not rendered) #3453

### Changes proposed in this pull request:
1) Stop rendering the green fill for hedges on polygons unless
2) Render standard green line for hedges on polygons instead

### Explanation:
Currently all closed ways tagged `barrier=hedge` will render with the dark green hedge fill color when they are imported as a polygon feature. This happens for closed ways tagged area=yes, relations with type=multipolygon or type=boundary, and for closed ways that are tagged with another polygon key like landuse=* or amenity=*. Unfortunately, many mappers add barrier=yes to other features like landuse=meadow to describe that there is a hedge around most of the meadow. In this case the meadow will often render like a solid hedge area, which is incorrect.

Also, hedges imported as areas currently have a narrow black outline, unlike those mapped as linear ways. 

This PR will remove the fill color for hedges on areas, and instead render them with the standard green line rendering used for other hedges. This is consistent with how other barrier features are rendered, including walls. 

There are currently 30,177 ways with `barrier=hedge` and `area=yes` which may currently be rendered with the fill color, which will have the rendering changed by this PR. Some also have another key such as "landuse", "amenity" etc which we import as polygons: there are 11,677 of these features, which are often currently being rendered incorrectly as hedge areas, since hedge areas are rendered above other landcover fill colors. 

As review in #3834 showed, most of the features with `area=yes` are not clearly hedges, but many appears to be areas of shrubs or garden areas or scrub, etc. The current rendering does not make it clear that these areas are barrier features, rather than just a general "green" area, which may contribute to such mis-tagging. 

So to summarize, as a result of this change:
Over 11,000 features currently incorrectly rendered as hedge fill because of another polygon key on the same way will now be correctly rendered
30,000 ways with area=yes will continue loose the area fill rendering but have a clearer "hedge" barrier style outline.

## Test renderings with links to the example places:

### 1) Long Acres Caravan & Camping
https://www.openstreetmap.org/way/225683577/#map=17/51.1651/-0.04265
way 225683577
barrier=hedge +
tourism=caravan_site

**Before**: 
![campsite-barrier-hedge](https://user-images.githubusercontent.com/42757252/55922479-419b4a00-5c3c-11e9-8879-2dcd62a2ced3.png)

**After**:
![z16-campground-hedges](https://user-images.githubusercontent.com/42757252/55936442-50502400-5c71-11e9-87e2-0939ff3acd68.png)

### 2) Wide "hedgebank" next to a road (like an area of shrubs used to stabilise the slope?) with current rendering and rendering after:
https://www.openstreetmap.org/way/379793281#map=17/47.6418/10.1072

z16 before
![z16-hedgebank-area-before](https://user-images.githubusercontent.com/42757252/62409137-0dde9880-b60e-11e9-980c-5db267fc27ff.png)

z16 after 
![z16-hedgebank-after-nofill](https://user-images.githubusercontent.com/42757252/63485975-78357b00-c4e0-11e9-8ed7-d9b74218ea5a.png)

z17 before
![z17-hedgebank-area-before](https://user-images.githubusercontent.com/42757252/62409139-12a34c80-b60e-11e9-80d9-bd127d802b03.png)

z17 after (1 pixel wide outline in green)
![z17-hedgebank-after-nofill](https://user-images.githubusercontent.com/42757252/63485946-5e943380-c4e0-11e9-9b4c-0faed7e6c807.png)

### 3) Hedge along orchard border
https://www.openstreetmap.org/way/417705052#map=18/48.58993/-1.46011 - France

z16 hedge before ecosite France
![z16-echosite-hedge-before](https://user-images.githubusercontent.com/42757252/62409175-79c10100-b60e-11e9-97b1-bfb5e76fc4e7.png)

z16 after
![z16-ecosite-hedge-nofill-after](https://user-images.githubusercontent.com/42757252/63486008-99966700-c4e0-11e9-976a-63bccce10ac9.png)

z17 before
![z17-ecosite-hedge-area-before](https://user-images.githubusercontent.com/42757252/62409185-91988500-b60e-11e9-927b-23d0e1a3cd87.png)

z17 after
![z17-ecosite-hedge-nofill-after](https://user-images.githubusercontent.com/42757252/63486038-c0549d80-c4e0-11e9-8ae2-e64f239f8ae3.png)


### z18 Rue de la gare, Luxembourg - compare linear hedge in parking lot (upper left) to those mapped as areas (lower left)
z18 before
![z18-hedges-rue-de-la-gare-before](https://user-images.githubusercontent.com/42757252/62409234-269b7e00-b60f-11e9-962b-a5213e98f56b.png)
z17 before
![z17-hedges-rue-de-la-gare-before](https://user-images.githubusercontent.com/42757252/62409236-28fdd800-b60f-11e9-9d60-dae60350d797.png)

z18 after
![z18-rue-de-la-gare-nofill-after](https://user-images.githubusercontent.com/42757252/63486064-e7ab6a80-c4e0-11e9-9c7b-2d972aa5b711.png)

z17 after
![z17-rue-de-la-gare-nofill-after](https://user-images.githubusercontent.com/42757252/63486069-f003a580-c4e0-11e9-8f57-e5a09a1364df.png)


### Place de les Martyrs, Luxembourg
- Currently grass area in center is incorrectly rendered as solid hedge.

z18 before
![z18-place-des-martyrs-before](https://user-images.githubusercontent.com/42757252/63486103-1d505380-c4e1-11e9-98fc-03e433ac0556.png)

z18 after
![z18-place-des-martyrs-hedges-nofill-after](https://user-images.githubusercontent.com/42757252/63486109-204b4400-c4e1-11e9-83fe-e52e908d8992.png)