### PR TITLE
Adjust width of hedge & citywall rendering from z15 to z19 and add z20, change hedge to @forest

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -856,6 +856,9 @@
     [zoom >= 19] {
       line-width: 4;
     }
+    [zoom >= 20] {
+      line-width: 5;
+    }
   }
   [feature = 'historic_citywalls'],
   [feature = 'barrier_city_wall'] {
@@ -876,6 +879,9 @@
     }
     [zoom >= 19] {
       line-width: 4;
+    }
+    [zoom >= 20] {
+      line-width: 5;
     }
   }
 }

--- a/landcover.mss
+++ b/landcover.mss
@@ -846,7 +846,7 @@
   }
   [feature = 'barrier_hedge'][zoom >= 16] {
     line-width: 1.5;
-    line-color: #aed1a0;
+    line-color: @forest;
     [zoom >= 17] {
       line-width: 2;
     }

--- a/landcover.mss
+++ b/landcover.mss
@@ -845,20 +845,37 @@
     line-color: #444;
   }
   [feature = 'barrier_hedge'][zoom >= 16] {
-    line-width: 3;
+    line-width: 1.5;
     line-color: #aed1a0;
+    [zoom >= 17] {
+      line-width: 2;
+    }
+    [zoom >= 18] {
+      line-width: 3;
+    }
+    [zoom >= 19] {
+      line-width: 4;
+    }
   }
   [feature = 'historic_citywalls'],
   [feature = 'barrier_city_wall'] {
     [zoom >= 15] {
-      line-width: 1.5;
+      line-width: 1;
       line-color: lighten(#444, 30%);
     }
-
+    [zoom >= 16] {
+      line-width: 1.5;
+    }
     [zoom >= 17] {
-      line-width: 3;
+      line-width: 2;
       barrier/line-width: 0.4;
       barrier/line-color: #444;
+    }
+    [zoom >= 18] {
+      line-width: 3;
+    }
+    [zoom >= 19] {
+      line-width: 4;
     }
   }
 }

--- a/landcover.mss
+++ b/landcover.mss
@@ -7,6 +7,7 @@
 @park: #c8facc;         // Lch(94,30,145)
 @allotments: #c9e1bf;   // Lch(87,20,135)
 @orchard: #aedfa3; // also vineyard, plant_nursery
+@hedge: @forest;       // Lch(80,30,135)
 
 // --- "Base" landuses ---
 
