### PR TITLE
Precedence of junctions over POIs

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1383,6 +1383,52 @@ Layer:
     properties:
       cache-features: true
       minzoom: 12
+  - id: junctions
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            highway,
+            junction,
+            ref,
+            name,
+            NULL AS way_pixels
+          FROM planet_osm_point
+          WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
+        UNION ALL
+          SELECT
+            way,
+            highway,
+            junction,
+            ref,
+            name,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+          FROM planet_osm_polygon
+          WHERE junction = 'yes'
+          ORDER BY way_pixels DESC NULLS LAST
+        ) AS junctions
+    properties:
+      minzoom: 11
+  - id: bridge-text
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            man_made,
+            name
+          FROM planet_osm_polygon
+          WHERE man_made = 'bridge'
+          ORDER BY way_area DESC
+        ) AS bridge_text
+    properties:
+      minzoom: 11
   - id: amenity-points
     class: points
     geometry: point
@@ -1683,52 +1729,6 @@ Layer:
     properties:
       minzoom: 10
       maxzoom: 12
-  - id: junctions
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            highway,
-            junction,
-            ref,
-            name,
-            NULL AS way_pixels
-          FROM planet_osm_point
-          WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
-        UNION ALL
-          SELECT
-            way,
-            highway,
-            junction,
-            ref,
-            name,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
-          FROM planet_osm_polygon
-          WHERE junction = 'yes'
-          ORDER BY way_pixels DESC NULLS LAST
-        ) AS junctions
-    properties:
-      minzoom: 11
-  - id: bridge-text
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            man_made,
-            name
-          FROM planet_osm_polygon
-          WHERE man_made = 'bridge'
-          ORDER BY way_area DESC
-        ) AS bridge_text
-    properties:
-      minzoom: 11
   - id: roads-text-ref
     geometry: linestring
     <<: *extents


### PR DESCRIPTION
Changes proposed in this pull request:
- Give junction names and bridge names precedence over amenity-points.

Test rendering with links to the example places:

Before:
![before](https://user-images.githubusercontent.com/6830724/65833922-2d6c0780-e2c5-11e9-97db-3297d58c3fa1.png)

After:
![after](https://user-images.githubusercontent.com/6830724/65833924-33fa7f00-e2c5-11e9-9bbf-e734e5b677e0.png)

Rationale:
Often I see junction names that appear on z15, but later disappear on z16 or z17 because of some shops near to the junction, just to re-appear again on higher zoom levels when there is enough space for both, the junction name and the shop icon. I think the junction name is more important as the shop icon. Furthermore, for more consistency features that have yet appeared on z15 should in general not be hidden later by features that only appear on z16 or z17.

The “bridge” layer was just next to the junction layer. I've moved it also, because I think the same arguments apply here. There should be fewer conflicts anyway, because bridges often pass over water - but not always!