### PR TITLE
Only use text-dy for wind generators, not for other power=generator features

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -1872,9 +1872,9 @@
     }
   }
 
-  [feature = 'power_generator'][location != 'rooftop'][location != 'roof'][zoom >= 17],
-  [feature = 'power_generator'][location = null][zoom >= 17],
-  [feature = 'power_generator'][zoom >= 19],
+  [feature = 'power_generator']['generator:source' = 'wind'][location != 'rooftop'][location != 'roof'][zoom >= 17],
+  [feature = 'power_generator']['generator:source' = 'wind'][location = null][zoom >= 17],
+  [feature = 'power_generator']['generator:source' = 'wind'][zoom >= 19],
   [feature = 'historic_city_gate'][zoom >= 17],
   [feature = 'natural_cave_entrance'][zoom >= 15],
   [feature = 'man_made_mast'][zoom >= 18],
@@ -1893,7 +1893,7 @@
     text-wrap-width: @standard-wrap-width;
     text-line-spacing: @standard-line-spacing-size;
     text-fill: darken(@man-made-icon, 20%);
-    [feature = 'power_generator'],
+    [feature = 'power_generator']['generator:source' = 'wind'],
     [feature = 'historic_city_gate'],
     [feature = 'man_made_mast'],
     [feature = 'man_made_tower'],


### PR DESCRIPTION
Fixes #3963

Changes proposed in this pull request:
- Limit text rendering using `text-dy` to `generator:source=wind` only

Other power generators which are not buildings have their text labels rendered in the landcover font style, adjusted by way_area. Buildings do not need a separate rendering. Only wind generators have an icon, so only they need `text-dy: 10` for the name to be rendered properly

Test rendering:

Before
![z19-fermenter-before](https://user-images.githubusercontent.com/42757252/68104312-f3be9a00-ff1d-11e9-9810-99a7a75779c4.png)

After
![z19-fermenter-after](https://user-images.githubusercontent.com/42757252/68104279-cffb5400-ff1d-11e9-8556-6474f42d5c40.png)