### PR TITLE
[WIP] Render natural=water (lakes, lagoons) differently when tagged salt=yes.

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -236,7 +236,8 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               OR tags->'basin' IN ('detention', 'infiltration')
-              THEN 'yes' ELSE 'no' END AS int_intermittent
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            CASE WHEN tags->'salt' IN ('yes') THEN 'yes' ELSE 'no' END AS int_salt
           FROM planet_osm_polygon
           WHERE
             (waterway IN ('dock', 'riverbank')
@@ -1524,6 +1525,7 @@ Layer:
                                 ELSE 'other' END AS shop,
               CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building,
               tags -> 'operator' AS operator,
+              CASE WHEN tags->'salt' IN ('yes') THEN 'yes' ELSE 'no' END AS int_salt,
               ref,
               way_area,
               COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels

--- a/water.mss
+++ b/water.mss
@@ -1,4 +1,5 @@
 @water-text: #4d80b3;
+@water-salt: #f1dddf;
 @glacier: #ddecec;
 @glacier-line: #9cf;
 
@@ -62,6 +63,9 @@
     [zoom >= 8] {
       [int_intermittent = 'no'] {
         polygon-fill: @water-color;
+        [natural = 'water'][int_salt = 'yes'] {
+          polygon-fill: @water-salt;
+        }
         [way_pixels >= 4] {
           polygon-gamma: 0.75;
         }
@@ -365,6 +369,7 @@
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
+      [int_salt = 'yes'] { text-halo-fill: @water-salt; }
       text-placement: interior;
     }
   }

--- a/water.mss
+++ b/water.mss
@@ -1,5 +1,4 @@
 @water-text: #4d80b3;
-@water-salt: #f1dddf;
 @glacier: #ddecec;
 @glacier-line: #9cf;
 
@@ -64,7 +63,10 @@
       [int_intermittent = 'no'] {
         polygon-fill: @water-color;
         [natural = 'water'][int_salt = 'yes'] {
-          polygon-fill: @water-salt;
+          polygon-pattern-file: url('symbols/salt-dots-2.png');
+          polygon-pattern-alignment: global;
+          [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
+          [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
         }
         [way_pixels >= 4] {
           polygon-gamma: 0.75;
@@ -369,7 +371,6 @@
       text-face-name: @oblique-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      [int_salt = 'yes'] { text-halo-fill: @water-salt; }
       text-placement: interior;
     }
   }


### PR DESCRIPTION
Fixes #3893 

Changes proposed in this pull request:
Render salt water areas in old pink color. This does not include salt ponds (might come soon), and does not include seas/oceans.

Test rendering with links to the example places:

https://www.openstreetmap.org/#map=13/37.9948/-0.7054

Before
![Screenshot_20190924_145328](https://user-images.githubusercontent.com/167327/65513189-1a2ef580-dedb-11e9-8ac3-b86e711a4984.png)

After
![Screenshot_20190924_145031](https://user-images.githubusercontent.com/167327/65513099-e18f1c00-deda-11e9-9b23-55036f4e7712.png)

I just noticed that this pink is close to mud and industrial zone, so most probably will need some changes, bu the basics are in.

Also nevermind that my render does not show sea/ocean, I have a bug with kosmtik.