### PR TITLE
[WIP] Borders for archeological site polygons.

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1648,7 +1648,6 @@
   [feature = 'amenity_cinema'],
   [feature = 'amenity_arts_centre'],
   [feature = 'amenity_community_centre'],
-  [feature = 'historic_archaeological_site'],
   [feature = 'amenity_nightclub'] {
     [zoom >= 17] {
       text-name: "[name]";
@@ -1665,6 +1664,22 @@
         text-dy: 12;
       }
     }
+  }
+
+  // this has to be kept in sync with the @culture block up there
+  // and the filters for #tourism-boundary in landcover.mss
+  // note that landcover already filters achaelogical sites that are touristic attractions
+  [feature = 'historic_archaeological_site'][way_pixels >= 750][zoom >= 10],
+  [feature = 'historic_archaeological_site'][zoom >= 17] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: @culture;
+    text-dy: 11;
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
   }
 
   [feature = 'amenity_public_bath'][zoom >= 17] {

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1676,7 +1676,10 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: @culture;
-    text-dy: 11;
+    [zoom >= 17] {
+      // allow space for the symbol
+      text-dy: 11;
+    }
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;

--- a/landcover.mss
+++ b/landcover.mss
@@ -910,6 +910,8 @@
 #tourism-boundary {
   [tourism = 'zoo'][zoom >= 10][way_pixels >= 750],
   [tourism = 'zoo'][zoom >= 17],
+  [historic = 'archaeological_site'][zoom >= 10][way_pixels >= 750],
+  [historic = 'archaeological_site'][zoom >= 17],
   [tourism = 'theme_park'][zoom >= 10][way_pixels >= 750],
   [tourism = 'theme_park'][zoom >= 17] {
     a/line-width: 1;

--- a/project.mml
+++ b/project.mml
@@ -571,7 +571,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE tourism = 'theme_park'
             OR tourism = 'zoo'
-            OR historic = 'archaeological_site'
+            OR (historic = 'archaeological_site' and tourism='attraction')
         ) AS tourism_boundary
     properties:
       minzoom: 10

--- a/project.mml
+++ b/project.mml
@@ -566,10 +566,12 @@ Layer:
             way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
-            tourism
+            tourism,
+            historic
           FROM planet_osm_polygon
           WHERE tourism = 'theme_park'
             OR tourism = 'zoo'
+            OR historic = 'archaeological_site'
         ) AS tourism_boundary
     properties:
       minzoom: 10


### PR DESCRIPTION
Fixes #3958

Changes proposed in this pull request:
- Add `historic=archeological_site` to `#tourism-boundary`.

Test rendering with links to the example places:

Athena: https://www.openstreetmap.org/#map=15/37.9742/23.7297
Italy: https://www.openstreetmap.org/#map=11/42.4126/11.9428
Roma: https://www.openstreetmap.org/#map=16/41.8915/12.4839
Messini: https://www.openstreetmap.org/#map=14/37.1780/21.9276
Olympía: https://www.openstreetmap.org/#map=13/37.6417/21.6304

After:
Athena:
![osm-arch_sites_polygon-athena](https://user-images.githubusercontent.com/167327/67771829-536a0080-fa59-11e9-89db-8b7b8e5ac560.png)

Italy:
![osm-arch_sites_polys-Italy](https://user-images.githubusercontent.com/167327/67771832-536a0080-fa59-11e9-9355-b1a8865270ee.png)

Roma:
![osm-arch_sites_polys-Messini](https://user-images.githubusercontent.com/167327/67771833-536a0080-fa59-11e9-974b-5190fc12f320.png)

Messini:
![osm-arch_sites_polys-Olympía](https://user-images.githubusercontent.com/167327/67771834-54029700-fa59-11e9-9d68-811c1f125fc8.png)

Olympía:
![osm-arch_sites_polys-Roma](https://user-images.githubusercontent.com/167327/67771836-54029700-fa59-11e9-8d60-678376500827.png)

Roma becomes a little bit more busy, but that's because every ruin has been mapped independently instead of mapping the whole Forum. I would like also to see how Petra (16/30.3280/35.4458) renders, but I don't have it in my import.

Finally, I should also include names in labels.