### PR TITLE
Remove operator text label rendering for amenity=vending_machine

### DIFF
--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2327,8 +2327,7 @@
     text-dy: 6;
   }
 
-  [feature = 'amenity_atm'][zoom >= 19],
-  [feature = 'amenity_vending_machine'][zoom >= 19] {
+  [feature = 'amenity_atm'][zoom >= 19] {
     text-name: "[operator]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;

--- a/amenity-points.mss
+++ b/amenity-points.mss
@@ -2327,7 +2327,8 @@
     text-dy: 6;
   }
 
-  [feature = 'amenity_atm'][zoom >= 19] {
+  [feature = 'amenity_atm'][zoom >= 19],
+  [feature = 'amenity_vending_machine'][vending = 'public_transport_tickets'][zoom >= 19] {
     text-name: "[operator]";
     text-size: @standard-font-size;
     text-wrap-width: @standard-wrap-width;


### PR DESCRIPTION
Fixes #3946

### Changes proposed in this pull request:
- Remove `operator=` text label rendering for `amenity=vending_machine` features

### Explanation: 
The operator tag is often incorrect and rarely helpful for these features. 

Searching for all in Wales with operator= finds a few more useful examples, including: "Amazon" , "Transport for Wales", "Knolton Farmhouse Cheese", "4CG", and "Newport Bus".

But many more operator tags are unhelpful: "Ceredigion Council", "Pembrokeshire Coast National Park Authority", "Pembrokeshire County Council", "Conwy Council", "Bangor University" x2, "Campus Catering", "Caerphilly County Borough Council".

The example given in issue #3946 is [node 4329279576](https://www.openstreetmap.org/node/4329279576) which has the operator is "Stadt Göttingen", meaning "Göttingen City", so rendering this is not useful.

It would make the most sense to stop rendering the operator tag for vending machines.

### Test rendering with links to the example places:

https://www.openstreetmap.org/#map=19/51.52810/9.94055
Before
![vending-before](https://user-images.githubusercontent.com/42757252/68186277-1b2d6980-ffe7-11e9-93ca-c43886a9e5d3.png)

After
![vending-after](https://user-images.githubusercontent.com/42757252/68186285-1e285a00-ffe7-11e9-867f-f8a023bfb648.png)