### PR TITLE
Adjust `aeroway=aerodrome` zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1505,7 +1505,7 @@
       marker-clip: false;
       marker-fill: @airtransport;
       [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 19200] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 192000] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -1526,7 +1526,7 @@
       marker-fill: @airtransport;
       [zoom >= 11] { marker-file: url('symbols/aerodrome.12.svg'); }
       [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 19200] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 192000] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -3236,7 +3236,7 @@
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
       }
-      [way_pixels > 19200] {
+      [way_pixels > 192000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,39 +1488,34 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome'][is_airport = 'yes'][zoom >= 10][zoom < 16],
-  [feature = 'aeroway_aerodrome'][is_airport = 'no'][zoom >= 12][zoom < 17] {
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+    [way_pixels <= 192000],
+    [way_pixels = null] {
+      marker-file: url('symbols/aerodrome.12.svg');
+      marker-placement: interior;
+      marker-clip: false;
+      marker-fill: @airtransport;
+      [zoom >= 15] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [zoom >= 16] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
+    }
+  }
+
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16] {
     [way_pixels <= 192000],
     [way_pixels = null] {
       marker-file: url('symbols/aerodrome.8.svg');
       marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
-      [zoom >= 11] {
-        marker-file: url('symbols/aerodrome.12.svg')
-      }
-      [is_airport = 'yes'] {
-        [zoom >= 14] {
-          marker-file: url('symbols/aerodrome.15.svg')
-        }
-        [zoom >= 15] {
-          marker-file: url('symbols/aerodrome.18.svg')
-        }
-      }
-      [is_airport = 'no'] {
-        [zoom >= 15] {
-          marker-file: url('symbols/aerodrome.15.svg')
-        }
-        [zoom >= 16] {
-          marker-file: url('symbols/aerodrome.18.svg')
-        }
-      }
-      [way_pixels > 12000] {
-        marker-file: url('symbols/aerodrome.15.svg')
-      }
-      [way_pixels > 48000] {
-        marker-file: url('symbols/aerodrome.18.svg')
-      }
+      [zoom >= 11] { marker-file: url('symbols/aerodrome.12.svg'); }
+      [zoom >= 14] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [zoom >= 15] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -3139,8 +3134,9 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome'][is_airport = 'yes'][zoom >= 11][zoom < 16],
-  [feature = 'aeroway_aerodrome'][is_airport = 'no'][zoom >= 13][zoom < 17] {
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 17] {
     [way_pixels <= 192000],
     [way_pixels = null] {
       text-name: "[name]";
@@ -3161,28 +3157,53 @@
           text-dy: 13;
         }
       }
-      [is_airport = 'yes'] {
-        [zoom >= 14] {
-          text-size: @landcover-font-size-big;
-          text-wrap-width: @landcover-wrap-width-size-big;
-          text-line-spacing: @landcover-line-spacing-size-big;
-          text-dy: 11;
-        }
-        [zoom >= 15][is_airport = 'yes'] {
+      [zoom >= 15] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [zoom >= 16] {
           text-size: @landcover-font-size-bigger;
           text-wrap-width: @landcover-wrap-width-size-bigger;
           text-line-spacing: @landcover-line-spacing-size-bigger;
           text-dy: 13;
         }
       }
-      [is_airport = 'no'] {
-        [zoom >= 15] {
-          text-size: @landcover-font-size-big;
-          text-wrap-width: @landcover-wrap-width-size-big;
-          text-line-spacing: @landcover-line-spacing-size-big;
-          text-dy: 11;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+  }
+
+
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16] {
+    [way_pixels <= 192000],
+    [way_pixels = null] {
+      text-name: "[name]";
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 9;
+      [way_pixels > 12000] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [way_pixels > 48000] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
         }
-        [zoom >= 16] {
+      }
+      [zoom >= 14] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big; 
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [zoom >= 15][is_airport = 'yes'] {
           text-size: @landcover-font-size-bigger;
           text-wrap-width: @landcover-wrap-width-size-bigger;
           text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,11 +1488,11 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
-    [way_pixels <= 768000],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+    [way_pixels <= 192000],
     [way_pixels = null] {
       marker-file: url('symbols/aerodrome.12.svg');
       marker-placement: interior;
@@ -3116,11 +3116,11 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['access' = 'private'],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['icao' = null],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['iata' = null] {
-    [way_pixels <= 768000],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['access' = 'private'],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['icao' = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['iata' = null] {
+    [way_pixels <= 192000],
     [way_pixels = null] {
       text-name: "[name]";
       text-size: @standard-font-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,10 +1488,10 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
-    [way_pixels = null] {
+  [feature = 'aeroway_aerodrome']['access' = 'private'],
+  [feature = 'aeroway_aerodrome']['icao' = null],
+  [feature = 'aeroway_aerodrome']['iata' = null] {
+    [zoom >= 12][zoom < 17][way_pixels = null] {
       marker-file: url('symbols/aerodrome.12.svg');
       marker-placement: interior;
       marker-clip: false;
@@ -1499,25 +1499,18 @@
       [zoom >= 15] { marker-file: url('symbols/aerodrome.15.svg'); }
       [zoom >= 16] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
-  }
-
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
-    [way_pixels <= 768000] {
+    [zoom >= 12][zoom < 18][way_pixels <= 768000] {
       marker-file: url('symbols/aerodrome.12.svg');
       marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
-      [zoom >= 15] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [zoom >= 16] { marker-file: url('symbols/aerodrome.18.svg'); }
-      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 19200] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16] {
-    [way_pixels = null] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null] {
+    [zoom >= 10][zoom < 16][way_pixels = null] {
       marker-file: url('symbols/aerodrome.8.svg');
       marker-placement: interior;
       marker-clip: false;
@@ -1526,19 +1519,14 @@
       [zoom >= 14] { marker-file: url('symbols/aerodrome.15.svg'); }
       [zoom >= 15] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
-  }
-
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16] {
-    [way_pixels <= 768000] {
+    [zoom >= 10][zoom < 18][way_pixels <= 768000] {
       marker-file: url('symbols/aerodrome.8.svg');
       marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
       [zoom >= 11] { marker-file: url('symbols/aerodrome.12.svg'); }
-      [zoom >= 14] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [zoom >= 15] { marker-file: url('symbols/aerodrome.18.svg'); }
-      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 19200] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -3157,10 +3145,10 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 17] {
-    [way_pixels = null] {
+  [feature = 'aeroway_aerodrome']['access' = 'private'],
+  [feature = 'aeroway_aerodrome']['icao' = null],
+  [feature = 'aeroway_aerodrome']['iata' = null] {
+    [zoom >= 13][zoom < 17][way_pixels = null] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3172,12 +3160,36 @@
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
-        [zoom >= 16] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
         }
+      [zoom >= 16] {
+        text-size: @landcover-font-size-bigger;
+        text-wrap-width: @landcover-wrap-width-size-bigger;
+        text-line-spacing: @landcover-line-spacing-size-bigger;
+        text-dy: 13;
+      }
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+    [zoom >= 13][zoom < 18][way_pixels <= 768000] {
+      text-name: "[name]";
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 9;
+      [way_pixels > 48000] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+      }
+      [way_pixels > 192000] {
+        text-size: @landcover-font-size-bigger;
+        text-wrap-width: @landcover-wrap-width-size-bigger;
+        text-line-spacing: @landcover-line-spacing-size-bigger;
+        text-dy: 13;
       }
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
@@ -3186,105 +3198,49 @@
     }
   }
 
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 17] {
-    [way_pixels <= 768000] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null] {
+    [zoom >= 11][zoom < 16][way_pixels = null] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
       text-fill: darken(@airtransport, 15%);
       text-dy: 9;
-      [way_pixels > 12000] {
+      [zoom >= 14] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
-        [way_pixels > 48000] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
-        }
       }
       [zoom >= 15] {
-        text-size: @landcover-font-size-big;
-        text-wrap-width: @landcover-wrap-width-size-big;
-        text-line-spacing: @landcover-line-spacing-size-big;
-        text-dy: 11;
-        [zoom >= 16] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
-        }
+        text-size: @landcover-font-size-bigger;
+        text-wrap-width: @landcover-wrap-width-size-bigger;
+        text-line-spacing: @landcover-line-spacing-size-bigger;
+        text-dy: 13;
       }
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: interior;
     }
-  }
-
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16] {
-    [way_pixels = null] {
+    [way_pixels <= 768000][zoom >= 11][zoom < 18] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
       text-fill: darken(@airtransport, 15%);
       text-dy: 9;
-      [zoom >= 14] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
-        [zoom >= 15] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
-        }
       }
-      text-face-name: @oblique-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
-    }
-  }
-
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16] {
-    [way_pixels <= 768000] {
-      text-name: "[name]";
-      text-size: @landcover-font-size;
-      text-wrap-width: @landcover-wrap-width-size;
-      text-line-spacing: @landcover-line-spacing-size;
-      text-fill: darken(@airtransport, 15%);
-      text-dy: 9;
-      [way_pixels > 12000] {
-        text-size: @landcover-font-size-big;
-        text-wrap-width: @landcover-wrap-width-size-big;
-        text-line-spacing: @landcover-line-spacing-size-big;
-        text-dy: 11;
-        [way_pixels > 48000] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
-        }
-      }
-      [zoom >= 14] {
-        text-size: @landcover-font-size-big;
-        text-wrap-width: @landcover-wrap-width-size-big; 
-        text-line-spacing: @landcover-line-spacing-size-big;
-        text-dy: 11;
-        [zoom >= 15] {
-          text-size: @landcover-font-size-bigger;
-          text-wrap-width: @landcover-wrap-width-size-bigger;
-          text-line-spacing: @landcover-line-spacing-size-bigger;
-          text-dy: 13;
-        }
+      [way_pixels > 19200] {
+        text-size: @landcover-font-size-bigger;
+        text-wrap-width: @landcover-wrap-width-size-bigger;
+        text-line-spacing: @landcover-line-spacing-size-bigger;
+        text-dy: 13;
       }
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1504,8 +1504,8 @@
       marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
-      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 192000] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -1525,8 +1525,8 @@
       marker-clip: false;
       marker-fill: @airtransport;
       [zoom >= 11] { marker-file: url('symbols/aerodrome.12.svg'); }
-      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.15.svg'); }
-      [way_pixels > 192000] { marker-file: url('symbols/aerodrome.18.svg'); }
+      [way_pixels > 12000] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [way_pixels > 48000] { marker-file: url('symbols/aerodrome.18.svg'); }
     }
   }
 
@@ -3179,13 +3179,13 @@
       text-line-spacing: @landcover-line-spacing-size;
       text-fill: darken(@airtransport, 15%);
       text-dy: 9;
-      [way_pixels > 48000] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
       }
-      [way_pixels > 192000] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3230,13 +3230,13 @@
       text-line-spacing: @landcover-line-spacing-size;
       text-fill: darken(@airtransport, 15%);
       text-dy: 9;
-      [way_pixels > 48000] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
       }
-      [way_pixels > 192000] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,12 +1488,17 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
-  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14] {
-    marker-file: url('symbols/aerodrome.12.svg');
-    marker-placement: interior;
-    marker-clip: false;
-    marker-fill: @airtransport;
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
+    [way_pixels <= 768000],
+    [way_pixels = null] {
+      marker-file: url('symbols/aerodrome.12.svg');
+      marker-placement: interior;
+      marker-clip: false;
+      marker-fill: @airtransport;
+    }
   }
 
   [feature = 'amenity_ferry_terminal'][zoom >= 15] {
@@ -3111,8 +3116,25 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
-  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['access' = 'private'],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['icao' = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['iata' = null] {
+    [way_pixels <= 768000],
+    [way_pixels = null] {
+      text-name: "[name]";
+      text-size: @standard-font-size;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 10;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+  }
+
   [feature = 'amenity_ferry_terminal'][zoom >= 15] {
     text-name: "[name]";
     text-size: @standard-font-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1491,8 +1491,20 @@
   [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
-    [way_pixels <= 192000],
     [way_pixels = null] {
+      marker-file: url('symbols/aerodrome.12.svg');
+      marker-placement: interior;
+      marker-clip: false;
+      marker-fill: @airtransport;
+      [zoom >= 15] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [zoom >= 16] { marker-file: url('symbols/aerodrome.18.svg'); }
+    }
+  }
+
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+    [way_pixels <= 768000] {
       marker-file: url('symbols/aerodrome.12.svg');
       marker-placement: interior;
       marker-clip: false;
@@ -1505,8 +1517,19 @@
   }
 
   [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16] {
-    [way_pixels <= 192000],
     [way_pixels = null] {
+      marker-file: url('symbols/aerodrome.8.svg');
+      marker-placement: interior;
+      marker-clip: false;
+      marker-fill: @airtransport;
+      [zoom >= 11] { marker-file: url('symbols/aerodrome.12.svg'); }
+      [zoom >= 14] { marker-file: url('symbols/aerodrome.15.svg'); }
+      [zoom >= 15] { marker-file: url('symbols/aerodrome.18.svg'); }
+    }
+  }
+
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16] {
+    [way_pixels <= 768000] {
       marker-file: url('symbols/aerodrome.8.svg');
       marker-placement: interior;
       marker-clip: false;
@@ -3137,8 +3160,36 @@
   [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 17],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 17],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 17] {
-    [way_pixels <= 192000],
     [way_pixels = null] {
+      text-name: "[name]";
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 9;
+      [zoom >= 15] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [zoom >= 16] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
+        }
+      }
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+  }
+
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 17] {
+    [way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
@@ -3176,10 +3227,35 @@
     }
   }
 
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16] {
+    [way_pixels = null] {
+      text-name: "[name]";
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 9;
+      [zoom >= 14] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [zoom >= 15] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
+        }
+      }
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+  }
 
   [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16] {
-    [way_pixels <= 192000],
-    [way_pixels = null] {
+    [way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -3203,7 +3203,7 @@
         text-wrap-width: @landcover-wrap-width-size-big; 
         text-line-spacing: @landcover-line-spacing-size-big;
         text-dy: 11;
-        [zoom >= 15][is_airport = 'yes'] {
+        [zoom >= 15] {
           text-size: @landcover-font-size-bigger;
           text-wrap-width: @landcover-wrap-width-size-bigger;
           text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,16 +1488,39 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+  [feature = 'aeroway_aerodrome'][is_airport = 'yes'][zoom >= 10][zoom < 16],
+  [feature = 'aeroway_aerodrome'][is_airport = 'no'][zoom >= 12][zoom < 17] {
     [way_pixels <= 192000],
     [way_pixels = null] {
-      marker-file: url('symbols/aerodrome.12.svg');
+      marker-file: url('symbols/aerodrome.8.svg');
       marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
+      [zoom >= 11] {
+        marker-file: url('symbols/aerodrome.12.svg')
+      }
+      [is_airport = 'yes'] {
+        [zoom >= 14] {
+          marker-file: url('symbols/aerodrome.15.svg')
+        }
+        [zoom >= 15] {
+          marker-file: url('symbols/aerodrome.18.svg')
+        }
+      }
+      [is_airport = 'no'] {
+        [zoom >= 15] {
+          marker-file: url('symbols/aerodrome.15.svg')
+        }
+        [zoom >= 16] {
+          marker-file: url('symbols/aerodrome.18.svg')
+        }
+      }
+      [way_pixels > 12000] {
+        marker-file: url('symbols/aerodrome.15.svg')
+      }
+      [way_pixels > 48000] {
+        marker-file: url('symbols/aerodrome.18.svg')
+      }
     }
   }
 
@@ -3116,18 +3139,56 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['access' = 'private'],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['icao' = null],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['iata' = null] {
+  [feature = 'aeroway_aerodrome'][is_airport = 'yes'][zoom >= 11][zoom < 16],
+  [feature = 'aeroway_aerodrome'][is_airport = 'no'][zoom >= 13][zoom < 17] {
     [way_pixels <= 192000],
     [way_pixels = null] {
       text-name: "[name]";
-      text-size: @standard-font-size;
-      text-wrap-width: @standard-wrap-width;
-      text-line-spacing: @standard-line-spacing-size;
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
       text-fill: darken(@airtransport, 15%);
-      text-dy: 10;
+      text-dy: 9;
+      [way_pixels > 12000] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+        text-dy: 11;
+        [way_pixels > 48000] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
+        }
+      }
+      [is_airport = 'yes'] {
+        [zoom >= 14] {
+          text-size: @landcover-font-size-big;
+          text-wrap-width: @landcover-wrap-width-size-big;
+          text-line-spacing: @landcover-line-spacing-size-big;
+          text-dy: 11;
+        }
+        [zoom >= 15][is_airport = 'yes'] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
+        }
+      }
+      [is_airport = 'no'] {
+        [zoom >= 15] {
+          text-size: @landcover-font-size-big;
+          text-wrap-width: @landcover-wrap-width-size-big;
+          text-line-spacing: @landcover-line-spacing-size-big;
+          text-dy: 11;
+        }
+        [zoom >= 16] {
+          text-size: @landcover-font-size-bigger;
+          text-wrap-width: @landcover-wrap-width-size-bigger;
+          text-line-spacing: @landcover-line-spacing-size-bigger;
+          text-dy: 13;
+        }
+      }
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;

--- a/project.mml
+++ b/project.mml
@@ -1498,6 +1498,14 @@ Layer:
                 ELSE NULL
               END AS height,
               tags->'location' as location,
+              CASE 
+                WHEN aeroway = 'aerodrome' THEN
+                  CASE
+                    WHEN tags->'icao' = NULL OR tags->'iata' = NULL OR access = 'private' THEN 'no' 
+                    ELSE 'yes'
+                  END
+                ELSE NULL 
+              END AS is_airport,
               tags->'icao' as icao,
               tags->'iata' as iata,
               tags->'office' as office,

--- a/project.mml
+++ b/project.mml
@@ -1498,14 +1498,6 @@ Layer:
                 ELSE NULL
               END AS height,
               tags->'location' as location,
-              CASE 
-                WHEN aeroway = 'aerodrome' THEN
-                  CASE
-                    WHEN tags->'icao' = NULL OR tags->'iata' = NULL OR access = 'private' THEN 'no' 
-                    ELSE 'yes'
-                  END
-                ELSE NULL 
-              END AS is_airport,
               tags->'icao' as icao,
               tags->'iata' as iata,
               tags->'office' as office,

--- a/symbols/aerodrome.15.svg
+++ b/symbols/aerodrome.15.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="15"
+   height="15"
+   viewBox="0 0 15 15"
+   version="1.1"
+   id="svg5">
+  <metadata
+     id="metadata11">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs9" />
+  <rect
+     width="12"
+     height="12"
+     x="0"
+     y="3"
+     id="canvas"
+     style="visibility:hidden;fill:none;stroke:none" />
+  <path
+     style="fill-rule:evenodd;stroke-width:1.25000012"
+     d="M 7.5,0 C 6.568305,0 6.2499999,2.5 6.2499999,2.5 V 4.9609376 L 0,9.3750004 V 10.625 L 6.2499999,9.0625003 V 12.070313 L 3.75,13.75 V 15 L 7.5,14.062501 11.25,15 V 13.75 L 8.75,12.070313 V 9.0625003 L 15,10.625 V 9.3750004 L 8.75,4.9609376 V 2.5 C 8.75,2.5 8.431695,0 7.5,0 Z"
+     id="path3" />
+</svg>

--- a/symbols/aerodrome.18.svg
+++ b/symbols/aerodrome.18.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="18"
+   height="18"
+   viewBox="0 0 18 18"
+   version="1.1"
+   id="svg5">
+  <defs
+     id="defs9" />
+  <rect
+     width="12"
+     height="12"
+     x="0"
+     y="6"
+     id="canvas"
+     style="visibility:hidden;fill:none;stroke:none" />
+  <path
+     style="fill-rule:evenodd;stroke-width:1.50000024"
+     d="M 9,0 C 7.881966,0 7.4999999,3 7.4999999,3 V 5.9531251 L 0,11.250001 V 12.75 l 7.4999999,-1.875 v 3.609376 L 4.5,16.5 V 18 L 9,16.875001 13.5,18 v -1.5 l -3,-2.015624 V 10.875 L 18,12.75 V 11.250001 L 10.5,5.9531251 V 3 C 10.5,3 10.118034,0 9,0 Z"
+     id="path3" />
+</svg>

--- a/symbols/aerodrome.8.svg
+++ b/symbols/aerodrome.8.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="12"
+   height="12"
+   viewBox="0 0 12 12"
+   version="1.1"
+   id="svg5">
+  <defs
+     id="defs9" />
+  <rect
+     width="12"
+     height="12"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     style="fill-rule:evenodd;stroke-width:0.66666669"
+     d="m 6,2.0000003 c -0.496904,0 -0.6666667,1.3333333 -0.6666667,1.3333333 v 1.3125 L 2,7.0000003 V 7.666667 L 5.3333333,6.8333336 V 8.4375003 L 4,9.3333333 V 10 L 6,9.5000003 8,10 V 9.3333333 L 6.6666667,8.4375003 V 6.8333336 L 10,7.666667 V 7.0000003 L 6.6666667,4.6458336 v -1.3125 c 0,0 -0.1697627,-1.3333333 -0.6666667,-1.3333333 z"
+     id="path3" />
+</svg>


### PR DESCRIPTION
Adjust aerodrome and airport zoom levels

Fixes #2664 and fixes #3809 
Related to issues #1028 and #1143
Follow-up of PR #2674

## Changes proposed in this pull request:

#### 1) For public aerodromes (`aeroway=aerodromes` with `iata=*` and `icao=*`, and not `access=private`)
- Move initial zoom level for text for airports from z10 to z11. (Icon continues to render from z10).
- Continue rendering icon and text until z16, instead of stopping at z13 as currently.

#### 2) For other aerodromes (`aeroway=aerodromes` lacking `iata=*`, `icao=*` or both, or with `access=private`)
- Increase icon initial zoom level from z11 to z12 
- Move initial text label zoom level from z11 to z13.
- Continue rendering till z17

#### 3) _Optional_: 
- Stop rendering icon and labels earlier (usually no sooner than z15 or z16) if `way_pixels>768,000` (this only works for large `aeroway=aerodrome` mapped as closed ways or multipolygons, however). 

## Explanation
The current initial and final zoom levels for aeroways are z10 and z13. This appears to have been picked to work with large, international airports in the high lattitudes, though even there it's surprising that airports are not rendered at z14. 

In #2664 and #3809  it is noted that aerodrome icons and labels disappear after z13, much sooner than almost any other feature. This is unexpected, and does not work well for average-sized airports and small aerodromes. 

It also does not work well at low latitudes near the equator, and it fails badly with small airstrips and airfields. Such features are rare in Europe, but common in parts of North America, Australia, New Zealand and the whole tropical region.

Also, in #1143 it was noted that too many small aerodromes were previously shown at mid-zoom levels, (z10 to z12). This was partially address in PR #2674 by moving aerodromes with `access=private` or lacking `iata`= (or `icao=`) to z11, however, this did not address any issues at z11 or z12, and it appears not to have considered the issues closer to the equator.

Another issue is that the text label or icon of an airport is often blocked by the name of the town at low zoom levels (z10 to z12), leading to just the text label or just the icon showing. This is particularly a problem for small airfields and airstrips, which show a zoom level before `place=village` currently, though they area usually less significant.

Recently, PR # solved #1028 by stopping area labels based on waypixels for most area features at `way_pixels > 768,000`

Many larger airports are now mapped as areas, but of the 100 aerodromes with an IATA and ICAO code in Germany there are still 11 mapped as nodes, and in Canada there are 78 nodes out of 260, so it's not possible to use `way_pixels` to adjust rendering in general.  *(However, it might be used just to stop rendering large airports a little sooner than others)

However, checking the `way_pixels` of various aerodromes in Canada, Northern Ireland and Indonesia, it's apparent that most should continue rendering till z16 or z17, rather than stopping at z13, if we were to use a `way_pixels < 768,000` cut-off.

See https://github.com/gravitystorm/openstreetmap-carto/issues/1028#issuecomment-526809401: 

I have tested various initial and final zoom levels for rendering airport icons and text labels, so far in Papua, Indonesia (4 degrees south), Prince Edward Island, Canada (46 degrees north) and Northern Ireland (55 degrees north). 

By changing airports (those with IATA codes) to show only the icon at z10, the feature is not too dominating on the map at this zoom level. At z11 larger airports are clearly visible and the text label is not too distracting (though it still may be a problem near the equator).

For smaller aerodromes without IATA codes or private aerodromes, the initial zoom level is changed from z11 to z12, and only the icon is shown at this zoom level, with the text label first shown at z13. This allows `place=village` to be shown 1 zoom level before these minor features have labels. 2 other renders mentioned using z12 or z13 as the initial zoom level in #1143, see https://github.com/gravitystorm/openstreetmap-carto/issues/1143#issuecomment-209842594 and https://github.com/gravitystorm/openstreetmap-carto/issues/1143#issuecomment-252240948

The final zoom level is changed to z16 for aerodromes with an IATA code and z17 without, based on the usual size of these two categories. Some large aerodromes at high lattitudes will not benefit from the icon and text label rendering at z16; this could be solved by checking for `way_pixels`, or we can accept that such airports are rare, and the majority of `aeroway=aerodrome` features will benefit from the rendering at z16 (or z17 for smaller ones).

## Test rendering with links to the example places:

### Belfast International Airport
https://www.openstreetmap.org/#map=11/54.6500/-6.2272
- Major airport in a rural area far from the city which takes up a large area. Since it's at 55 degrees north, it's almost twice as wide (and 4x the area) on-screen as similar-sized airports at the equator

#### z10 before 
(also visible: Belfast city airport, at right, but text labels is blocked by place label)
(At this zoom level, the text lable is several times larger than the airport, even for this large airport at high latitude)
![z10-belfast-airports-before](https://user-images.githubusercontent.com/42757252/64063972-c829e580-cc36-11e9-8e60-6bfe4b9effcd.png)
**z10 after** - symbols still shown, but no text at this zoom level
![z10-belfast-international-and-city-after](https://user-images.githubusercontent.com/42757252/64061524-e5e75280-cc16-11e9-9651-f2ce4cb1606f.png)

#### z11 before
![z11-belfast-international-before](https://user-images.githubusercontent.com/42757252/64061613-37441180-cc18-11e9-9e63-244bc0820bcd.png)
**z11 after** - small aerodrome to southwest is not shown now, because at this low zoom level 
![z11-belfast-international-after](https://user-images.githubusercontent.com/42757252/64061528-f697c880-cc16-11e9-91cd-c34f0acd392b.png)

#### z13 before (same after)
(last zoom level where icon and text label are rendered currently)
![z13-belfast-international-before](https://user-images.githubusercontent.com/42757252/64061542-3363bf80-cc17-11e9-9293-13181b42cbe3.png)

#### z14 before (no label or icon)
![z14-belfast-international-before-no-label](https://user-images.githubusercontent.com/42757252/64061539-1f1fc280-cc17-11e9-94ff-026479f26ec5.png)
**z14 after**
![z14-belfast-international-after](https://user-images.githubusercontent.com/42757252/64064035-9d8c5c80-cc37-11e9-817c-802457544858.png)

#### z15 before - inspector view
(not rendered, even though < 525k `way_pixels`)
![z15-belfast-international-before-waypixels-524418](https://user-images.githubusercontent.com/42757252/64060905-35755080-cc0e-11e9-9193-e52da16bef8f.png)
**z15 after**
![z15-belfast-international-after](https://user-images.githubusercontent.com/42757252/64064033-982f1200-cc37-11e9-9fe9-a2ee07d840da.png)

#### z16 before 
(first zoom level where terminal building name is shown)
![z16-belfast-international-before-waypixels-2million](https://user-images.githubusercontent.com/42757252/64061536-0fa07980-cc17-11e9-84fc-1125a25a6f2b.png)
**z16 after** - not shown, if `way_pixels` are checked. 
![z16-belfast-international-before-waypixels-2million](https://user-images.githubusercontent.com/42757252/64064041-b563e080-cc37-11e9-8e21-a8ea6db13ecc.png)

### Belfast city airport
https://www.openstreetmap.org/#map=11/54.6198/-5.8705
Also an airport with a full-length runway at high lattitude, but it only hits 36,000 way_pixels at z14, so it should render till z16 (576k waypixels). 
* **z10 - see above**
* ** z11-z13** unchanged

#### z14 Before
Only 36k `way_pixels`, but no icon or text label rendering
![z14-belfast-city-airport-waypixels-35864](https://user-images.githubusercontent.com/42757252/64060925-7c634600-cc0e-11e9-896a-9afa4669583e.png)
**z14 after**
![z14-belfast-city-airport-after](https://user-images.githubusercontent.com/42757252/64064022-76ce2600-cc37-11e9-9c82-e84eee2ebb71.png)

#### z15 After 
(No rendering before)
![z15-belfast-city-airport-after](https://user-images.githubusercontent.com/42757252/64064027-851c4200-cc37-11e9-94d0-702340a232d4.png)

#### z16 After - inspector view
(Only 574k `way_pixels`, so it should be rendered - and this is true for almost all airports at z16)
![z16-belfast-city-airport-after-waypixels-574000](https://user-images.githubusercontent.com/42757252/64064087-5ce11300-cc38-11e9-90f1-bac142f93daf.png)

### Dunnamanagh Airstrip
https://www.openstreetmap.org/#map=12/54.8889/-7.2669
- This aerodrome is a good example of the many small runways without an IATA or ICAO code, yet it's been mapped as an area with a building, apron and taxiway. Shouldn't render before z12, but can render until z17 without problems (and near the equator z17 would be important)

#### z11 before
- Renders before any villages, label as big as a good-sized town.
![z11-dunnamanagh-airstrip-before](https://user-images.githubusercontent.com/42757252/64064241-a7af5a80-cc39-11e9-91b7-b6fb78443782.png)
(After: not rendered)

#### z12 before
- Label is too prominent compared to villages
![z12-dunnamanagh-airstrip-before](https://user-images.githubusercontent.com/42757252/64064251-e04f3400-cc39-11e9-8a9e-cec9226c9c85.png)
** z12 after** - just icon
![z12-dunnamanagh-airstrip-after](https://user-images.githubusercontent.com/42757252/64064249-cc0b3700-cc39-11e9-9470-142f1e1ec478.png)

#### z15 after
- No icon or text label rendering before
![z15-dunnamanagh-airstrip-after](https://user-images.githubusercontent.com/42757252/64064268-1d1b2b00-cc3a-11e9-9a57-84887abe92c4.png)

#### z17 after
![z17-dunnamanagh-airstrip-after-last-zoom-level](https://user-images.githubusercontent.com/42757252/64064238-9ebe8900-cc39-11e9-8e83-d9ca9d502498.png)