### PR TITLE
Remove Postgres 9.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,5 @@ script:
   - osm2pgsql -G --hstore --style openstreetmap-carto.style -U postgres -d gis -r libxml2 <(echo '<osm version="0.6"/>')
   # Apply the custom indexes
   - psql -1Xq -v ON_ERROR_STOP=1 -d gis -f indexes.sql
-  # Test for hstore operation not supported in PostgreSQL 9.3
-  - '! grep "tags->''[^'']\+'' IS" project.mml > /dev/null'
   # Test for classes in project.mml (not supported in vector tiles)
   - '! grep "class:" project.mml > /dev/null'


### PR DESCRIPTION
9.3 and 9.4 are EOL, so we don't need to do this check anymore.