### PR TITLE
Remove rendering of barrier=embankment

### DIFF
--- a/landcover.mss
+++ b/landcover.mss
@@ -850,10 +850,6 @@
     line-width: 0.4;
     line-color: #444;
   }
-  [feature = 'barrier_embankment'][zoom >= 14] {
-    line-width: 0.4;
-    line-color: #444;
-  }
   [feature = 'barrier_hedge'][zoom >= 16] {
     line-width: 1.5;
     line-color: @hedge;

--- a/project.mml
+++ b/project.mml
@@ -583,7 +583,7 @@ Layer:
             way, COALESCE(historic, barrier) AS feature
           FROM
             (SELECT way,
-              ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+              ('barrier_' || (CASE WHEN barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                     'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall') THEN barrier ELSE NULL END)) AS barrier,
               ('historic_' || (CASE WHEN historic = 'citywalls' THEN historic ELSE NULL END)) AS historic
               FROM
@@ -603,14 +603,14 @@ Layer:
                   FROM planet_osm_line
                   WHERE way && !bbox!
                 ) _
-              WHERE barrier IN ('chain', 'city_wall', 'embankment', 'ditch', 'fence', 'guard_rail',
+              WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'kerb', 'retaining_wall', 'wall')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
           ) AS features
         ) AS line_barriers
     properties:
-      minzoom: 14
+      minzoom: 15
   - id: cliffs
     geometry: linestring
     <<: *extents


### PR DESCRIPTION
Closes #3744

### Changes proposed in this pull request:
- Remove the rendering of barrier=embankment
- Change minzoom for barrier layer to z15 since this is now the earliest that any `barriers` feature is shown (city walls).

### Explanation:
- The tag `barrier=embankment` was once somewhat used, but never was documented in the wiki. Instead `man_made=embankment` or `man_made=dyke` are the much more common ways to make one-sided embankments and levees. The definition of `barrier=embankment` was not clear and it is not similar to the other barriers rendered in the same way (fences and walls), so it's best to no longer support this tag. (See #3744)

### Test rendering:
(Note: these images also show changes proposed in #3969)
(Test shows fence, kerb, wall, embankment from top to bottom)
Before
![kerb-embankment-test-before](https://user-images.githubusercontent.com/42757252/68574870-3c41fe80-04ae-11ea-8dbe-7899b7578f13.png)

After
![kerb-embankment-barrier-after](https://user-images.githubusercontent.com/42757252/68574893-47952a00-04ae-11ea-81f8-df9caaa46f4f.png)
