### PR TITLE
Move highway areas below all linear road types

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -450,6 +450,61 @@ Layer:
         ) AS buildings
     properties:
       minzoom: 14
+  - id: highway-area-casing
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            COALESCE((
+              'highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'track', 'path', 'platform') THEN highway ELSE NULL END)),
+              ('railway_' || (CASE WHEN (railway IN ('platform')
+                              AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              THEN railway ELSE NULL END))
+            ) AS feature
+          FROM planet_osm_polygon
+          WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'track', 'path', 'platform')
+            OR (railway IN ('platform')
+                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                AND (covered NOT IN ('yes') OR covered IS NULL))
+          ORDER BY COALESCE(layer,0), way_area DESC
+        ) AS highway_area_casing
+    properties:
+      minzoom: 14
+  - id: highway-area-fill
+    # FIXME: No geometry?
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            COALESCE(
+              ('highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street',
+                                                    'track', 'path', 'platform', 'services') THEN highway ELSE NULL END)),
+              ('railway_' || (CASE WHEN (railway IN ('platform')
+                              AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              THEN railway ELSE NULL END)),
+              (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))
+            ) AS feature
+          FROM planet_osm_polygon
+          WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'living_street', 'track', 'path', 'platform', 'services')
+            OR (railway IN ('platform')
+                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                AND (covered NOT IN ('yes') OR covered IS NULL))
+            OR aeroway IN ('runway', 'taxiway', 'helipad')
+          ORDER BY COALESCE(layer,0), way_area desc
+        ) AS highway_area_fill
+    properties:
+      minzoom: 14
   - id: tunnels
     class: access
     geometry: linestring
@@ -679,32 +734,6 @@ Layer:
         ) AS turning_circle_sql
     properties:
       minzoom: 15
-  - id: highway-area-casing
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            COALESCE((
-              'highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'track', 'path', 'platform') THEN highway ELSE NULL END)),
-              ('railway_' || (CASE WHEN (railway IN ('platform')
-                              AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                              AND (covered NOT IN ('yes') OR covered IS NULL))
-                              THEN railway ELSE NULL END))
-            ) AS feature
-          FROM planet_osm_polygon
-          WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'track', 'path', 'platform')
-            OR (railway IN ('platform')
-                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                AND (covered NOT IN ('yes') OR covered IS NULL))
-          ORDER BY COALESCE(layer,0), way_area DESC
-        ) AS highway_area_casing
-    properties:
-      minzoom: 14
   - id: roads-casing
     geometry: linestring
     <<: *extents
@@ -804,35 +833,6 @@ Layer:
     properties:
       cache-features: true
       minzoom: 10
-  - id: highway-area-fill
-    # FIXME: No geometry?
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            COALESCE(
-              ('highway_' || (CASE WHEN highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street',
-                                                    'track', 'path', 'platform', 'services') THEN highway ELSE NULL END)),
-              ('railway_' || (CASE WHEN (railway IN ('platform')
-                              AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                              AND (covered NOT IN ('yes') OR covered IS NULL))
-                              THEN railway ELSE NULL END)),
-              (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))
-            ) AS feature
-          FROM planet_osm_polygon
-          WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'living_street', 'track', 'path', 'platform', 'services')
-            OR (railway IN ('platform')
-                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                AND (covered NOT IN ('yes') OR covered IS NULL))
-            OR aeroway IN ('runway', 'taxiway', 'helipad')
-          ORDER BY COALESCE(layer,0), way_area desc
-        ) AS highway_area_fill
-    properties:
-      minzoom: 14
   - id: roads-fill
     class: access
     geometry: linestring

--- a/roads.mss
+++ b/roads.mss
@@ -5,6 +5,7 @@
 @service-fill: @residential-fill;
 @living-street-fill: #ededed;
 @pedestrian-fill: #dddde8;
+@pedestrian-area-fill: #ebebf7;
 @raceway-fill: pink;
 @road-fill: #ddd;
 @footway-fill: salmon;
@@ -2626,7 +2627,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   [feature = 'highway_cycleway'],
   [feature = 'highway_path'] {
     [zoom >= 15] {
-      polygon-fill: @pedestrian-fill;
+      polygon-fill: @pedestrian-area-fill;
     }
   }
 


### PR DESCRIPTION
This PR moves highway areas below all linear road types (resolves #3281).

In particular, this change has the following effects:

* Render highway areas below tunnels (resolves #529). This prevents the current situation where 
 tunnels are invisible if there happens to be a highway area above them.
* Render highway areas below line/area barriers, ferry routes, tourism boundaries, cliffs, landuse-overlay, and turning circles. I think these changes are mainly neutral or positive.
* Render highway areas below ~line/area barriers~ linear roads. This is probably the most controversial aspect (but necessary for the other changes). See screenshot below.

* ~This PR is a necessary condition for merging the roads-casing and roads-fill layers (part of #2046), which would greatly simplify our code.~
* This PR is a necessary condition for rendering buildings above highway area (#688).

* Promoting linear highways over areas makes life easier for other data consumers, that already tend to have poor support for highway areas. For example:
  * Transport and wikipedia do not render road areas
  * Humanitarian, bicycle, mapbox, streets, OSM bright renders linear roads on top of areas, like in this proposal
