### PR TITLE
Don't form areas from tags like building=no

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -398,7 +398,7 @@ function isarea (tags)
     for k, v in pairs(tags) do
         -- Check if it has a polygon key and not a linestring override, or a polygon k=v
         for _, ptag in ipairs(polygon_keys) do
-            if k == ptag and not (linestring_values[k] and linestring_values[k][v]) then
+            if k == ptag and v ~= "no" and not (linestring_values[k] and linestring_values[k][v]) then
                 return 1
             end
         end

--- a/scripts/lua/test.lua
+++ b/scripts/lua/test.lua
@@ -50,6 +50,9 @@ assert(isarea({waterway = "river"}) == 0, "test failed: river")
 assert(isarea({waterway = "riverbank"}) == 1, "test failed: river")
 assert(isarea({highway = "services"}) == 1, "test failed: river")
 assert(isarea({natural="cliff"}) == 0, "test failed: cliff") -- issue #3084
+assert(isarea({building = "no"}) == 0, "test failed: building=no")
+assert(isarea({building = "no", area = "yes"}) == 1, "test failed: building=no with area tag")
+assert(isarea({building = "no", landuse = "forest"}) == 1, "test failed: building=no with other area tag")
 
 print("TESTING: filter_tags_generic")
 assert(({filter_tags_generic({})})[1] == 1, "Untagged filter")


### PR DESCRIPTION
ref. https://github.com/gravitystorm/openstreetmap-carto/issues/3611#issuecomment-582672393

Checked by loading an extract and verifying that building=no with other polygon tags are still areas, and then loading just a building=no way