@@ -846,7 +847,7 @@
   }
   [feature = 'barrier_hedge'][zoom >= 16] {
     line-width: 1.5;
-    line-color: @forest;
+    line-color: @hedge;
     [zoom >= 17] {
       line-width: 2;
     }


### PR DESCRIPTION
Adjust width of hedge & citywall rendering from z15 to z19 and add z20, change hedge to @forest

Fixes #3845
Related to #3747

## Changes proposed in this pull request:
- Adjust hedge and citywall width from z15 to z19, so that hedges and citywalls have the same width and the width changes by small steps, increasing by no more than 50% between zoom levels.
- Slightly adjust hedge color to match @forest
- Add rendering rule for `barrier=hedge` and `barrier=city_wall` / `historic=citywalls` at z20 with slightly greater width. 

## Explanation
**Background:** 
- Current citywalls (tagged either as `barrier=city_wall` or `historic=citywalls`) are rendered from z15, while hedges only render from z16. 
- However, at z16 citywalls are only 1.5 pixels wide, while hedges begin at 3 pixels wide. 
- At z17 citywalls are rendered wider, 3px, matching hedges. The width does not change again at higher zoom levels. This jump is 100%, which makes it appear to match the change in scale.
- This means that hedges are wider than treerows (2.5px) at z16, but narrower at all other zoom levels (treerows are 5px at z17, and 10px at z18)
- The citywall tags are used for all sorts of mainly historic fortification walls, not only city walls, also comprising walls of castles, towns, village forts, and so on, based on a review of uses in Luxembourg. These walls can be as narrow as 1 meter in some cases, though they are also sometimes wider, and usually are tall enough to be visually significant. Most of these features are near towns, cities or villages, though some castles and forts are in rural areas. 
- Hedges have varying width, but most are 1m wide or more, putting them in the same range as citywalls. They are more often rural features, though also found in cities.
- Some rendering rules were just added for roads at z20, but there are none for barriers yet. 
- Hedges are currently rendered in #aed1a0 - Lch 80,29,135, while forest/wood is #add19e - Lch 80,30,135 - this difference is not perceptible.

**Changes**
- Citywall width is adjusted to start at 1.0 pixel wide at z15, increasing to 1.5 at z16 (same as current), 2.0 at z17, 3.0 at z18 (same as current), 4.0 at z19 and 5.0 at z20. This leads to consistent small steps, none of which are more than 50%, so there is no risk in interpreting this as representing a real width.
- Hedges start at 1.5px at z16, and increase by the same steps to 5.0 at z20. This means hedges are narrow than current rendering at z16 and z17, same at z18, and wider at z19 and z20.
- Now hedges are clearly narrower than treerows at all widths (though treerows need further improvements)
- Hedges now use @forest color for simplicity. I attempted changing them to @scrub, since they are often shorter than trees, to provide more contrast with tree rows, but this color does not have sufficient contrast with some landcovers fill colors. It might be possible to consider something like the darker color used for the scrub pattern (rather than the fill), in another PR
- The width is now adjusted slightly between z19 and z20. This is only a 25% increase; we could consider going to 6 pixels wide at z20 for a 50% increase,  but I believe other changes are needed to the style at that zoom level first (many other narrow line features should be widened at z20 as well). 



## Test rendering with links to the example places:

### Luxembourg City
**z15 before**
![z15-luxembourg-citywall-before](https://user-images.githubusercontent.com/42757252/63631365-58799080-c661-11e9-8b60-f27b23e1e6e2.png)
z15 after
![z15-luxembourg-citywalls-after3](https://user-images.githubusercontent.com/42757252/63631377-7a731300-c661-11e9-9855-d0870d762b7c.png)

**z16 before**
![z16-luxembourg-park-citywalls-before](https://user-images.githubusercontent.com/42757252/63631443-a773f580-c662-11e9-85ca-74cce4de4562.png)
z16 after (nearly the same; small hedge is different only)
![z16-luxembourg-park-after3](https://user-images.githubusercontent.com/42757252/63631483-2c5f0f00-c663-11e9-88f5-3faa27cab92c.png)

**z17 before**
![z17-luxembourg-park-citywalls-before](https://user-images.githubusercontent.com/42757252/63631495-4a2c7400-c663-11e9-97ca-7d538f813baa.png)
z17 after
![z17-luxembourg-park-after3](https://user-images.githubusercontent.com/42757252/63631499-60d2cb00-c663-11e9-9463-d4c81fd7b295.png)

**z18 before**
![z18-luxembourg-park-citywalls-before](https://user-images.githubusercontent.com/42757252/63631505-7f38c680-c663-11e9-929b-2781499cf058.png)
z18 after (unchanged)
![z18-luxembourg-park-after3](https://user-images.githubusercontent.com/42757252/63631512-92e42d00-c663-11e9-8f83-7e8f44673d23.png)

**z19 before**
![z19-luxembourg-park-citywalls-before](https://user-images.githubusercontent.com/42757252/63631515-aabbb100-c663-11e9-9f14-4fe1938c547c.png)
z19 after
![z19-luxembourg-park-after3](https://user-images.githubusercontent.com/42757252/63631540-23227200-c664-11e9-8e3e-3a45769d70f6.png)

**z20 before**
![z20-luxembourg-park-citywalls-before](https://user-images.githubusercontent.com/42757252/63631617-51548180-c665-11e9-80aa-7d9d73f84c6b.png)
z20 after
![z20-luxembourg-park-citywalls-after3](https://user-images.githubusercontent.com/42757252/63631556-6977d100-c664-11e9-8f99-2d99ebc253a2.png)

### Hedge vs treerow
**z16 before**
![z16-hedge-vs-treerow-before](https://user-images.githubusercontent.com/42757252/63631620-616c6100-c665-11e9-841e-1356378cea20.png)
z16 after
![z16-hedge-vs-treerow-after3](https://user-images.githubusercontent.com/42757252/63631629-8bbe1e80-c665-11e9-8150-d567ac624477.png)

**z17 before**
![z17-hedge-vs-treerow-before](https://user-images.githubusercontent.com/42757252/63631632-95478680-c665-11e9-9a6f-9ea4569bbd80.png)
z17 after
![z17-hedge-vs-treerow-after3](https://user-images.githubusercontent.com/42757252/63631633-9ed0ee80-c665-11e9-94c9-fab3e1b0c5d9.png)

**z18 before**
![z18-hedge-vs-treerow-before](https://user-images.githubusercontent.com/42757252/63631643-adb7a100-c665-11e9-840d-e057befb8060.png)
z18 after (unchanged except hedge color - not really visible)
![z18-hedge-vs-treerow-after3](https://user-images.githubusercontent.com/42757252/63631653-c6c05200-c665-11e9-8d5e-f8f897620df2.png)

**z19 before**
![z19-hedge-vs-treerow-before](https://user-images.githubusercontent.com/42757252/63631909-844c4480-c668-11e9-9824-6c6d894b8515.png)
z19 after
![z19-hedge-vs-treerow-after3](https://user-images.githubusercontent.com/42757252/63631926-a776f400-c668-11e9-9e3b-125095869513.png)

**z20 hedges after**
![z20-hedge-place-des-martyrs-after3](https://user-images.githubusercontent.com/42757252/63631944-e5741800-c668-11e9-8661-fdc5e786cc14.png)