### PR TITLE
Import closed ways with the key `club=` as polygons

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -14,6 +14,7 @@ local polygon_keys = {
     'area:highway',
     'building',
     'building:part',
+    'club',
     'harbour',
     'healthcare',
     'historic',


### PR DESCRIPTION
Related to #3611 

Changes proposed in this pull request:
- Import closed ways which are tagged with the key `club=*` as polygons

While this style is unlikely to render features with this key, some contributors have suggested that this style should provide a complete list of the main keys and tags which are intended to be mapped as areas (polygons)