### PR TITLE
Remove rendering of power=cable features

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1125,7 +1125,6 @@ Layer:
             way
           FROM planet_osm_line
           WHERE power = 'line'
-            OR (power = 'cable' AND tags->'location' IN ('overground', 'overhead', 'surface', 'outdoor', 'platform'))
         ) AS power_line
     properties:
       minzoom: 14


### PR DESCRIPTION
Fixes #3984

Changes proposed in this pull request:
- Removes rendering of power=cable features which are currently rendered (those tagged with location=overhead, =overground, =surface, =outdoor and =platform). 

Currently only the small minority of `power=cable` features with `location=` values of `overhead, `=overground`, `=surface`, `=outdoor` and `=platform` are rendered. Most power=cable features are underground (or under water).

These location values are rare, the vast majority of power cables are underground or undersea, and the documentation suggests that this tag should usually not be used for overhead and overground cables. Some mappers occasionally use this tag instead of `power=minor_line` for distribution lines on poles which happen to use insulated cables instead of the usual uninsulated cables.

Occasionally the tag is used appropriately for overground cables in substations, but these features are not relevant for a general-use map.

Test rendering with links to the example places:

https://www.openstreetmap.org/#map=17/50.8502/4.3434
Before
<img width="553" alt="power-cable-overground-before" src="https://user-images.githubusercontent.com/42757252/75510485-7d92f580-5a2e-11ea-9f03-506377bdcc03.png">

After
<img width="553" alt="power-cable-overground-after" src="https://user-images.githubusercontent.com/42757252/75510281-c39b8980-5a2d-11ea-85a4-cbb8ea5349b5.png">
