### PR TITLE
Render leisure=hackerspace

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1424,6 +1424,13 @@
      marker-clip: false;
    }
 
+  [feature = 'leisure_hackerspace'][zoom >= 17]  {
+     marker-file: url('symbols/leisure/hackerspace.svg');
+     marker-fill: @shop-icon;
+     marker-placement: interior;
+     marker-clip: false;
+   }
+
   [feature = 'leisure_beach_resort'][zoom >= 16] {
      marker-file: url('symbols/leisure/beach_resort.svg');
      marker-fill: @leisure-green;
@@ -1857,6 +1864,19 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: @leisure-green;
+    text-dy: 11;
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+  }
+
+  [feature = 'leisure_hackerspace'][zoom >= 17] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: @shop-text;
     text-dy: 11;
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;

--- a/project.mml
+++ b/project.mml
@@ -1437,7 +1437,7 @@ Layer:
                 'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area IS NULL THEN tags->'emergency' ELSE NULL END,
                 'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
-                                                    'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
+                                                    'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'hackerspace', 'ice_rink', 'marina', 'miniature_golf',
                                                     'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
                                                     'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure ELSE NULL END,
                 'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power ELSE NULL END,

--- a/symbols/leisure/hackerspace.svg
+++ b/symbols/leisure/hackerspace.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14" height="14" version="1.1" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g stroke-width="0">
+  <circle cx="7" cy="2.4182" r="1.7818"/>
+  <circle cx="11.582" cy="7" r="1.7818"/>
+  <circle cx="11.582" cy="11.582" r="1.7818"/>
+  <circle cx="7" cy="11.582" r="1.7818"/>
+  <circle cx="2.4182" cy="11.582" r="1.7818"/>
+ </g>
+ <path id="canvas" d="m13.373 0.29018h14v14h-14z" fill="none" visibility="hidden"/>
+ <path d="m0.12444 13.874h13.751v0.0011h-13.751zm-0.0014-13.8v0.0019531h13.754v-0.0019531zm0 0.048828v13.754h0.0039v-4.6016h4.5977v4.5996h2e-3v-4.5996h4.5469v4.5996h2e-3v-4.5996h4.5995v-0.00195h-4.5996v-4.5469h4.5996v-0.00195h-4.5996v-4.5996h-2e-3v4.5996h-4.5468v-4.5996h-2e-3v4.5996h-4.5976v-4.6016zm13.801 0.0019531v13.75h2e-3v-13.75zm-13.797 4.6016h4.5977v4.5469h-4.5977zm4.5996 0h4.5469v4.5469h-4.5469z" stroke="#000" stroke-linecap="round" stroke-width=".24888"/>
+</svg>


### PR DESCRIPTION
Adds rendering for leisure=hackerspace on nodes and closed ways ("areas") with an icon based on the [hacker glider](http://www.catb.org/hacker-emblem/) shop color. The icon and name label are rendered at z17 and up, similar to other amenities.

This PR includes the first of the following symbols. Please let me know if you had a different preference of icon or colour and I would be happy to adjust.

![foo](https://user-images.githubusercontent.com/97706/64206441-e8051780-ce89-11e9-9e2b-0e62d1be82c4.png)
