### PR TITLE
Use ST_Boundary for admin-text & protected-areas-text

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2136,12 +2136,13 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_Boundary(way) as way,
             name,
             admin_level,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE boundary = 'administrative'
+          WHERE way && !bbox!
+            AND boundary = 'administrative'
             AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
             AND osm_id < 0
@@ -2156,13 +2157,14 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
+            ST_Boundary(way) as way,
             name,
             boundary,
             tags->'protect_class' AS protect_class,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
-          WHERE (boundary IN ('aboriginal_lands', 'national_park')
+          WHERE way && !bbox!
+            AND (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
                  OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
             AND name IS NOT NULL


### PR DESCRIPTION
Related to #3201 - Migration to vector tiles

Changes proposed in this pull request:
- Use ST_Boundary for admin-text & protected-areas-text

This creates a line geometry from the polygon in planet_osm_polygon for rendering the text labels along the boundaries of protected areas and administrative boundary areas. 

This is necessary for rendering vector tiles properly

Test rendering is unchanged
(Remember to test with metatile set to 8 in localconfig.json e.g.:
```
{
    "where": "metatile",
    "then": 8
  },
```

Before
![z16-wesaput-master-ST_Boundary](https://user-images.githubusercontent.com/42757252/67455370-5e432080-f668-11e9-902f-fe539b979246.png)

After
![z16-wesaput-after-ST_Boundary-screenshot](https://user-images.githubusercontent.com/42757252/67455439-89c60b00-f668-11e9-8781-2f91a1b5cd4c.png)