### PR TITLE
Do not render stream, ditch and drain tunnels at z14

### DIFF
--- a/water.mss
+++ b/water.mss
@@ -194,7 +194,7 @@
   [waterway = 'stream'],
   [waterway = 'ditch'],
   [waterway = 'drain'] {
-    [int_intermittent != 'yes'][zoom >= 14],
+    [int_intermittent != 'yes'][int_tunnel != 'yes'][zoom >= 14],
     [zoom >= 15] {
       // the additional line of land color is used to provide a background for dashed casings
       [int_tunnel = 'yes'] {


### PR DESCRIPTION
Fixes #3676

### Changes proposed in this pull request:
- Do not render stream, ditch and drain tunnels at z14

### Explanation:
- Currently stream, ditch and drain waterway tunnels are rendered the same as above-ground waterways at z14
- At z15 and above they have a special tunnel rendering. 
- This commit removes the rendering at z14, since at this level intermittent streams are no longer rendered. It would not make sense to render stream culverts at z14 but not intermittent streams.

### Test rendering:

https:/www.openstreetmap.org/#map=15/36.9649/-121.9659
Before
![z15-rodeo-creek-same](https://user-images.githubusercontent.com/42757252/67138745-d2ee1780-f282-11e9-8289-ad2f7f6883ab.png)

![z14-rodeo-creek-before](https://user-images.githubusercontent.com/42757252/67138741-ca95dc80-f282-11e9-9e78-b31999159eae.png)

After
![z14-rodeo-creek-after-no-tunnel](https://user-images.githubusercontent.com/42757252/67138742-d08bbd80-f282-11e9-896c-1dbc5053c985.png)

**https:/www.openstreetmap.org/#map=15/37.1896/-122.2085**
Before
![z14-sempervirens-stream-tunnel-before](https://user-images.githubusercontent.com/42757252/67146319-d904e800-f2c4-11e9-9de6-b18279b6fb3e.png)

![z15-sempervirens-stream-tunnel-before](https://user-images.githubusercontent.com/42757252/67138748-de414300-f282-11e9-8ba4-8fa586551b85.png)

After
![z14-sempervirens-stream-tunnel-after](https://user-images.githubusercontent.com/42757252/67138749-e305f700-f282-11e9-9164-1053a2b43ab2.png)