### PR TITLE
Import waterway=tidal_channel as a linestring

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -41,7 +41,7 @@ local linestring_values = {
     natural = {cliff = true, tree_row = true, ridge = true, arete = true},
     power = {cable = true, line = true, minor_line = true},
     tourism = {yes = true},
-    waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, wadi = true, weir = true}
+    waterway = {canal = true, derelict_canal = true, ditch = true, drain = true, river = true, stream = true, tidal_channel = true, wadi = true, weir = true}
 }
 
 -- Objects with any of the following key/value combinations will be treated as polygon


### PR DESCRIPTION
Related to #3611 and #3865

Changes proposed in this pull request:
- Add waterway=tidal_channel to the list of linestring exceptions in openstreetmap-carto.lua so that closed ways with this tag will only be imported as a linestring
- This tag is only used on lines, similarly to waterway=stream and waterway=river
- While it is not currently rendered, there are over 2,500 features with this tag: https://wiki.openstreetmap.org/wiki/Tag:waterway=tidal_channel
- Adding this to the lua transformations file will make it easier to render this feature correctly in the future or in other map styles which are based off of this style.