### PR TITLE
Remove unused text-placement: interior and marker-placement: interior

### DIFF
--- a/addressing.mss
+++ b/addressing.mss
@@ -56,7 +56,6 @@ no official postal addresses) */
   [zoom >= 14][way_pixels > 3000],
   [zoom >= 17] {
     text-name: "[name]";
-    text-placement: interior;
     text-face-name: @book-fonts;
     text-fill: #444;
     text-halo-radius: @standard-halo-radius;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -54,7 +54,6 @@
       marker-fill: @man-made-icon;
     }
     marker-fill: @accommodation-icon;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -64,21 +63,18 @@
   [feature = 'amenity_atm'][zoom >= 19] {
     marker-file: url('symbols/amenity/atm.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_bureau_de_change'][zoom >= 17] {
     marker-file: url('symbols/amenity/bureau_de_change.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_bank'][zoom >= 17] {
     marker-file: url('symbols/amenity/bank.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -90,7 +86,6 @@
   [feature = 'amenity_ice_cream'][zoom >= 17],
   [feature = 'amenity_pub'][zoom >= 17],
   [feature = 'amenity_restaurant'][zoom >= 17] {
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @gastronomy-icon;
     [feature != 'amenity_food_court'][zoom = 17] {
@@ -124,14 +119,12 @@
   [feature = 'amenity_internet_cafe'][zoom >= 17] {
     marker-file: url('symbols/amenity/internet_cafe.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_bbq'][zoom >= 17] {
     marker-file: url('symbols/amenity/bbq.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -141,14 +134,12 @@
   [feature = 'amenity_public_bookcase'][zoom >= 19] {
     marker-file: url('symbols/amenity/public_bookcase.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_bicycle_rental'][zoom >= 17] {
     marker-file: url('symbols/amenity/rental_bicycle.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -156,7 +147,6 @@
     [zoom >= 16] {
       marker-file: url('symbols/square.svg');
       marker-fill: @transportation-icon;
-      marker-placement: interior;
       marker-width: 6;
       marker-clip: false;
     }
@@ -171,21 +161,18 @@
     [access = 'yes'] {
       marker-file: url('symbols/highway/elevator.12.svg');
       marker-fill: @transportation-icon;
-      marker-placement: interior;
     }
   }
 
   [feature = 'amenity_bus_station'][zoom >= 16] {
     marker-file: url('symbols/amenity/bus_station.svg');
     // use colors from SVG to allow for white background
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_taxi'][zoom >= 17] {
     marker-file: url('symbols/amenity/taxi.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -200,21 +187,18 @@
       marker-file: url('symbols/amenity/public_transport_tickets.svg');
     }
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'highway_traffic_signals'][zoom >= 17] {
     marker-file: url('symbols/highway/traffic_light.13.svg');
     marker-fill: #545454;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_toll_booth'][zoom >= 16] {
     marker-file: url('symbols/barrier/toll_booth.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -229,13 +213,11 @@
       marker-file: url('symbols/historic/bust.svg');
     }
     marker-fill: @memorials;
-    marker-placement: interior;
   }
 
   [feature = 'tourism_camp_site'][zoom >= 16] {
     marker-file: url('symbols/tourism/camping.svg');
     marker-fill: @accommodation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -243,13 +225,11 @@
   [feature = 'highway_ford'][zoom >= 16] {
     marker-file: url('symbols/highway/ford.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_caravan_site'][zoom >= 16] {
     marker-file: url('symbols/tourism/caravan_park.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @accommodation-icon;
   }
@@ -257,49 +237,42 @@
   [feature = 'amenity_car_rental'][zoom >= 17] {
     marker-file: url('symbols/amenity/rental_car.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_car_wash'][zoom >= 17] {
     marker-file: url('symbols/amenity/car_wash.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_chalet'][zoom >= 17] {
     marker-file: url('symbols/tourism/chalet.svg');
     marker-fill: @accommodation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_cinema'][zoom >= 16] {
     marker-file: url('symbols/amenity/cinema.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_public_bath'][zoom >= 17] {
     marker-file: url('symbols/amenity/public_bath.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_nightclub'][zoom >= 17] {
     marker-file: url('symbols/amenity/nightclub.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_fire_station'][zoom >= 16] {
     marker-file: url('symbols/amenity/firestation.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -324,7 +297,6 @@
       [zoom >= 18] {
         nozzle/marker-file: url('symbols/amenity/fountain.svg');
         nozzle/marker-fill: @marina-text;
-        nozzle/marker-placement: interior;
         nozzle/marker-clip: false;
       }
     }
@@ -333,7 +305,6 @@
   [feature = 'amenity_charging_station'][zoom >= 17] {
     marker-file: url('symbols/amenity/charging_station.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -343,28 +314,24 @@
   [feature = 'amenity_fuel'][zoom >= 17] {
     marker-file: url('symbols/amenity/fuel.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_guest_house'][zoom >= 17] {
     marker-file: url('symbols/tourism/guest_house.svg');
     marker-fill: @accommodation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_apartment'][zoom >= 18] {
     marker-file: url('symbols/tourism/apartment.svg');
     marker-fill: @accommodation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_bicycle_repair_station'][zoom >= 19] {
     marker-file: url('symbols/amenity/bicycle_repair_station.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -374,34 +341,29 @@
   [feature = 'amenity_casino'][zoom >= 17] {
     marker-file: url('symbols/amenity/casino.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_gallery'][zoom >= 17] {
     marker-file: url('symbols/shop/art.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @amenity-brown;
   }
 
   [feature = 'tourism_hostel'][zoom >= 17] {
     marker-file: url('symbols/tourism/hostel.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @accommodation-icon;
   }
 
   [feature = 'tourism_hotel'][zoom >= 17] {
     marker-file: url('symbols/tourism/hotel.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @accommodation-icon;
   }
 
   [feature = 'tourism_motel'][zoom >= 17] {
     marker-file: url('symbols/tourism/motel.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @accommodation-icon;
   }
@@ -430,7 +392,6 @@
     [information = 'terminal'] {
       marker-file: url('symbols/tourism/terminal.svg');
     }
-      marker-placement: interior;
       marker-fill: @man-made-icon;
       marker-clip: false;
   }
@@ -438,20 +399,17 @@
   [feature = 'amenity_embassy'][zoom >= 17] {
     marker-file: url('symbols/amenity/embassy.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_library'][zoom >= 16] {
     marker-file: url('symbols/amenity/library.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_courthouse'][zoom >= 16] {
     marker-file: url('symbols/amenity/courthouse.svg');
-    marker-placement: interior;
     marker-fill: @public-service;
     marker-clip: false;
   }
@@ -459,14 +417,12 @@
   [feature = 'amenity_community_centre'][zoom >= 17] {
     marker-file: url('symbols/amenity/community_centre.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_shower'][zoom >= 18] {
     marker-file: url('symbols/amenity/shower.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -476,14 +432,12 @@
   [feature = 'amenity_social_facility'][zoom >= 17] {
     marker-file: url('symbols/amenity/social_facility.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_townhall'][zoom >= 16] {
     marker-file: url('symbols/amenity/town_hall.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -496,7 +450,6 @@
     [zoom >= 18] {
       marker-file: url('symbols/man_made/mast.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
       ["tower:type" = 'lighting'] {
         marker-file: url('symbols/man_made/mast_lighting.svg');
@@ -518,7 +471,6 @@
     [zoom >= 17] {
       marker-file: url('symbols/man_made/tower_generic.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
       ["tower:type" = 'defensive'] {
         marker-file: url('symbols/man_made/tower_defensive.svg');
@@ -566,7 +518,6 @@
   [feature = 'man_made_communications_tower'][zoom >= 14] {
     marker-file: url('symbols/man_made/communications_tower.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -576,7 +527,6 @@
     [zoom >= 18] {
       marker-file: url('symbols/man_made/chimney.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
     }
   }
@@ -586,7 +536,6 @@
     [zoom >= 17] {
       marker-file: url('symbols/man_made/crane.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
     }
   }
@@ -597,7 +546,6 @@
     [zoom >= 16] {
       marker-file: url('symbols/man_made/telescope_dish.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
     }
   }
@@ -610,7 +558,6 @@
     [zoom >= 17] {
       marker-file: url('symbols/man_made/telescope_dome.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
       marker-clip: false;
     }
   }
@@ -618,14 +565,12 @@
   [feature = 'historic_city_gate'][zoom >= 17] {
     marker-file: url('symbols/historic/city_gate.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_museum'][zoom >= 16] {
     marker-file: url('symbols/tourism/museum.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -633,7 +578,6 @@
   [feature = 'amenity_doctors'][zoom >= 17] {
     marker-file: url('symbols/amenity/doctors.svg');
     marker-fill: @health-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -646,35 +590,30 @@
       marker-file: url('symbols/amenity/dentist.svg');
     }
     marker-fill: @health-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_hospital'][zoom >= 15] {
     marker-file: url('symbols/amenity/hospital.svg');
     marker-fill: @health-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_pharmacy'][zoom >= 17] {
     marker-file: url('symbols/amenity/pharmacy.svg');
     marker-fill: @health-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_veterinary'][zoom >= 17] {
     marker-file: url('symbols/amenity/veterinary.svg');
     marker-fill: @health-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_place_of_worship'][zoom >= 16] {
     marker-file: url('symbols/amenity/place_of_worship.svg');
     marker-fill: @religious-icon;
-    marker-placement: interior;
     marker-clip: false;
     [religion = 'christian'] {
       marker-file: url('symbols/religion/christian.svg');
@@ -709,35 +648,30 @@
   [feature = 'man_made_silo'][zoom >= 18] {
     marker-file: url('symbols/man_made/storage_tank.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_police'][zoom >= 16] {
     marker-file: url('symbols/amenity/police.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_vehicle_inspection'][zoom >= 17] {
     marker-file: url('symbols/amenity/vehicle_inspection.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_post_box'][zoom >= 19] {
     marker-file: url('symbols/amenity/post_box.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_post_office'][zoom >= 17] {
     marker-file: url('symbols/amenity/post_office.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -745,7 +679,6 @@
   [feature = 'amenity_recycling'][zoom >= 19] {
     marker-file: url('symbols/amenity/recycling.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -755,28 +688,24 @@
   [feature = 'amenity_telephone'][zoom >= 17] {
     marker-file: url('symbols/amenity/telephone.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'emergency_phone'][zoom >= 19] {
     marker-file: url('symbols/amenity/emergency_phone.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_theatre'][zoom >= 16] {
     marker-file: url('symbols/amenity/theatre.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_arts_centre'][zoom >= 17] {
     marker-file: url('symbols/amenity/arts_centre.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -785,7 +714,6 @@
     [zoom >= 19] {
       marker-file: url('symbols/amenity/toilets.svg');
       marker-fill: @amenity-brown;
-      marker-placement: interior;
       marker-clip: false;
       [access != ''][access != 'permissive'][access != 'yes'] {
         marker-opacity: 0.33;
@@ -796,7 +724,6 @@
   [feature = 'amenity_drinking_water'][zoom >= 17] {
     marker-file: url('symbols/amenity/drinking_water.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -806,7 +733,6 @@
   [feature = 'amenity_prison'][zoom >= 17] {
     marker-file: url('symbols/amenity/prison.svg');
     marker-fill: @public-service;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -818,7 +744,6 @@
         marker-width: 6;
       }
       marker-line-width: 0;
-      marker-placement: interior;
       marker-clip: false;
       marker-fill: darken(@societal_amenities, 80%);
     }
@@ -830,14 +755,12 @@
       marker-width: 6;
     }
     marker-line-width: 0;
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @shop-icon;
   }
 
   [feature = 'tourism_viewpoint'][zoom >= 16] {
     marker-file: url('symbols/tourism/viewpoint.svg');
-    marker-placement: interior;
     marker-fill: @amenity-brown;
     marker-clip: false;
   }
@@ -845,7 +768,6 @@
   [feature = 'man_made_water_tower'][zoom >= 17] {
     marker-file: url('symbols/man_made/water_tower.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -872,28 +794,24 @@
       marker-file: url('symbols/historic/stone.svg');
     }
     marker-fill: @memorials;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'man_made_obelisk'][zoom >= 17] {
     marker-file: url('symbols/historic/obelisk.svg');
     marker-fill: @memorials;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'historic_monument'][zoom >= 16] {
     marker-file: url('symbols/historic/monument.svg');
     marker-fill: @memorials;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'historic_fort'][zoom >= 16] {
     marker-file: url('symbols/historic/fort.svg');
     marker-fill: @memorials;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -903,7 +821,6 @@
   [feature = 'historic_manor'][zoom >= 16] {
     marker-file: url('symbols/historic/castle.svg');
     marker-fill: @memorials;
-    marker-placement: interior;
     marker-clip: false;
     [castle_type = 'palace'],
     [castle_type = 'stately'] {
@@ -925,13 +842,11 @@
   [feature = 'historic_archaeological_site'][zoom >= 16] {
     marker-file: url('symbols/historic/archaeological_site.svg');
     marker-fill: @culture;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_marketplace'][zoom >= 16][way_pixels > 3000],
   [feature = 'amenity_marketplace'][zoom >= 17] {
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @shop-icon;
     marker-file: url('symbols/shop/marketplace.svg');
@@ -941,7 +856,6 @@
     [shop != 'mall'][shop != 'massage'][zoom >= 17],
     [shop = 'supermarket'][zoom >= 16],
     [shop = 'department_store'][zoom >= 16] {
-      marker-placement: interior;
       marker-clip: false;
       marker-fill: @shop-icon;
     }
@@ -1281,7 +1195,6 @@
   [feature = 'advertising_column'][zoom >= 19]{
       marker-file: url('symbols/advertising_column.svg');
       marker-fill: @advertising-grey;
-      marker-placement: interior;
       marker-clip: false;
   }
 
@@ -1289,7 +1202,6 @@
   [feature = 'office'][zoom >= 18] {
     marker-width: 6;
     marker-line-width: 0;
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @office;
   }
@@ -1298,7 +1210,6 @@
   [feature = 'leisure_sports_centre'][sport = 'swimming'][zoom >= 17],
   [feature = 'leisure_swimming_area'][zoom >= 17] {
     marker-file: url('symbols/leisure/water_park.svg');
-    marker-placement: interior;
     marker-fill: @leisure-green;
     marker-clip: false;
   }
@@ -1306,7 +1217,6 @@
   [feature = 'leisure_fitness_centre'][zoom >= 17],
   [feature = 'leisure_fitness_station'][zoom >= 17] {
     marker-file: url('symbols/leisure/fitness.svg');
-    marker-placement: interior;
     marker-fill: @leisure-green;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
@@ -1316,7 +1226,6 @@
 
   [feature = 'leisure_dog_park'][zoom >= 17] {
     marker-file: url('symbols/shop/pet.svg');
-    marker-placement: interior;
     marker-fill: @leisure-green;
     marker-clip: false;
   }
@@ -1324,7 +1233,6 @@
   [feature = 'leisure_playground'][zoom >= 17] {
     marker-file: url('symbols/leisure/playground.svg');
     marker-fill: @leisure-green;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1334,21 +1242,18 @@
   [feature = 'leisure_miniature_golf'][zoom >= 17] {
     marker-file: url('symbols/leisure/miniature_golf.svg');
     marker-fill: @leisure-green;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'leisure_golf_course'][zoom >= 15] {
     marker-file: url('symbols/leisure/golf.svg');
     marker-fill: @leisure-green;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'tourism_picnic_site'][zoom >= 16] {
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @leisure-green;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1358,7 +1263,6 @@
   [feature = 'leisure_picnic_table'][zoom >= 17] {
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1368,7 +1272,6 @@
   [feature = 'leisure_firepit'][zoom >= 17] {
     marker-file: url('symbols/leisure/firepit.svg');
     marker-fill: @amenity-brown;
-    marker-placement: interior;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
@@ -1378,49 +1281,42 @@
   [feature = 'leisure_sauna'][zoom >= 17] {
      marker-file: url('symbols/leisure/sauna.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_beach_resort'][zoom >= 16] {
      marker-file: url('symbols/leisure/beach_resort.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_bowling_alley'][zoom >= 17] {
      marker-file: url('symbols/leisure/bowling_alley.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_outdoor_seating'][zoom >= 19] {
      marker-file: url('symbols/leisure/outdoor_seating.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_bird_hide'][zoom >= 17] {
      marker-file: url('symbols/leisure/bird_hide.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_amusement_arcade'][zoom >= 17] {
      marker-file: url('symbols/leisure/amusement_arcade.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
    }
 
   [feature = 'leisure_fishing'][zoom >= 17] {
      marker-file: url('symbols/leisure/fishing.svg');
      marker-fill: @leisure-green;
-     marker-placement: interior;
      marker-clip: false;
   }
 
@@ -1428,20 +1324,17 @@
   [feature = 'leisure_slipway'][zoom >= 17] {
     marker-file: url('symbols/leisure/slipway.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'amenity_boat_rental'][zoom >= 17] {
     marker-file: url('symbols/amenity/boat_rental.svg');
     marker-fill: @transportation-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'aeroway_helipad'][zoom >= 16] {
     marker-file: url('symbols/helipad.16.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @airtransport;
   }
@@ -1453,7 +1346,6 @@
     [way_pixels <= 192000],
     [way_pixels = null] {
       marker-file: url('symbols/aerodrome.12.svg');
-      marker-placement: interior;
       marker-clip: false;
       marker-fill: @airtransport;
     }
@@ -1461,14 +1353,12 @@
 
   [feature = 'amenity_ferry_terminal'][zoom >= 15] {
     marker-file: url('symbols/amenity/ferry.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @airtransport;
   }
 
   [feature = 'man_made_lighthouse'][zoom >= 15] {
     marker-file: url('symbols/man_made/lighthouse.svg');
-    marker-placement: interior;
     marker-clip: false;
     marker-fill: @man-made-icon;
   }
@@ -1476,27 +1366,23 @@
   [feature = 'natural_peak'][zoom >= 11] {
     marker-file: url('symbols/natural/peak.svg');
     marker-fill: @landform-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'natural_volcano'][zoom >= 11] {
     marker-file: url('symbols/natural/peak.svg');
     marker-fill: #d40000;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'natural_saddle'][zoom >= 15] {
     marker-file: url('symbols/natural/saddle.svg');
     marker-fill: @landform-color;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'natural_cave_entrance'][zoom >= 15] {
     marker-file: url('symbols/natural/cave.svg');
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1506,7 +1392,6 @@
     [zoom >= 15][name != null],
     [zoom >= 16] {
       marker-file: url('symbols/waterfall.svg');
-      marker-placement: interior;
       marker-clip: false;
       marker-fill: @water-text;
     }
@@ -1515,7 +1400,6 @@
   [feature = 'military_bunker'][zoom >= 17] {
     marker-file: url('symbols/bunker.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1524,7 +1408,6 @@
     [zoom >= 15][location = null],
     [zoom >= 19] {
       marker-file: url('symbols/generator_wind.svg');
-      marker-placement: interior;
       marker-fill: @man-made-icon;
       marker-clip: false;
     }
@@ -1532,7 +1415,6 @@
 
   [feature = 'man_made_windmill'][zoom >= 16] {
     marker-file: url('symbols/man_made/windmill.svg');
-    marker-placement: interior;
     marker-fill: @man-made-icon;
     marker-clip: false;
   }
@@ -1540,7 +1422,6 @@
   [feature = 'amenity_hunting_stand'][zoom >= 16] {
     marker-file: url('symbols/amenity/hunting_stand.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1551,7 +1432,6 @@
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
     }
   }
 }
@@ -1561,14 +1441,12 @@
   [feature = 'historic_wayside_cross'][zoom >= 16] {
     marker-file: url('symbols/man_made/cross.svg');
     marker-fill: @religious-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'historic_wayside_shrine'][zoom >= 17] {
     marker-file: url('symbols/historic/shrine.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1583,7 +1461,6 @@
       [feature = 'amenity_bicycle_parking'] { marker-file: url('symbols/amenity/bicycle_parking.svg'); }
       [feature = 'amenity_motorcycle_parking'] { marker-file: url('symbols/amenity/motorcycle_parking.svg'); }
       [feature = 'amenity_parking_entrance'] { marker-file: url('symbols/amenity/parking_entrance.svg'); }
-      marker-placement: interior;
       marker-clip: false;
       marker-fill: @transportation-icon;
       [access != ''][access != 'permissive'][access != 'yes'] { marker-opacity: 0.33; }
@@ -1593,7 +1470,6 @@
   [feature = 'railway_level_crossing'][zoom >= 14]::railway,
   [feature = 'railway_crossing'][zoom >= 15]::railway{
     marker-file: url('symbols/level_crossing.svg');
-    marker-placement: interior;
     [zoom >= 16] {
       marker-file: url('symbols/level_crossing2.svg');
     }
@@ -1601,14 +1477,12 @@
 
   [feature = 'highway_mini_roundabout'][zoom >= 17]::highway {
     marker-file: url('symbols/highway/mini_roundabout.svg');
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_gate']::barrier {
     [zoom >= 17] {
       marker-file: url('symbols/barrier/gate.svg');
-      marker-placement: interior;
       marker-clip: false;
     }
   }
@@ -1617,49 +1491,42 @@
   [feature = 'barrier_swing_gate'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/lift_gate.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_cattle_grid'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/cattle_grid.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_stile'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/stile.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_motorcycle_barrier'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/motorcycle_barrier.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_cycle_barrier'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/cycle_barrier.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_full-height_turnstile'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/full-height_turnstile.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
   [feature = 'barrier_kissing_gate'][zoom >= 17]::barrier {
     marker-file: url('symbols/barrier/kissing_gate.svg');
     marker-fill: @barrier-icon;
-    marker-placement: interior;
     marker-clip: false;
   }
 
@@ -1671,7 +1538,6 @@
       marker-width: 3;
       marker-line-width: 0;
       marker-fill: #7d7c7c;
-      marker-placement: interior;
 
       [zoom >= 18] {
         marker-width: 4;
@@ -1682,7 +1548,6 @@
   [feature = 'amenity_bench'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/bench.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
@@ -1691,7 +1556,6 @@
   [feature = 'amenity_waste_basket'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/waste_basket.svg');
     marker-fill: @man-made-icon;
-    marker-placement: interior;
     [access != ''][access != 'permissive'][access != 'yes'] {
       marker-opacity: 0.33;
     }
@@ -1704,7 +1568,6 @@
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
-      marker-placement: interior;
     }
   }
 }

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1774,7 +1774,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     [feature = 'amenity_bar'] {
       text-dy: 13;
     }
@@ -1799,7 +1798,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [feature = 'amenity_nightclub']{
         text-dy: 12;
       }
@@ -1816,7 +1814,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'leisure_sauna'][zoom >= 17] {
@@ -1829,7 +1826,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_car_rental'][zoom >= 17],
@@ -1850,7 +1846,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_courthouse'][zoom >= 17],
@@ -1876,7 +1871,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_vehicle_inspection'][zoom >= 17],
@@ -1905,7 +1899,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_bbq'][zoom >= 17],
@@ -1925,7 +1918,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     [access != ''][access != 'permissive'][access != 'yes'] {
       text-opacity: 0.33;
       text-halo-radius: 0;
@@ -1943,7 +1935,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_marketplace'][zoom >= 16][way_pixels > 3000],
@@ -1957,7 +1948,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: rgba(255, 255, 255, 0.6);
-    text-placement: interior;
   }
 
   [feature = 'natural_peak'][zoom >= 13],
@@ -1975,7 +1965,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'natural_cape'][zoom >= 14] {
@@ -1987,7 +1976,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'tourism_information'][zoom >= 19],
@@ -2001,7 +1989,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       text-dy: 11;
   }
 
@@ -2019,7 +2006,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2063,7 +2049,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'tourism_artwork'][zoom >= 17],
@@ -2089,7 +2074,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'military_bunker'][zoom >= 17] {
@@ -2102,7 +2086,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'leisure_miniature_golf'][zoom >= 17],
@@ -2115,7 +2098,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     text-dy: 13;
   }
 
@@ -2135,7 +2117,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2160,7 +2141,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2181,7 +2161,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [access != ''][access != 'permissive'][access != 'yes'] {
         text-fill: darken(@park, 50%);
       }
@@ -2279,7 +2258,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2357,7 +2335,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [feature = 'natural_reef'],
       [feature = 'natural_wetland'],
       [feature = 'natural_marsh'],
@@ -2487,7 +2464,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     [feature = 'natural_spring'] {
       text-dy: 6;
     }
@@ -2503,7 +2479,6 @@
     text-fill: @amenity-brown;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     text-face-name: @standard-font;
   }
 
@@ -2518,7 +2493,6 @@
     text-fill: @amenity-brown;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     text-face-name: @standard-font;
   }
 
@@ -2543,7 +2517,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     [feature = 'tourism_motel'] {
       text-dy: 13;
     }
@@ -2575,7 +2548,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'highway_bus_stop'],
@@ -2592,7 +2564,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [feature = 'highway_bus_stop'] {
         text-dy: 9;
       }
@@ -2624,7 +2595,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2638,7 +2608,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     [zoom >= 18] {
       text-dy: 10;
     }
@@ -2655,7 +2624,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_recycling'][recycling_type = 'centre'][zoom >= 17],
@@ -2669,7 +2637,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_hospital'][zoom >= 16],
@@ -2683,7 +2650,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
 
@@ -2722,7 +2688,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2736,7 +2701,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       text-dy: 8;
       text-fill: darken(@societal_amenities, 80%);
     }
@@ -2753,7 +2717,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
-      text-placement: interior;
     }
   }
 
@@ -2769,7 +2732,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
-      text-placement: interior;
       [shop = 'car_repair'] {
         text-fill: @amenity-brown;
       }
@@ -2827,7 +2789,6 @@
         text-face-name: @standard-font;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: rgba(255, 255, 255, 0.6);
-        text-placement: interior;
       }
     }
 
@@ -2842,7 +2803,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
-      text-placement: interior;
     }
   }
 
@@ -2858,7 +2818,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
-      text-placement: interior;
     }
   }
 
@@ -2871,7 +2830,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'power_plant'][is_building = 'no'][zoom >= 10],
@@ -2899,7 +2857,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2959,7 +2916,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2985,7 +2941,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -3025,7 +2980,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
@@ -3043,7 +2997,6 @@
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -3057,7 +3010,6 @@
     text-face-name: @oblique-fonts;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_hunting_stand'][zoom >= 17] {
@@ -3070,7 +3022,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'natural_tree'][zoom >= 17] {
@@ -3086,7 +3037,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'amenity_casino'][zoom >= 17] {
@@ -3099,7 +3049,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'tourism_attraction'][zoom >= 17][is_building = 'no'] {
@@ -3110,7 +3059,6 @@
     text-fill: @tourism;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
     text-face-name: @standard-font;
   }
 }
@@ -3131,7 +3079,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [access != ''][access != 'permissive'][access != 'yes'] {
         text-opacity: 0.33;
         text-halo-radius: 0;
@@ -3154,7 +3101,6 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 }
 

--- a/stations.mss
+++ b/stations.mss
@@ -16,7 +16,6 @@
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: 0;
-      text-placement: interior;
     }
   }
 
@@ -42,7 +41,6 @@
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.5; // -0.15 em
-      text-placement: interior;
     }
     [zoom >= 15] {
       marker-width: 9;
@@ -74,7 +72,6 @@
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
-      text-placement: interior;
     }
   }
 
@@ -99,7 +96,6 @@
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
-      text-placement: interior;
     }
   }
 
@@ -124,7 +120,6 @@
       text-halo-fill: @standard-halo-fill;
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
-      text-placement: interior;
     }
   }
 }

--- a/stations.mss
+++ b/stations.mss
@@ -4,7 +4,6 @@
 #stations {
   [railway = 'subway_entrance'][zoom >= 18] {
     marker-file: url('symbols/entrance.10.svg');
-    marker-placement: interior;
     marker-fill: @transportation-icon;
     marker-clip: false;
     [zoom >= 19] {
@@ -21,7 +20,6 @@
 
   [railway = 'station'][zoom >= 12] {
     marker-file: url('symbols/square.svg');
-    marker-placement: interior;
     marker-fill: @station-color;
     marker-clip: false;
     [station != 'subway'] {
@@ -54,7 +52,6 @@
   [railway = 'halt'] {
     [zoom >= 13] {
       marker-file: url('symbols/square.svg');
-      marker-placement: interior;
       marker-fill: @station-color;
       marker-width: 4;
       marker-clip: false;
@@ -78,7 +75,6 @@
   [aerialway = 'station']::aerialway {
     [zoom >= 13] {
       marker-file: url('symbols/square.svg');
-      marker-placement: interior;
       marker-fill: @station-color;
       marker-width: 4;
       marker-clip: false;
@@ -102,7 +98,6 @@
   [railway = 'tram_stop'] {
     [zoom >= 14] {
       marker-file: url('symbols/square.svg');
-      marker-placement: interior;
       marker-fill: @station-color;
       marker-width: 4;
       marker-clip: false;

--- a/water-features.mss
+++ b/water-features.mss
@@ -128,9 +128,6 @@
       text-fill: #222;
       text-size: 10;
       text-face-name: @book-fonts;
-      #text-poly {
-        text-placement: interior;
-      }
       #text-line {
         text-placement: line;
         text-dy: 8;
@@ -154,9 +151,6 @@
       text-fill: #222;
       text-size: 10;
       text-face-name: @book-fonts;
-      #text-poly {
-        text-placement: interior;
-      }
       #text-line {
         text-placement: line;
         text-spacing: 400;

--- a/water.mss
+++ b/water.mss
@@ -380,7 +380,6 @@
     text-face-name: @oblique-fonts;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: point;
     [zoom >= 15] {
       text-size: 12;
       text-wrap-width: 37; // 3.1 em


### PR DESCRIPTION
### Changes proposed in this pull request:
- Remove `text-placement: interior` from features in `text-point` and other layers

Since the layers `text-point`, `stations`, `text-low-priority`, and `building-text` all use ST_PointOnSurface it is no longer necessary to use `text-placement: interior` except for features in text-poly-low-zoom (z9 and below)

- Remove `marker-placement: interior` 

This code is no longer needed because all layers used to place markers (`amenity-points`, `amenity-low-priority`, `station`) now use ST_PointOnSurface to select a point

- Remove one instance of unneeded code `text-placement: point` from natural_strait - this is the default text placement and does not need to be explicitly stated

Test rendering is unchanged.