### PR TITLE
Remove rendering of barrier=kerb

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -861,6 +861,10 @@
     line-width: 0.4;
     line-color: #444;
   }
+  [feature = 'barrier_embankment'][zoom >= 14] {
+    line-width: 0.4;
+    line-color: #444;
+  }
   [feature = 'barrier_hedge'][zoom >= 16] {
     line-width: 1.5;
     line-color: @hedge;

--- a/landcover.mss
+++ b/landcover.mss
@@ -861,10 +861,6 @@
     line-width: 0.4;
     line-color: #444;
   }
-  [feature = 'barrier_embankment'][zoom >= 14] {
-    line-width: 0.4;
-    line-color: #444;
-  }
   [feature = 'barrier_hedge'][zoom >= 16] {
     line-width: 1.5;
     line-color: @hedge;

--- a/project.mml
+++ b/project.mml
@@ -583,11 +583,11 @@ Layer:
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
             ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
+                  'handrail', 'hedge', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_line
             WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
+                  'handrail', 'hedge', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
           ) AS features
@@ -618,11 +618,11 @@ Layer:
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
             ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
+                  'handrail', 'hedge', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_polygon
             WHERE (barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
+                  'handrail', 'hedge', 'retaining_wall', 'wall')
               OR historic = 'citywalls')
               AND building IS NULL
           ) AS features

--- a/project.mml
+++ b/project.mml
@@ -582,11 +582,11 @@ Layer:
         (SELECT
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_line
-            WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+            WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
@@ -617,11 +617,11 @@ Layer:
         (SELECT
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_polygon
-            WHERE (barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+            WHERE (barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls')
               AND building IS NULL

--- a/project.mml
+++ b/project.mml
@@ -582,11 +582,11 @@ Layer:
         (SELECT
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_line
-            WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
+            WHERE barrier IN ('chain', 'city_wall', 'ditch', 'embankment', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
@@ -617,11 +617,11 @@ Layer:
         (SELECT
             way, COALESCE(historic, barrier) AS feature
           FROM (SELECT way,
-            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
+            ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'embankment', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
             ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
             FROM planet_osm_polygon
-            WHERE (barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
+            WHERE (barrier IN ('chain', 'city_wall', 'ditch', 'embankment', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'retaining_wall', 'wall')
               OR historic = 'citywalls')
               AND building IS NULL


### PR DESCRIPTION
Closes #3714 

### Changes proposed in this pull request:
- <s>Remove the rendering of barrier=embankment</s>
- Remove the rendering of barrier=kerb 

### Explanation:
- Kerbs (aka curbs) are rendered the same as significant obstacles like walls and fences. In issue #3714 I attempted to find a subtle rendering for kerbs which would not look like a fence or wall, but failed to find a good option for z19. Without rendering sidewalk and street areas these features are not intuitive.
- <s>The tag `barrier=embankment` was once somewhat common but never was documented in the wiki. Instead `man_made=embankment` or `man_made=dyke` are the much more common ways to make one-sided embankments and levees. The definition of `barrier=embankment` was not clear, so it's best to no longer support this tag.</s> (See #3744)

### Test rendering:

(Test shows fence, kerb, wall, embankment from top to bottom)
Before
![kerb-embankment-test-before](https://user-images.githubusercontent.com/42757252/68574870-3c41fe80-04ae-11ea-8dbe-7899b7578f13.png)

After
![kerb-embankment-barrier-after](https://user-images.githubusercontent.com/42757252/68574893-47952a00-04ae-11ea-81f8-df9caaa46f4f.png)
