### PR TITLE
Remove overlay pattern for natural=sand

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -720,10 +720,6 @@
     }
   }
 
-  [natural = 'sand'][zoom >= 5] {
-    polygon-pattern-file: url('symbols/beach.png');
-    polygon-pattern-alignment: global;
-  }
   [int_wetland != null][zoom >= 5] {
     polygon-pattern-file: url('symbols/wetland.png');
     polygon-pattern-alignment: global;

--- a/project.mml
+++ b/project.mml
@@ -289,7 +289,7 @@ Layer:
             tags->'leaf_type' AS leaf_type,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE ("natural" IN ('mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub', 'sand') OR landuse = 'forest')
+          WHERE ("natural" IN ('mud', 'wetland', 'wood', 'beach', 'shoal', 'reef', 'scrub') OR landuse = 'forest')
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
           ORDER BY COALESCE(layer,0), way_area DESC


### PR DESCRIPTION
Related to #3707 and #545
Reverts #2746 - addition of `beach.png` pattern for `natural=sand`

Changes proposed in this pull request:
- Remove pattern rendering for natural=sand from landcover-area-symbols (where it renders above water areas)

## Explanation
- The tag `natural=sand` is currently rendered with a unique color fill, different than beaches or bare_earth, so the pattern is not needed to distinguish sand from similar areas. Removing the pattern will make the map less busy. This will also make it easier to add a pattern for `natural=dune` areas, if desired.
- Removing the natural=sand pattern will also hide areas tagged natural=sand outside of the coastline. These should be tagged `natural=beach` or `natural=shoal`.

## Test renderings

### Horton's Nose - `sand` next to `beach`
http://www.openstreetmap.org/#map=17/53.31607/-3.50920
z17 before
![z17-hortons-nose-sand-before-17:53 31607:-3 50920](https://user-images.githubusercontent.com/42757252/63685057-65e97300-c839-11e9-88ca-2cc77114f280.png)
z17 after
![z17-hortons-nose-sand-rock-after](https://user-images.githubusercontent.com/42757252/63685350-0cce0f00-c83a-11e9-9c95-55d91e82f15e.png)

### Point of Ayr - `natural=beach` next to `natural=sand` (dunes)
http://www.openstreetmap.org/#map=15/53.3569/-3.3175
z15 before
![z15-point-of-ayr-sand-before-15:53 3569:-3 3175](https://user-images.githubusercontent.com/42757252/63685059-66820980-c839-11e9-9930-fdecb6b84214.png)
z15 after
![z15-point-of-ayr-sand-after](https://user-images.githubusercontent.com/42757252/63685052-641faf80-c839-11e9-9278-4f1d775aa26b.png)