### PR TITLE
Move small amenities to z18

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -61,7 +61,7 @@
     }
   }
 
-  [feature = 'amenity_atm'][zoom >= 19] {
+  [feature = 'amenity_atm'][zoom >= 18] {
     marker-file: url('symbols/amenity/atm.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
@@ -664,7 +664,7 @@
     marker-clip: false;
   }
 
-  [feature = 'amenity_post_box'][zoom >= 19] {
+  [feature = 'amenity_post_box'][zoom >= 18] {
     marker-file: url('symbols/amenity/post_box.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
@@ -692,7 +692,7 @@
     marker-clip: false;
   }
 
-  [feature = 'emergency_phone'][zoom >= 19] {
+  [feature = 'emergency_phone'][zoom >= 18] {
     marker-file: url('symbols/amenity/emergency_phone.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;


### PR DESCRIPTION
Related to #4002, #1745 and PR #1884

Changes proposed in this pull request:
- This PR, similar to closed PR #1884, moves amenity=atm and amenity=post_box to z18, though in this case they are currently rendered only at z19, while previously they were rendered at z17. 
- Also emergency phones are moved back to z18 from z19. Previously they had been rendered at z17

This is an attempt to compromise. While these features were moved from z17 to z19 without consensus, rather than attempting to move them back to z17 we can use z18.

In rural areas these features should be shown at z17, while in some very large cities (e.g. Warsaw) there may be many icons in one screenshot at that zoom level due to the high density of features in capital cities.