### PR TITLE
Change geometry to "point" for building-text, text-poly-low-zoom & roads-area-text-name layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1771,7 +1771,7 @@ Layer:
     properties:
       minzoom: 13
   - id: roads-area-text-name
-    geometry: polygon
+    geometry: point
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -1956,7 +1956,7 @@ Layer:
     properties:
       minzoom: 15
   - id: text-poly-low-zoom
-    geometry: polygon
+    geometry: point
     <<: *extents
     Datasource:
       <<: *osm2pgsql
@@ -2029,7 +2029,7 @@ Layer:
     properties:
       minzoom: 10
   - id: building-text
-    geometry: polygon
+    geometry: point
     <<: *extents
     Datasource:
       <<: *osm2pgsql


### PR DESCRIPTION
Fixes #4022

Changes proposed in this pull request:
- Changes the geometry of building-text, text-poly-low-zoom and roads-area-text-name to point, because these layers now are labeled as a point, created by ST_PointOnSurface

Thank you for catching this issue, @imagico 

Test rendering is unchanged.

I don't think this will affect performance.