### PR TITLE
Remove way_pixels selection from bridge layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -418,7 +418,6 @@ Layer:
       table: |-
         (SELECT
             way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             man_made,
             name
           FROM planet_osm_polygon


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove way_pixels selection from bridge layer SQL query

The `bridge` layer for rendering man_made=bridge polygons does not use way_pixels, so this is not needed. Removing the line will slightly improve performance.

Test rendering is unchanged:

Before
![way_pixels-bridge-before](https://user-images.githubusercontent.com/42757252/67554498-81460100-f74a-11e9-8352-cc7b864bfb0f.png)

After
![way_pixels-bridge-after](https://user-images.githubusercontent.com/42757252/67554505-83a85b00-f74a-11e9-860a-18c128aea7bb.png)