### PR TITLE
Switch addresses to use ST_PointOnSurface

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -25,7 +25,6 @@
         }
       }
     }
-    text-placement: interior;
     text-face-name: @book-fonts;
     text-fill: @address-color;
     text-halo-radius: @standard-halo-radius;

--- a/project.mml
+++ b/project.mml
@@ -2085,7 +2085,7 @@ Layer:
             tags->'addr:unit' AS addr_unit,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
+          WHERE way && !bbox! AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
             AND building IS NOT NULL
         UNION ALL
         SELECT
@@ -2095,7 +2095,7 @@ Layer:
             tags->'addr:unit' AS addr_unit,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
+          WHERE way && !bbox! AND ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:

--- a/project.mml
+++ b/project.mml
@@ -2079,7 +2079,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             "addr:housenumber" AS addr_housenumber,
             "addr:housename" AS addr_housename,
             tags->'addr:unit' AS addr_unit,


### PR DESCRIPTION
### Related to #1644
- This appears to be the last relevant layer that needs to be switched now, unless we wish to switch all polygon layers to use ST_PointOnSurface

## Changes proposed in this pull request:
- Switch `addresses` to use ST_PointOnSurface
- This makes addresses consistent with `amenity-points` and `building` names.
- Address numbers will no longer be displayed separately than the POI or building name for oddly-shaped polygons

## Test rendering:

https://www.openstreetmap.org/#map=19/50.63295/3.06320

### Passage 57
Before
![passage-57-before](https://user-images.githubusercontent.com/42757252/65382363-71e42a00-dd3e-11e9-975a-2eb54b368f7f.png)
After
![z19-passage-57-after](https://user-images.githubusercontent.com/42757252/65382365-7d375580-dd3e-11e9-8cb6-9b269c1c9765.png)

### Monop
Before
![z19-monop-before](https://user-images.githubusercontent.com/42757252/65382366-81fc0980-dd3e-11e9-82b0-2293c596a266.png)
After
![z19-monop-after](https://user-images.githubusercontent.com/42757252/65382369-86c0bd80-dd3e-11e9-8911-673ea860155e.png)
