### PR TITLE
Import emergency= features as polygons, with exceptions

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -14,6 +14,7 @@ local polygon_keys = {
     'area:highway',
     'building',
     'building:part',
+    'emergency',
     'harbour',
     'healthcare',
     'historic',
@@ -35,6 +36,7 @@ local polygon_keys = {
 
 -- Objects with any of the following key/value combinations will be treated as linestring
 local linestring_values = {
+    emergency = {designated = true, destination = true, no = true, official = true, yes = true},
     historic = {citywalls = true},
     leisure = {track = true, slipway = true},
     man_made = {breakwater = true, cutline = true, embankment = true, groyne = true, pipeline = true},


### PR DESCRIPTION
Related to #3611

Changes proposed in this pull request:
- Import closed ways tagged with the key `emergency=` as polygon features, with exceptions for those values which are used as "access" tags on lines: designated, destination, no, official, yes

While we have not decided to render any specific `emergency=` features now or in the next few months, it is possible that this will be desired in the next few years. Also, other styles which are based off of this stylesheet may wish to interpret `emergency=` features, so it is beneficial to have a proper import schema for this tag.