### PR TITLE
Import the key `craft=` as a polygon

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -12,6 +12,7 @@ local polygon_keys = {
     'allotments',
     'amenity',
     'area:highway',
+    'craft',
     'building',
     'building:part',
     'harbour',


### PR DESCRIPTION
Related to #3611 and #1697

Changes proposed in this pull request:
- Import the key `craft=` as a polygon when mapped as a closed way
- Adds 'craft' to the list of polygon keys in openstreetmap-carto

The key "craft=" is similar to "office=" in that it can be used on points or areas. It is commonly used and there is a chance this will be rendered in this style, or if not, then in others based on it: http://wiki.openstreetmap.org/wiki/Key:craft