### PR TITLE
Change text-poly-low-zoom to use ST_PointOnSurface

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1597,7 +1597,6 @@
     text-face-name: @oblique-fonts;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    text-placement: interior;
   }
 
   [feature = 'place_locality'][zoom >= 16] {
@@ -2056,7 +2055,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [feature = 'landuse_military'] {
         text-fill: darken(@military, 40%);
       }
@@ -2096,7 +2094,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 
@@ -2746,7 +2743,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
       [feature = 'natural_scree'],
       [feature = 'natural_shingle'],
       [feature = 'natural_bare_rock'] {
@@ -2829,7 +2825,6 @@
       text-face-name: @landcover-face-name;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-placement: interior;
     }
   }
 

--- a/project.mml
+++ b/project.mml
@@ -1975,7 +1975,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             COALESCE(
               'landuse_' || CASE WHEN landuse IN ('forest', 'military', 'farmland') THEN landuse ELSE NULL END,
@@ -1992,7 +1992,8 @@ Layer:
             name,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
-          WHERE (landuse IN ('forest', 'military', 'farmland')
+          WHERE way && !bbox!
+            AND (landuse IN ('forest', 'military', 'farmland')
               OR military IN ('danger_area')
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
               OR "place" IN ('island')


### PR DESCRIPTION
Related to #3201 - migration to server-side vector tiles

## Changes proposed in this pull request:
- Change `text-poly-low-zoom` layer to use `ST_PointOnSurface` - this is necessary to use this style with vector tiles, and this makes the low zoom rendering consistent with the label placement at higher zoom levels (z10 and up
- Also remove unneeded `text-placment: interior` for the polygon features affected - this code is no longer needed, because the labels are placed on a point, not in a polygon, by Mapnik at the time of rendering.

## Test rendering:

z8 Libya
https://www.openstreetmap.org/#map=8/27.330/17.216
![z8-libya-rocks-compare-st](https://user-images.githubusercontent.com/42757252/66186933-8ae5c700-e6be-11e9-97fd-bea698a7073d.png)

z9 Wan am namus
https://www.openstreetmap.org/#map=9/24.8628/17.7742
![z9-wan-am-namus-compare](https://user-images.githubusercontent.com/42757252/66186930-8a4d3080-e6be-11e9-9ac4-8e87d37b8e05.png)