### PR TITLE
Import aerialway=station as a polygon feature

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -46,6 +46,7 @@ local linestring_values = {
 
 -- Objects with any of the following key/value combinations will be treated as polygon
 local polygon_values = {
+    aerialway = {station = true},
     highway = {services = true, rest_area = true},
     junction = {yes = true},
     railway = {station = true}


### PR DESCRIPTION
Related to #3611

Changes proposed in this pull request:
- Add `aerialway=station` to list of local polygon tags in openstreetmap-carto.lua
- This will import closed ways tagged with `aerialway=station` as polygons for proper rendering as a POI.
- Currently aerialway= features are not imported as polygons when mapped as closed ways, but according to https://wiki.openstreetmap.org/wiki/Tag:aerialway%3Dstation this is also an allowed mapping method as an area
- Most `aerialway=station` features are mapped as nodes (24,000), but there are almost 2700 mapped as areas (http://overpass-turbo.eu/s/PFK)

Rendering is unchanged. Not expected to have a significant affect on import time based on tests with moderately sized .pbf extracts (luxembourg, Papua)