### PR TITLE
Apply bbox to part of "addresses" query

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2097,7 +2097,7 @@ Layer:
             tags->'addr:unit' AS addr_unit,
             NULL AS way_pixels
           FROM planet_osm_point
-          WHERE way && !bbox! AND ("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL)
+          WHERE way && !bbox! AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL))
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:


### PR DESCRIPTION
Adding parenthesis around additional conditions allows to use index and prevents from selecting all rows from DB containing "addr:housename" or "addr:unit".

Fixes #3937 

Changes proposed in this pull request:
- Adding parenthesis around additional conditions

Test rendering with links to the example places:
No changes in rendering