### PR TITLE
Revert PR #3930 which added river-color

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -228,7 +228,6 @@ Layer:
         (SELECT
             way,
             "natural",
-            water,
             waterway,
             landuse,
             name,

--- a/style.mss
+++ b/style.mss
@@ -2,10 +2,8 @@ Map {
   background-color: @land-color;
 }
 
-@land-color: #f2efe9;
-
 @water-color: #aad3df;
-@river-color: #8fcadd;     // Lch(78,21,227)
+@land-color: #f2efe9;
 
 @standard-halo-radius: 1;
 @standard-halo-fill: rgba(255,255,255,0.6);

--- a/water.mss
+++ b/water.mss
@@ -60,42 +60,22 @@
     [zoom >= 1][zoom < 2][way_pixels >= 16],
     [zoom >= 2][zoom < 8][way_pixels >= 32],
     [zoom >= 8] {
-      [water != 'river'][water != 'canal'][waterway != 'riverbank'] {
-        [int_intermittent = 'no'] {
-          polygon-fill: @water-color;
-          [way_pixels >= 4] {
-            polygon-gamma: 0.75;
-          }
-          [way_pixels >= 64] {
-            polygon-gamma: 0.6;
-          }
+      [int_intermittent = 'no'] {
+        polygon-fill: @water-color;
+        [way_pixels >= 4] {
+          polygon-gamma: 0.75;
         }
-        [int_intermittent = 'yes'] {
-          polygon-pattern-file: url('symbols/intermittent_water.png');
-          polygon-pattern-alignment: global;
-          [way_pixels >= 4] {
-            polygon-pattern-gamma: 0.75;
-          }
-          [way_pixels >= 64] {
-            polygon-pattern-gamma: 0.6;
-          }
+        [way_pixels >= 64] {
+          polygon-gamma: 0.6;
         }
       }
-      [natural = 'water'][water = 'river'],
-      [natural = 'water'][water = 'canal'],
-      [waterway = 'riverbank'] {
-        [int_intermittent = 'no'] {
-          polygon-fill: @river-color;
-          [way_pixels >= 4] { polygon-gamma: 0.75; }
-          [way_pixels >= 64] { polygon-gamma: 0.6; }
+      [int_intermittent = 'yes'] {
+        polygon-pattern-file: url('symbols/intermittent_water.png');
+        [way_pixels >= 4] {
+          polygon-pattern-gamma: 0.75;
         }
-        [int_intermittent  = 'yes'] {
-          [zoom >= 15] {
-            polygon-pattern-file: url('symbols/intermittent_river.png');
-            polygon-pattern-alignment: global;
-            [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
-            [way_pixels >= 64] { polygon-pattern-gamma: 0.6;  }
-          }
+        [way_pixels >= 64] {
+          polygon-pattern-gamma: 0.6;
         }
       }
     }
@@ -133,7 +113,7 @@
       line-join: round;
       line-clip: false;
     }
-    line-color: @river-color;
+    line-color: @water-color;
     line-width: 0.7;
     [zoom >= 9] { line-width: 1.2; }
     [zoom >= 10] { line-width: 1.6; }
@@ -163,7 +143,7 @@
       }
     }
 
-    water/line-color: @river-color;
+    water/line-color: @water-color;
     water/line-width: 2;
     water/line-cap: round;
     water/line-join: round;
@@ -221,7 +201,7 @@
         background/line-color: @land-color;
       }
       water/line-width: 2;
-      water/line-color: @river-color;
+      water/line-color: @water-color;
 
       [bridge = 'yes'] {
         bridgecasing/line-color: black;


### PR DESCRIPTION
This commit reverts PR #3930, which changed river color to #8fcadd for waterways and river, canal areas