### PR TITLE
Move parking back to amenity-points layers, change way_pixels limit and fix initial zoom level

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2929,7 +2929,7 @@
   [feature = 'amenity_bicycle_parking'],
   [feature = 'amenity_motorcycle_parking'],
   [feature = 'amenity_parking_entrance'] {
-    [zoom >= 10][way_pixels > 900],
+    [zoom >= 14][way_pixels > 900],
     [zoom >= 18] {
       text-name: "[name]";
       text-size: @standard-font-size;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1434,21 +1434,6 @@
       marker-fill: @man-made-icon;
     }
   }
-}
-
-#amenity-low-priority {
-  [feature = 'man_made_cross'][zoom >= 16],
-  [feature = 'historic_wayside_cross'][zoom >= 16] {
-    marker-file: url('symbols/man_made/cross.svg');
-    marker-fill: @religious-icon;
-    marker-clip: false;
-  }
-
-  [feature = 'historic_wayside_shrine'][zoom >= 17] {
-    marker-file: url('symbols/historic/shrine.svg');
-    marker-fill: @man-made-icon;
-    marker-clip: false;
-  }
 
   [feature = 'amenity_parking'],
   [feature = 'amenity_bicycle_parking'],
@@ -1465,6 +1450,21 @@
       marker-fill: @transportation-icon;
       [access != ''][access != 'permissive'][access != 'yes'] { marker-opacity: 0.33; }
     }
+  }
+}
+
+#amenity-low-priority {
+  [feature = 'man_made_cross'][zoom >= 16],
+  [feature = 'historic_wayside_cross'][zoom >= 16] {
+    marker-file: url('symbols/man_made/cross.svg');
+    marker-fill: @religious-icon;
+    marker-clip: false;
+  }
+
+  [feature = 'historic_wayside_shrine'][zoom >= 17] {
+    marker-file: url('symbols/historic/shrine.svg');
+    marker-fill: @man-made-icon;
+    marker-clip: false;
   }
 
   [feature = 'railway_level_crossing'][zoom >= 14]::railway,
@@ -2924,9 +2924,7 @@
     text-halo-fill: @standard-halo-fill;
     text-face-name: @standard-font;
   }
-}
 
-#text-low-priority {
   [feature = 'amenity_parking'],
   [feature = 'amenity_bicycle_parking'],
   [feature = 'amenity_motorcycle_parking'],
@@ -2950,7 +2948,9 @@
       [feature = 'amenity_motorcycle_parking'] { text-dy: 12; }
     }
   }
+}
 
