### PR TITLE
Use ST_PointOnSurface for junctions

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1391,14 +1391,15 @@ Layer:
           WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
         UNION ALL
           SELECT
-            way,
+            ST_PointOnSurface(way) AS way,
             highway,
             junction,
             ref,
             name,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE junction = 'yes'
+          WHERE way && !bbox!
+            AND junction = 'yes'
           ORDER BY way_pixels DESC NULLS LAST
         ) AS junctions
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1388,7 +1388,8 @@ Layer:
             name,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes'
+          WHERE way && !bbox!
+            AND (highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes')
         UNION ALL
           SELECT
             ST_PointOnSurface(way) AS way,


### PR DESCRIPTION
Related to #3201

Changes proposed in this pull request:
- Use ST_PointOnSurface for `junctions` layer in project.mml

Test rendering:

Before
![junction-area-before](https://user-images.githubusercontent.com/42757252/66808295-e0935c80-ef65-11e9-92a2-678f1666daaf.png)

After
![z17-junction-area-after](https://user-images.githubusercontent.com/42757252/66808245-cce7f600-ef65-11e9-9186-25b3f3b6d4cd.png)

This PR will need to be updated after #3915 is merged