### PR TITLE
Import natural=earth_bank as a linestring only

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -36,7 +36,7 @@ local linestring_values = {
     historic = {citywalls = true},
     leisure = {track = true, slipway = true},
     man_made = {embankment = true, breakwater = true, groyne = true},
-    natural = {cliff = true, tree_row = true, ridge = true, arete = true},
+    natural = {arete = true, cliff = true, earth_bank = true, ridge = true, tree_row = true},
     power = {line = true, minor_line = true},
     waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, wadi = true, weir = true}
 }


### PR DESCRIPTION
Related to  #3611 and #2288

Changes proposed in this pull request:
- Add natural=earth_bank to the list of linestring exceptions in openstreetmap-carto.lua so that closed ways with this tag will not be imported as polygons, but as a linestring only.
- This tag is only used on lines, similarly to natural=cliff or man_made=embankment
- While it is not currently rendered, there are over 4,000 features with this tag, including 202 closed ways (where the bank encircles an area) which are not intended to represent areas. http://overpass-turbo.eu/s/Qa3
- Adding this to the lua transformations file will make it easier to render this feature correctly in the future or in other map styles which are based off of this style.