### PR TITLE
Use ST_PointOnSurface for roads-area-text-name

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1796,13 +1796,13 @@ Layer:
             name
           FROM planet_osm_polygon
           WHERE way && !bbox!
-            AND highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
+            AND (highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
               OR (railway IN ('platform')
                   AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                   AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                   AND (covered NOT IN ('yes') OR covered IS NULL))
               OR (place IN ('square')
-                  AND (leisure IS NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden')))
+                  AND (leisure IS NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden'))))
             AND name IS NOT NULL
           ORDER BY way_area DESC
         ) AS roads_area_text_name

--- a/project.mml
+++ b/project.mml
@@ -1788,20 +1788,21 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             highway,
             place,
             leisure,
             name
           FROM planet_osm_polygon
-          WHERE highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
-            OR (railway IN ('platform')
-                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                AND (covered NOT IN ('yes') OR covered IS NULL))
-            OR (place IN ('square')
-                AND (leisure IS NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden')))
+          WHERE way && !bbox!
+            AND highway IN ('residential', 'unclassified', 'pedestrian', 'service', 'footway', 'cycleway', 'living_street', 'track', 'path', 'platform')
+              OR (railway IN ('platform')
+                  AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                  AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
+                  AND (covered NOT IN ('yes') OR covered IS NULL))
+              OR (place IN ('square')
+                  AND (leisure IS NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden')))
             AND name IS NOT NULL
           ORDER BY way_area DESC
         ) AS roads_area_text_name

--- a/roads.mss
+++ b/roads.mss
@@ -3309,7 +3309,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     text-name: "[name]";
     text-size: 11;
     text-face-name: @book-fonts;
-    text-placement: interior;
     text-wrap-width: 30; // 2.7 em
     text-line-spacing: -1.7; // -0.15 em
   }


### PR DESCRIPTION
Related to #3201

Changes proposed in this pull request:
- Use ST_PointOnSurface for roads-area-text-name in project.mll
- Remove no longer needed `text-placement: interior` from roads.mss

This is necessary to be able to use this style with server-side vector tiles.

## Test rendering

https://www.openstreetmap.org/#map=18/47.13734/9.52334
before:
![z18-peter-kaiser-platz-before](https://user-images.githubusercontent.com/42757252/66808126-8eead200-ef65-11e9-83b0-1dbc5474fde2.png)

after:
![z18-peter-kaiser-platz-st-pointonsurface](https://user-images.githubusercontent.com/42757252/66808136-91e5c280-ef65-11e9-890f-b5ac37ff020c.png)