### PR TITLE
Use ST_PointOnSurface for country and state text labels

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -38,7 +38,6 @@
     text-face-name: @book-fonts;
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
-    text-placement: interior;
     text-character-spacing: 0.5;
   }
 }
@@ -55,7 +54,6 @@
     text-face-name: @oblique-fonts;
     text-halo-fill: @standard-halo-fill;
     text-halo-radius: @standard-halo-radius * 1.5;
-    text-placement: interior;
     [zoom >= 7] {
       text-size: 11;
       text-wrap-width: 50; // 4.5 em

--- a/project.mml
+++ b/project.mml
@@ -1198,11 +1198,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name
           FROM planet_osm_polygon
-          WHERE boundary = 'administrative'
+          WHERE way && !bbox!
+            AND boundary = 'administrative'
             AND admin_level = '2'
             AND name IS NOT NULL
             AND way_area > 100*!pixel_width!::real*!pixel_height!::real
@@ -1241,12 +1242,13 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
             ref
           FROM planet_osm_polygon
-          WHERE boundary = 'administrative'
+          WHERE way && !bbox!
+            AND boundary = 'administrative'
             AND admin_level = '4'
             AND name IS NOT NULL
             AND way_area > 100*!pixel_width!::real*!pixel_height!::real


### PR DESCRIPTION
Related to #3201 - migration to server-side vector tiles

## Changes proposed in this pull request:
- Change `country-names` and `state-names` layers to use a point generated by `ST_PointOnSurface` instead of a polygon. This is necessary to be able to use vector tiles with this style.
- Remove `text-placement: interior;` from `place-names` since this code is no longer needed; the label will be placed on the point created

## Test renderings

The label placement with `ST_pointonsurface` is better in some cases but worse than the current placement in others.

Liechtenstein country label:
![z10-compare-liechtenstein](https://user-images.githubusercontent.com/42757252/66183352-9d0e3800-e6b3-11e9-847b-2fb6d8a65342.png)

Libya provinces:
![z6-libya-compare-st](https://user-images.githubusercontent.com/42757252/66183345-9384d000-e6b3-11e9-9924-0d1288235a38.png)