### PR TITLE
Remove rendering of waterway=wadi

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -214,7 +214,7 @@ Layer:
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'no' AS bridge
           FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
             AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ORDER BY COALESCE(layer,0)
         ) AS water_lines
@@ -594,7 +594,7 @@ Layer:
             WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
-              AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi'))
+              AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
           ) AS features
         ) AS line_barriers
     properties:
@@ -916,7 +916,7 @@ Layer:
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
             'yes' AS bridge
           FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
             AND bridge IN ('yes', 'aqueduct')
           ORDER BY COALESCE(layer,0)
         ) AS waterway_bridges
@@ -2118,7 +2118,7 @@ Layer:
               THEN 'yes' ELSE 'no' END AS int_intermittent,
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
-          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'wadi')
+          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
                  OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL or tunnel != 'culvert')
             AND name IS NOT NULL

--- a/water.mss
+++ b/water.mss
@@ -122,8 +122,7 @@
 
 .water-lines {
   [waterway = 'canal'][zoom >= 12],
-  [waterway = 'river'][zoom >= 12],
-  [waterway = 'wadi'][zoom >= 13] {
+  [waterway = 'river'][zoom >= 12] {
     // the additional line of land color is used to provide a background for dashed casings
     [int_tunnel = 'yes'] {
       background/line-color: @land-color;
@@ -148,8 +147,7 @@
     water/line-cap: round;
     water/line-join: round;
 
-    [int_intermittent = 'yes'],
-    [waterway = 'wadi'] {
+    [int_intermittent = 'yes'] {
       [bridge = 'yes'][zoom >= 14] {
         bridgefill/line-color: white;
         bridgefill/line-join: round;


### PR DESCRIPTION
Fixes #1365

## Changes proposed in this pull request:
- Removes rendering of deprecated feature waterway=wadi, which should instead be mapped as `intermittent=yes` + `waterway=stream` or `waterway=river` if it is a waterway, or as `natural=valley` if it is a dry valley. Removing the rendering will support mappers in consistent use of these tags
- Does not remove wadi from the list of linestring exceptions in `openstreetmap-carto.lua` because these features should be imported as linear ways, in case this style is adapted for other purposes. 

### Trend of `waterway=wadi` usage over time:

![waterway-wadi-taghistory](https://user-images.githubusercontent.com/42757252/66732831-6517a980-ee98-11e9-86a6-8082ffc21877.png)

In comparison, intermittent=yes (which is used with waterway=* over 92% of the time) has increased to over 2 million uses, with over 1.9 million waterway=stream + intermittent=yes 

Also, as mentioned in the related issue (https://github.com/gravitystorm/openstreetmap-carto/issues/1365#issuecomment-464341386), "three groups from individual mappers in Tunisia, Pakistan and southern Turkey from about 4 years ago account for nearly half of the data].