### PR TITLE
Fix rendering of water body labels

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2317,7 +2317,6 @@
     }
   }
 
-  [feature = 'natural_bay'][zoom >= 14],
   [feature = 'natural_spring'][zoom >= 16] {
     text-name: "[name]";
     text-size: 10;
@@ -2327,9 +2326,7 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    [feature = 'natural_spring'] {
-      text-dy: 6;
-    }
+    text-dy: 6;
   }
 
   [feature = 'amenity_atm'][zoom >= 19],

--- a/water.mss
+++ b/water.mss
@@ -341,12 +341,15 @@
   [feature = 'landuse_basin'],
   [feature = 'waterway_dock'] {
     [zoom >= 0][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 17] {
+    [zoom >= 14][way_pixels <= 768000][feature = 'natural_bay'],
+    [zoom >= 14][way_pixels <= 768000][feature = 'natural_strait'],
+    [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: 10;
       text-wrap-width: 25; // 2.5 em
       text-line-spacing: -1.5; // -0.15 em
-      [way_pixels > 12000] {
+      [way_pixels > 12000],
+      [zoom >= 15][feature = 'natural_strait'] {
         text-size: 12;
         text-wrap-width: 37; // 3.1 em
         text-line-spacing: -1.6; // -0.13 em
@@ -366,24 +369,6 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: interior;
-    }
-  }
-}
-
-#text-point[zoom >= 14] {
-  [feature = 'natural_strait'] {
-    text-name: "[name]";
-    text-size: 10;
-    text-wrap-width: 25; // 2.5 em
-    text-line-spacing: -1.5; // -0.15 em
-    text-fill: @water-text;
-    text-face-name: @oblique-fonts;
-    text-halo-radius: @standard-halo-radius;
-    text-halo-fill: @standard-halo-fill;
-    [zoom >= 15] {
-      text-size: 12;
-      text-wrap-width: 37; // 3.1 em
-      text-line-spacing: -1.6; // -0.13 em
     }
   }
 }


### PR DESCRIPTION
This is a bugfix PR for water body labels.

Changes proposed in this pull request:
- Since #3764 (Stop label rendering for too big areas) water body labels disappear once the surface is quite big. In the same PR I had introduced a bug that makes labels appear again from z17. Consider the [Lagune Pouto](https://www.openstreetmap.org/#map=17/5.36215/-3.77535): The label correctly appears at z11, correctly disappears at z16 and incorrectly appears again at z17. The current PR will fix this.
- `natural_bay` has rendering rules both in `amenity-points.mss` (rendering a label in regular font) and `water.mss` (rendering a label in italic font). Consider the [Baie des sirènes](https://www.openstreetmap.org/#map=17/4.64612/-6.91497): The label is rendered in a regular font up to z16, but starting from z17 with an italic font. This PR puts all the rendering rules for `natural_bay` at the same place and unifies the font face (using italic).
- In `water.mss` there is almost duplicate code for `natural_strait`. This PR unifies the code in one single block.

The XML code that Carto produces decreases slightly with this PR.