### PR TITLE
Remove name from SQL select when unused

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -230,7 +230,6 @@ Layer:
             "natural",
             waterway,
             landuse,
-            name,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
@@ -323,8 +322,7 @@ Layer:
       table: |-
         (SELECT
             way,
-            waterway,
-            name
+            waterway
           FROM planet_osm_line
           WHERE waterway IN ('dam', 'weir', 'lock_gate')
         ) AS water_barriers_line
@@ -338,8 +336,7 @@ Layer:
       table: |-
         (SELECT
             way,
-            waterway,
-            name
+            waterway
           FROM planet_osm_polygon
           WHERE waterway IN ('dam', 'weir', 'lock_gate')
         ) AS water_barriers_poly
@@ -419,8 +416,7 @@ Layer:
         (SELECT
             way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            man_made,
-            name
+            man_made
           FROM planet_osm_polygon
           WHERE man_made = 'bridge'
         ) AS bridge
@@ -565,7 +561,6 @@ Layer:
         (SELECT
             way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            name,
             tourism
           FROM planet_osm_polygon
           WHERE tourism = 'theme_park'
@@ -901,7 +896,6 @@ Layer:
         (SELECT
             way,
             waterway,
-            name,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
@@ -1148,7 +1142,6 @@ Layer:
       table: |-
         (SELECT
             way,
-            name,
             boundary,
             tags->'protect_class' AS protect_class,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels


### PR DESCRIPTION
Changes proposed in this pull request:
- The column `name` was selected but not used for `water-areas`, `water-barriers-poly`, `water-barriers-line`, `bridge`,  `waterway-bridges`, `tourism-boundary`, and `protected-areas`. 
- The name labels for these features are rendered in different layers. 
- Therefore, `name` can be removed from the sql query for these layers

Test rendering is unchanged:

Before z16
![z16-name-test-before](https://user-images.githubusercontent.com/42757252/67449134-187c5d00-f654-11e9-8cb1-9a581c09ba72.png)

After
![z16-names-test-after](https://user-images.githubusercontent.com/42757252/67449193-56798100-f654-11e9-96b0-f41487250c11.png)
