### PR TITLE
Reduce landcover fading at mid-low zoom levels

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -11,9 +11,8 @@
 
 // --- "Base" landuses ---
 
-@built-up-lowzoom: #aaaaaa;
-@built-up-z11: #c0c0c0;
-@built-up-z12: #d0d0d0;
+@built-up-lowzoom: #d0d0d0;
+@built-up-z12: #d7d4d3;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
 @retail: #ffd6d1;           // Lch(89,16,30)
@@ -71,17 +70,11 @@
 
 #landcover-low-zoom[zoom < 10],
 #landcover[zoom >= 10] {
-  ::low-zoom[zoom < 10]                   { image-filters: scale-hsla(0,1,0,1,0.6,0.95,0,1); }
-  ::lower-mid-zoom[zoom >= 10][zoom < 11] { image-filters: scale-hsla(0,1,0,1,0.6,0.95,0,1); }
-  ::mid-zoom[zoom >= 11][zoom < 12]       { image-filters: scale-hsla(0,1,0,1,0.5,0.96,0,1); }
-  ::upper-mid-zoom[zoom >= 12][zoom < 13] { image-filters: scale-hsla(0,1,0,1,0.4,0.97,0,1); }
-  ::high-zoom[zoom >= 13]                 { image-filters: scale-hsla(0,1,0,1,0,  1,   0,1); }
+  ::low-zoom[zoom < 12] { image-filters: scale-hsla(0,1,0,1,0.2,1,0,1); }
+  ::high-zoom[zoom >= 12]                 { image-filters: scale-hsla(0,1,0,1,0,  1,   0,1); }
 
-  ::low-zoom[zoom < 10],
-  ::lower-mid-zoom[zoom >= 10][zoom < 11],
-  ::mid-zoom[zoom >= 11][zoom < 12],
-  ::upper-mid-zoom[zoom >= 12][zoom < 13],
-  ::high-zoom[zoom >= 13] {
+  ::low-zoom[zoom < 12],
+  ::high-zoom[zoom >= 12] {
 
   [feature = 'leisure_swimming_pool'][zoom >= 14] {
     polygon-fill: @water-color;
@@ -231,7 +224,6 @@
 
   [feature = 'landuse_residential'][zoom >= 8] {
     polygon-fill: @built-up-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-z11; }
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @residential; }
     [zoom >= 16] {
@@ -360,7 +352,6 @@
   [feature = 'amenity_marketplace'] {
     [zoom >= 8] {
       polygon-fill: @built-up-lowzoom;
-      [zoom >= 11] { polygon-fill: @built-up-z11; }
       [zoom >= 12] { polygon-fill: @built-up-z12; }
       [zoom >= 13] { polygon-fill: @retail; }
       [zoom >= 16] {
@@ -377,7 +368,6 @@
 
   [feature = 'landuse_industrial'][zoom >= 8] {
     polygon-fill: @built-up-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-z11; }
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @industrial; }
     [zoom >= 16] {
@@ -458,7 +448,6 @@
 
   [feature = 'landuse_commercial'][zoom >= 8] {
     polygon-fill: @built-up-lowzoom;
-    [zoom >= 11] { polygon-fill: @built-up-z11; }
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @commercial; }
     [zoom >= 16] {
@@ -591,9 +580,6 @@
       polygon-fill: @built-up-lowzoom;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
       [way_pixels >= 64] { polygon-gamma: 0.3;  }
-    }
-    [zoom >= 11] {
-      polygon-fill: @built-up-z11;
     }
     [zoom >= 12] {
       polygon-fill: @built-up-z12;

--- a/landcover.mss
+++ b/landcover.mss
@@ -12,7 +12,7 @@
 // --- "Base" landuses ---
 
 @built-up-lowzoom: #d0d0d0;
-@built-up-z12: #d7d4d3;
+@built-up-z12: #dddddd;
 @residential: #e0dfdf;      // Lch(89,0,0)
 @residential-line: #b9b9b9; // Lch(75,0,0)
 @retail: #ffd6d1;           // Lch(89,16,30)


### PR DESCRIPTION
### Related to #3935 and #3936
- Intermediate step before #3670

## Changes proposed in this pull request:
- Only fade from z11 and only 1 level - reduces the 3 level fading to only one level, using `lighten 0.2` instead of 0.4.
- Remove built-up-z11 color - this is no longer needed, since z11 is now the same as z10 and below
- Change `@built-up-z12` to `#dddddd` - this maintains the current rendered color at z12
- Change `@built-up-low-zoom` to `#d0d0d0` - same as current `@built-up-z12` color


### Explanation
As discussed in issue #3936 and the WIP PR#3670, the current fading of the landcover layers at low and mid-low zoom levels makes it difficult to distinguish different types of landcover/landuse at z12 and below.

Roads, railroads, and waterways are much more prominent than landcover at z12 and below, especially at z10 and below. Water areas are not faded, and therefore increase in prominence relative to landcover

This PR reduces the fading. While this transition still makes it more difficult to distinguish between light landcovers (like farmland), this situation is partial improved. This change will also make the transition smoother between the current fading and a future goal of no fading at low zoom levels, but few landcover classes, as shown in #3670 

## Test rendering :

Before
z10 Luxembourg
![z10-luxembourg-before](https://user-images.githubusercontent.com/42757252/67615248-e0684c00-f804-11e9-82ea-2cd4a6fce2a4.png)

z11
![z11-luxembourg-before](https://user-images.githubusercontent.com/42757252/67615198-591ad880-f804-11e9-87c9-d556799ceba1.png)

z12
![z12-n-luxembourg-before](https://user-images.githubusercontent.com/42757252/67615237-bf076000-f804-11e9-9a50-36bc257a4ecd.png)

After
z10
![z10-luxembourg-reduce-fade](https://user-images.githubusercontent.com/42757252/67615232-aa2acc80-f804-11e9-810f-848f70288342.png)

z11
![z11-luxembourg-reduce-fade](https://user-images.githubusercontent.com/42757252/67615202-5f10b980-f804-11e9-90f8-24bd773a950e.png)

z12
![z12-luxembourg-reduce-fade](https://user-images.githubusercontent.com/42757252/67615251-eeb66800-f804-11e9-804d-e8542cc1b6c3.png)

Also see more examples in https://github.com/gravitystorm/openstreetmap-carto/issues/3936#issuecomment-544090680