### PR TITLE
Fix syntax of font list and enable Armenian font

### DIFF
--- a/fonts.mss
+++ b/fonts.mss
@@ -77,7 +77,8 @@ A regular style.
 */
 @book-fonts:    "Noto Sans Regular",
                 "Noto Sans CJK JP Regular",
-                "Noto Sans Adlam Regular", "Noto Sans Adlam Unjoined Regular"
+                "Noto Sans Adlam Regular",
+                "Noto Sans Adlam Unjoined Regular",
                 "Noto Sans Armenian Regular",
                 "Noto Sans Balinese Regular",
                 "Noto Sans Bamum Regular",


### PR DESCRIPTION
Specifically, add a comma between "Noto Sans Adlam Unjoined Regular" and
"Noto Sans Armenian Regular". The missing comma resulted in the Armenian
font being missing from the generated Mapnik XML.

Fixes #3986.

Before
![armenian-before](https://user-images.githubusercontent.com/113030/70557033-53920b80-1b82-11ea-8feb-a0673a85d1b6.png)

After
![armenian-after](https://user-images.githubusercontent.com/113030/70557042-57be2900-1b82-11ea-967b-5fedb0beda45.png)