+#text-low-priority {
   [feature = 'man_made_cross'][zoom >= 17],
   [feature = 'historic_wayside_cross'][zoom >= 17],
   [feature = 'historic_wayside_shrine'][zoom >= 17] {

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1439,7 +1439,7 @@
   [feature = 'amenity_bicycle_parking'],
   [feature = 'amenity_motorcycle_parking'],
   [feature = 'amenity_parking_entrance'] {
-    [zoom >= 14][way_pixels > 900],
+    [zoom >= 14][way_pixels > 750],
     [zoom >= 17][feature = 'amenity_parking'],
     [zoom >= 18] {
       [feature = 'amenity_parking'] { marker-file: url('symbols/amenity/parking.svg'); }
@@ -2929,7 +2929,7 @@
   [feature = 'amenity_bicycle_parking'],
   [feature = 'amenity_motorcycle_parking'],
   [feature = 'amenity_parking_entrance'] {
-    [zoom >= 14][way_pixels > 900],
+    [zoom >= 14][way_pixels > 3000],
     [zoom >= 18] {
       text-name: "[name]";
       text-size: @standard-font-size;

--- a/project.mml
+++ b/project.mml
@@ -1460,6 +1460,13 @@ Layer:
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
                 'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier ELSE NULL END,
                 'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway ELSE NULL END,
+                'amenity_' || CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
+                'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity ELSE NULL END,
+                'amenity_' || CASE WHEN amenity IN ('parking_entrance')
+                                        AND tags->'parking' IN ('underground')
+                                        AND (access IS NULL OR access NOT IN ('private', 'no'))
+                                        AND way_area IS NULL
+                                   THEN amenity ELSE NULL END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism ELSE NULL END,
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place ELSE NULL END
               ) AS feature,
@@ -2194,13 +2201,6 @@ Layer:
             COALESCE(
               'highway_' || CASE WHEN highway IN ('mini_roundabout') AND way_area IS NULL THEN highway ELSE NULL END,
               'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') AND way_area IS NULL THEN railway ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking') THEN amenity ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('parking_entrance')
-                                      AND tags->'parking' IN ('underground')
-                                      AND (access IS NULL OR access NOT IN ('private', 'no'))
-                                      AND way_area IS NULL
-                                 THEN amenity ELSE NULL END,
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic ELSE NULL END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made ELSE NULL END,
@@ -2243,7 +2243,7 @@ Layer:
               ) _
             WHERE highway IN ('mini_roundabout')
                OR railway IN ('level_crossing', 'crossing')
-               OR amenity IN ('parking', 'parking_entrance', 'bicycle_parking', 'motorcycle_parking', 'bench', 'waste_basket', 'waste_disposal')
+               OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
                OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
@@ -2262,4 +2262,4 @@ Layer:
       # see https://github.com/gravitystorm/openstreetmap-carto/pull/1349#issuecomment-77805678
       table: *amenity_low_priority_sql
     properties:
-      minzoom: 10
+      minzoom: 17


### PR DESCRIPTION
Fixes #3908
Partial revert of #3874 
Follow-up to fix bug in #3612

## Changes proposed in this pull request:

### 1) Move parking back to amenity-points layers
- Moves `amenity=parking`, `amenity=motorcycle_parking`, `amenity=bicycle_parking` and `amenity=parking_entrance` to `amenity-points` and `text-point` layers instead of `amenity-low-priority` and `text-low-priority`
- This fixes bugs where the building text or address number is shown instead of the icon and parking text, introduced by #3874 
- Parking had previously been rendered in both amenity-points and amenity-low-priority.
- Recently PR #3874 had consolidated parking rendering in low-priority only, but this leads to problems when there is a building or an address on the same feature
- This commit moves parking back to the amenity-points layer, but near the end. 
- The minzoom for text-low-priority is now changed back to z17 since there are no longer any features rendered sooner that this in the layer.

### 2) Change initial zoom level to be z14 for both text label and icon
- This bug was introduced by my PR #3612 where the initial zoom was changed to z14 for the icon, but not for the text. 
- In PR #3612 it was planned to render parking from z14 only, however this was not changed for the text labels, only for the icon.
- This commit fixes the parking rendering at z10 to z13, though in practice almost no parking lots are large enough to have been rendered at these levels.

### 3) Change way_pixels limit for parking icon and text
- Start showing icon at 750 pixels instead of 900, but don't show text label till 3000 way_pixels, as with most other features
- Only `amenity=marketplace` and parking have an icon that appears based on `way_pixels`. The other uses 3000 way_pixels, which is the limit also used for all text labels.
- Since the icon is only 14 x 14 pixels, it's reasonable to show it one zoom level sooner than the text, at 750 way_pixels (1/4 of 3000 - so 1 zoom level sooner)

## Test renderings 

### Hanau, Germany
https://www.openstreetmap.org/way/221032567#map=17/50.13289/8.92118
z16 compare current (left), after (right)
![z16-parkhaus-compare](https://user-images.githubusercontent.com/42757252/66251341-1b3d0e00-e78a-11e9-9b17-130b4c1a5b72.png)

z17
![z17-parkhaus-after](https://user-images.githubusercontent.com/42757252/66251344-1bd5a480-e78a-11e9-9b90-2a4241a4db54.png)

z18
![z18-parkhaus-compare](https://user-images.githubusercontent.com/42757252/66251346-1d9f6800-e78a-11e9-8e66-3f469c4b6b83.png)

### Montpellier, France
https://www.openstreetmap.org/#map=17/43.61338/3.88557

z16 comparison (left before, right after)
![z16-parking-joffre-compare](https://user-images.githubusercontent.com/42757252/66251381-77a02d80-e78a-11e9-9c0f-3e31a740e724.png)

z17
![z17-parking-joffre-compare](https://user-images.githubusercontent.com/42757252/66251382-7969f100-e78a-11e9-8322-63667b9a35a0.png)