### PR TITLE
Restore rendering of text labels on points

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1745,20 +1745,22 @@
 .text-low-zoom[zoom < 10],
 #text-point[zoom >= 10] {
   [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels <= 768000],
+  [feature = 'place_island'][zoom >= 16][way_pixels = null],
   [feature = 'place_island'][zoom >= 16][way_pixels <= 768000],
   [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels <= 768000],
+  [feature = 'place_islet'][zoom >= 17][way_pixels = null],
   [feature = 'place_islet'][zoom >= 17][way_pixels <= 768000] {
     text-name: "[name]";
     text-fill: #000;
     text-size: @landcover-font-size;
     text-wrap-width: @landcover-wrap-width-size;
     text-line-spacing: @landcover-line-spacing-size;
-    [way_pixels > 12000] {
+    [way_pixels > 12000][way_pixels != null] {
       text-size: @landcover-font-size-big;
       text-wrap-width: @landcover-wrap-width-size-big;
       text-line-spacing: @landcover-line-spacing-size-big;
     }
-    [way_pixels > 48000] {
+    [way_pixels > 48000][way_pixels != null] {
       text-size: @landcover-font-size-bigger;
       text-wrap-width: @landcover-wrap-width-size-bigger;
       text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2205,17 +2207,18 @@
 
   [feature = 'leisure_swimming_pool'][is_building = 'no'] {
     [zoom >= 14][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2260,17 +2263,18 @@
   [feature = 'boundary_aboriginal_lands'],
   [feature = 'boundary_protected_area'] {
     [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2299,17 +2303,18 @@
 
   [feature = 'military_danger_area'][is_building = 'no'] {
     [zoom >= 9][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2324,17 +2329,18 @@
 
   [feature = 'landuse_garages'][is_building = 'no'] {
     [zoom >= 13][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2401,19 +2407,21 @@
   [feature = 'leisure_ice_rink'],
   [feature = 'leisure_pitch'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels = null][is_building = 'no'],
     [zoom >= 17][way_pixels <= 768000][is_building = 'no'],
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][shop = 'mall'],
+    [zoom >= 17][way_pixels = null][shop = 'mall'],
     [zoom >= 17][way_pixels <= 768000][shop = 'mall'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2669,17 +2677,18 @@
 
   [feature = 'leisure_marina'][zoom >= 15] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2963,17 +2972,18 @@
   [feature = 'power_sub_station'][is_building = 'no'][zoom >= 13],
   [feature = 'power_substation'][is_building = 'no'][zoom >= 13]{
     [way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2991,17 +3001,18 @@
   [feature = 'natural_bare_rock'],
   [feature = 'natural_sand'] {
     [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
+    [zoom >= 17][way_pixels = null][is_building = 'no'],
     [zoom >= 17][way_pixels <= 768000][is_building = 'no'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3023,17 +3034,18 @@
 
   [feature = 'aeroway_apron'][is_building = 'no'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3049,17 +3061,18 @@
   [feature = 'highway_services'][is_building = 'no'],
   [feature = 'highway_rest_area'][is_building = 'no'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3075,17 +3088,18 @@
   [feature = 'natural_glacier'][is_building = 'no'] {
     [zoom >= 8][way_pixels > 10000][way_pixels <= 768000],
     [zoom >= 10][way_pixels > 750][way_pixels <= 768000],
+    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000] {
+      [way_pixels > 12000][way_pixels != null] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000] {
+      [way_pixels > 48000][way_pixels != null] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1745,22 +1745,20 @@
 .text-low-zoom[zoom < 10],
 #text-point[zoom >= 10] {
   [feature = 'place_island'][zoom >= 4][way_pixels > 3000][way_pixels <= 768000],
-  [feature = 'place_island'][zoom >= 16][way_pixels = null],
   [feature = 'place_island'][zoom >= 16][way_pixels <= 768000],
   [feature = 'place_islet'][zoom >= 11][way_pixels > 3000][way_pixels <= 768000],
-  [feature = 'place_islet'][zoom >= 17][way_pixels = null],
   [feature = 'place_islet'][zoom >= 17][way_pixels <= 768000] {
     text-name: "[name]";
     text-fill: #000;
     text-size: @landcover-font-size;
     text-wrap-width: @landcover-wrap-width-size;
     text-line-spacing: @landcover-line-spacing-size;
-    [way_pixels > 12000][way_pixels != null] {
+    [way_pixels > 12000] {
       text-size: @landcover-font-size-big;
       text-wrap-width: @landcover-wrap-width-size-big;
       text-line-spacing: @landcover-line-spacing-size-big;
     }
-    [way_pixels > 48000][way_pixels != null] {
+    [way_pixels > 48000] {
       text-size: @landcover-font-size-bigger;
       text-wrap-width: @landcover-wrap-width-size-bigger;
       text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2207,18 +2205,17 @@
 
   [feature = 'leisure_swimming_pool'][is_building = 'no'] {
     [zoom >= 14][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2263,18 +2260,17 @@
   [feature = 'boundary_aboriginal_lands'],
   [feature = 'boundary_protected_area'] {
     [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2303,18 +2299,17 @@
 
   [feature = 'military_danger_area'][is_building = 'no'] {
     [zoom >= 9][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2329,18 +2324,17 @@
 
   [feature = 'landuse_garages'][is_building = 'no'] {
     [zoom >= 13][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2407,21 +2401,19 @@
   [feature = 'leisure_ice_rink'],
   [feature = 'leisure_pitch'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
-    [zoom >= 17][way_pixels = null][is_building = 'no'],
     [zoom >= 17][way_pixels <= 768000][is_building = 'no'],
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000][shop = 'mall'],
-    [zoom >= 17][way_pixels = null][shop = 'mall'],
     [zoom >= 17][way_pixels <= 768000][shop = 'mall'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2677,18 +2669,17 @@
 
   [feature = 'leisure_marina'][zoom >= 15] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -2972,18 +2963,17 @@
   [feature = 'power_sub_station'][is_building = 'no'][zoom >= 13],
   [feature = 'power_substation'][is_building = 'no'][zoom >= 13]{
     [way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3001,18 +2991,17 @@
   [feature = 'natural_bare_rock'],
   [feature = 'natural_sand'] {
     [zoom >= 8][way_pixels > 3000][way_pixels <= 768000][is_building = 'no'],
-    [zoom >= 17][way_pixels = null][is_building = 'no'],
     [zoom >= 17][way_pixels <= 768000][is_building = 'no'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3034,18 +3023,17 @@
 
   [feature = 'aeroway_apron'][is_building = 'no'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3061,18 +3049,17 @@
   [feature = 'highway_services'][is_building = 'no'],
   [feature = 'highway_rest_area'][is_building = 'no'] {
     [zoom >= 10][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;
@@ -3088,18 +3075,17 @@
   [feature = 'natural_glacier'][is_building = 'no'] {
     [zoom >= 8][way_pixels > 10000][way_pixels <= 768000],
     [zoom >= 10][way_pixels > 750][way_pixels <= 768000],
-    [zoom >= 17][way_pixels = null],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;
       text-line-spacing: @landcover-line-spacing-size;
-      [way_pixels > 12000][way_pixels != null] {
+      [way_pixels > 12000] {
         text-size: @landcover-font-size-big;
         text-wrap-width: @landcover-wrap-width-size-big;
         text-line-spacing: @landcover-line-spacing-size-big;
       }
-      [way_pixels > 48000][way_pixels != null] {
+      [way_pixels > 48000] {
         text-size: @landcover-font-size-bigger;
         text-wrap-width: @landcover-wrap-width-size-bigger;
         text-line-spacing: @landcover-line-spacing-size-bigger;

--- a/project.mml
+++ b/project.mml
@@ -1365,12 +1365,12 @@ Layer:
               railway,
               aerialway,
               tags->'station' AS station,
-              0 as way_area
+              NULL as way_area
             FROM planet_osm_point
             WHERE way && !bbox!
             ) _
           WHERE railway IN ('station', 'halt', 'tram_stop')
-            OR railway = 'subway_entrance' AND way_area = '0'
+            OR railway = 'subway_entrance' AND way_area IS NULL
             OR aerialway = 'station'
           ORDER BY
             CASE railway
@@ -1429,12 +1429,12 @@ Layer:
                 'amenity_' || CASE WHEN amenity IN ('parking_entrance')
                                         AND tags->'parking' IN ('underground')
                                         AND (access IS NULL OR access NOT IN ('private', 'no'))
-                                        AND way_area = '0' -- Only parking points are rendered
+                                        AND way_area IS NULL -- Only parking points are rendered
                                   THEN amenity ELSE NULL END,
                 'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity ELSE NULL END,
                 'amenity_' || CASE WHEN amenity IN ('vending_machine') AND tags->'vending' IN ('excrement_bags', 'parking_tickets', 'public_transport_tickets') THEN amenity ELSE NULL END,
                 'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,
-                'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area = '0' THEN tags->'emergency' ELSE NULL END,
+                'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area IS NULL THEN tags->'emergency' ELSE NULL END,
                 'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
@@ -1448,28 +1448,28 @@ Layer:
                                                     'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farmland',
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
                                                     'construction', 'military', 'plant_nursery') THEN landuse ELSE NULL END,
-                'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area = '0' THEN "natural" ELSE NULL END,
+                'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" ELSE NULL END,
                 'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'bay', 'spring',
                                                       'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" ELSE NULL END,
-                'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area = '0' THEN waterway ELSE NULL END,
+                'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway ELSE NULL END,
                 'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                 'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
                               THEN historic ELSE NULL END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,
-                'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area = '0' THEN 'ford' ELSE NULL END,
+                'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' ELSE NULL END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
                                           OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
                                           THEN boundary ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism ELSE NULL END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
-                'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area = '0' THEN barrier ELSE NULL END,
+                'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier ELSE NULL END,
                 'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
-                'man_made_' || CASE WHEN man_made IN ('cross') AND way_area = '0' THEN man_made ELSE NULL END,
-                'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area = '0' THEN historic ELSE NULL END,
+                'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made ELSE NULL END,
+                'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
-                'place_' || CASE WHEN place IN ('locality') AND way_area = '0' THEN place ELSE NULL END
+                'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place ELSE NULL END
               ) AS feature,
               access,
               CASE
@@ -1534,7 +1534,7 @@ Layer:
               tags -> 'operator' AS operator,
               ref,
               way_area,
-              way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels
             FROM
               (SELECT
                   ST_PointOnSurface(way) AS way,
@@ -1588,7 +1588,7 @@ Layer:
                   tourism,
                   waterway,
                   tags,
-                  0 AS way_area
+                  NULL AS way_area
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _

--- a/project.mml
+++ b/project.mml
@@ -1365,12 +1365,12 @@ Layer:
               railway,
               aerialway,
               tags->'station' AS station,
-              NULL as way_area
+              0 as way_area
             FROM planet_osm_point
             WHERE way && !bbox!
             ) _
           WHERE railway IN ('station', 'halt', 'tram_stop')
-            OR railway = 'subway_entrance' AND way_area IS NULL
+            OR railway = 'subway_entrance' AND way_area = '0'
             OR aerialway = 'station'
           ORDER BY
             CASE railway
@@ -1429,12 +1429,12 @@ Layer:
                 'amenity_' || CASE WHEN amenity IN ('parking_entrance')
                                         AND tags->'parking' IN ('underground')
                                         AND (access IS NULL OR access NOT IN ('private', 'no'))
-                                        AND way_area IS NULL -- Only parking points are rendered
+                                        AND way_area = '0' -- Only parking points are rendered
                                   THEN amenity ELSE NULL END,
                 'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity ELSE NULL END,
                 'amenity_' || CASE WHEN amenity IN ('vending_machine') AND tags->'vending' IN ('excrement_bags', 'parking_tickets', 'public_transport_tickets') THEN amenity ELSE NULL END,
                 'advertising_' || CASE WHEN tags->'advertising' in ('column') THEN tags->'advertising' else NULL END,
-                'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area IS NULL THEN tags->'emergency' ELSE NULL END,
+                'emergency_' || CASE WHEN tags->'emergency' IN ('phone') AND way_area = '0' THEN tags->'emergency' ELSE NULL END,
                 'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
@@ -1448,28 +1448,28 @@ Layer:
                                                     'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farmland',
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
                                                     'construction', 'military', 'plant_nursery') THEN landuse ELSE NULL END,
-                'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" ELSE NULL END,
+                'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area = '0' THEN "natural" ELSE NULL END,
                 'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'bay', 'spring',
                                                       'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" ELSE NULL END,
-                'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway ELSE NULL END,
+                'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area = '0' THEN waterway ELSE NULL END,
                 'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,
                 'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
                               THEN historic ELSE NULL END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military ELSE NULL END,
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway ELSE NULL END,
-                'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' ELSE NULL END,
+                'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area = '0' THEN 'ford' ELSE NULL END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
                                           OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
                                           THEN boundary ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism ELSE NULL END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
-                'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier ELSE NULL END,
+                'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area = '0' THEN barrier ELSE NULL END,
                 'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
-                'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made ELSE NULL END,
-                'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic ELSE NULL END,
+                'man_made_' || CASE WHEN man_made IN ('cross') AND way_area = '0' THEN man_made ELSE NULL END,
+                'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area = '0' THEN historic ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
-                'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place ELSE NULL END
+                'place_' || CASE WHEN place IN ('locality') AND way_area = '0' THEN place ELSE NULL END
               ) AS feature,
               access,
               CASE
@@ -1588,7 +1588,7 @@ Layer:
                   tourism,
                   waterway,
                   tags,
-                  NULL AS way_area
+                  0 AS way_area
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _


### PR DESCRIPTION
**Fixes #3876**
**Fixes #3868**

## Changes proposed in this pull request:
- Restore rendering of text labels on points, including landcover and islands

## Explanation: 
Prior to #3764 most features in `landcover` had text labels rendered at high zoom level when tagged on nodes. For islands this was the case before  #1444. It appears that text labels of the name for points was unintentionally lost in these two PRs.
This PR restores this rendering by adding a check for way_pixels=null.
Suprisingly, `way_pixels != null` has to be checked for each instance of `[way_pixels > 12000]` or else the points render with the large lancover text size

## Test rendering:

Old rendering, before #3764 but after #1444
![z17-landcover-poi-before-3764](https://user-images.githubusercontent.com/42757252/64484619-e358ae80-d24f-11e9-9172-3b785f9ba1f3.png)

Current test rendering:
![z17-landcover-poi-text-current-rendering](https://user-images.githubusercontent.com/42757252/64484623-f23f6100-d24f-11e9-891f-bc1ab4bcc22b.png)

After this PR:
![z17-landcover-poi-test-after](https://user-images.githubusercontent.com/42757252/64484615-c7eda380-d24f-11e9-90cd-424e500c6902.png)
