### PR TITLE
Adjust aerodrome zoom levels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,10 +1488,10 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
     [way_pixels <= 192000],
     [way_pixels = null] {
       marker-file: url('symbols/aerodrome.12.svg');
@@ -3116,10 +3116,10 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['access' = 'private'],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['icao' = null],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['iata' = null] {
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 18],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 18],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 18] {
     [way_pixels <= 192000],
     [way_pixels = null] {
       text-name: "[name]";

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,11 +1488,11 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
-  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
-  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
-    [way_pixels <= 768000],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 16],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 17],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 17] {
+    [way_pixels <= 192000],
     [way_pixels = null] {
       marker-file: url('symbols/aerodrome.12.svg');
       marker-placement: interior;
@@ -3116,11 +3116,11 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['access' = 'private'],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['icao' = null],
-  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['iata' = null] {
-    [way_pixels <= 768000],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 16],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['access' = 'private'],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['icao' = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 17]['iata' = null] {
+    [way_pixels <= 192000],
     [way_pixels = null] {
       text-name: "[name]";
       text-size: @standard-font-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1488,12 +1488,17 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
-  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14] {
-    marker-file: url('symbols/aerodrome.12.svg');
-    marker-placement: interior;
-    marker-clip: false;
-    marker-fill: @airtransport;
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
+    [way_pixels <= 768000],
+    [way_pixels = null] {
+      marker-file: url('symbols/aerodrome.12.svg');
+      marker-placement: interior;
+      marker-clip: false;
+      marker-fill: @airtransport;
+    }
   }
 
   [feature = 'amenity_ferry_terminal'][zoom >= 15] {
@@ -3111,8 +3116,25 @@
     text-placement: interior;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 14],
-  [feature = 'aeroway_aerodrome'][zoom >= 11][zoom < 14],
+  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['access' = 'private'],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['icao' = null],
+  [feature = 'aeroway_aerodrome'][zoom >= 13][zoom < 18]['iata' = null] {
+    [way_pixels <= 768000],
+    [way_pixels = null] {
+      text-name: "[name]";
+      text-size: @standard-font-size;
+      text-wrap-width: @standard-wrap-width;
+      text-line-spacing: @standard-line-spacing-size;
+      text-fill: darken(@airtransport, 15%);
+      text-dy: 10;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: interior;
+    }
+  }
+
   [feature = 'amenity_ferry_terminal'][zoom >= 15] {
     text-name: "[name]";
     text-size: @standard-font-size;


### PR DESCRIPTION
Adjust aerodrome and airport zoom levels

Fixes #2664 and fixes #3809 
Related to issues #1028 and #1143
Follow-up of PR #2674, replaces closed PR #3856

## Changes proposed in this pull request:

#### 1) For airports (`aeroway=aerodromes` with `iata=*` and `icao=*`, and not `access=private`)
- Move initial zoom level for text for airports from z10 to z11. The Icon continues to render from z10
- Continue rendering icon and text until z16, but stop rendering large areas earlier (when `way_pixels > 192,000`)

#### 2) For other aerodromes (`aeroway=aerodromes` lacking `iata=*`, `icao=*` or both, or with `access=private`)
- Increase icon initial zoom level from z11 to z12 
- Move initial text label zoom level from z11 to z13.
- Continue rendering till z17, or until `way_pixels > 192,000` if mapped as an area.

## Explanation
The current initial and final zoom levels for aeroways are z10 and z13. This appears to have been picked to work with large, international airports in the high lattitudes, though even there it's surprising that airports are not rendered at z14. 

In #2664 and #3809  it is noted that aerodrome icons and labels disappear after z13, much sooner than almost any other feature.

Also, in #1143 it was noted that too many small aerodromes were previously shown at mid-zoom levels, (z10 to z12). This was partially address in PR #2674 by moving aerodromes with `access=private` or lacking `iata`= (or `icao=`) to z11

Another issue is that the text label or icon of an airport is often blocked by the name of the town at low zoom levels (z10 to z12), leading to just the text label or just the icon showing. This is particularly a problem for small airfields and airstrips, which show a zoom level before `place=village` currently, though they area usually less significant.

Recently, issue #1028 was solved by stopping area labels based on waypixels for most area features at `way_pixels > 768,000`

Many larger airports are now mapped as areas, but of the 100 aerodromes with an IATA and ICAO code in Germany there are still 11 mapped as nodes, and in Canada there are 78 nodes out of 260, so it's not possible to rely on `way_pixels` entirely.  However, it might be used to stop rendering large airports a sooner than others

By changing airports (those with IATA codes, which are required for any airport that has commercial airline flights) to show only the icon at z10, the feature is not too dominating on the map at this zoom level. At z11 larger airports are clearly visible and the text label is not too distracting (though it still may be a problem near the equator).

For aerodromes without IATA codes, the initial zoom level is changed from z11 to z12, and only the icon is shown at this zoom level, with the text label first shown at z13. This allows `place=village` to be shown 1 zoom level before these minor features have labels.

The final zoom level is changed to z16 for aerodromes with an IATA code and z17 without, based on the usual size of these two categories. Some large aerodromes at high latitudes will not benefit from the icon and text label rendering at z16; this is solved by checking for `way_pixels < 192,000`. 

The way_pixels limit is one zoom level lower than for landcover (which uses 768,000), because airports are often significantly longer than they are wide, and because the text size is not increased with way_pixels as with `landcover` text labels.

Often this prevents rendering of large international airports below z14 or z15 in northern Europe, and z15 or z16 near the equator.