### PR TITLE
Import man_made=pipeline, man_made=cutline and power=cable as linestrings

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -37,7 +37,7 @@ local polygon_keys = {
 local linestring_values = {
     historic = {citywalls = true},
     leisure = {track = true, slipway = true},
-    man_made = {breakwater = true, cutline = true, embankment = true, groyne = true},
+    man_made = {breakwater = true, cutline = true, embankment = true, groyne = true, pipeline = true},
     natural = {cliff = true, tree_row = true, ridge = true, arete = true},
     power = {cable = true, line = true, minor_line = true},
     tourism = {yes = true},

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -39,7 +39,7 @@ local linestring_values = {
     leisure = {track = true, slipway = true},
     man_made = {embankment = true, breakwater = true, groyne = true},
     natural = {cliff = true, tree_row = true, ridge = true, arete = true},
-    power = {line = true, minor_line = true},
+    power = {cable = true, line = true, minor_line = true},
     tourism = {yes = true},
     waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, wadi = true, weir = true}
 }

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -37,7 +37,7 @@ local polygon_keys = {
 local linestring_values = {
     historic = {citywalls = true},
     leisure = {track = true, slipway = true},
-    man_made = {embankment = true, breakwater = true, groyne = true},
+    man_made = {breakwater = true, cutline = true, embankment = true, groyne = true},
     natural = {cliff = true, tree_row = true, ridge = true, arete = true},
     power = {cable = true, line = true, minor_line = true},
     tourism = {yes = true},


### PR DESCRIPTION
### Related to #3611

### Changes proposed in this pull request:
This PR adds each of the 3 features as local linestring_values in openstreetmap-carto.lua:
- import `man_made=pipeline` closed ways as linestrings
- import `man_made=cutline` closed ways as linestrings
- import `power=cable` closed ways as linestrings

### Explanation:
- All closed way features (ways which start and end on the same node and do not self-intersect) which are tagged with `man_made` or `power` are normally imported as polygons when added to the rendering database, as are linear `man_made` features like embankments and breakwaters.
- But there are exceptions for features that are only mapped as lines: currently `power=line` and `power=minor_line`, but `power=cable` is missing from this list of linestring exceptions.
- The tag `man_made=cutline` is also rendered and is only mapped as a line, so it should not be imported as a polygon
- We do not yet render `man_made=pipeline`, but it is only mapped as a line, and there is a plan to add rendering soon, see #640 
- Importing these features as polygons takes more server resources, so performance during import is slightly improved by this change.

This PR will be applied to the schema_changes branch, not to `master`, because it requires a rendering database reload at the time the release is applied to the rendering servers.