### PR TITLE
Move Travis to Ubuntu bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: node_js
-dist: xenial
+dist: bionic
 sudo: false
 node_js:
-  - "6"
+  - "10"
 services:
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
   apt:
     packages:
     - lua5.1
     - libxml2-utils
     - python-yaml
-    - postgresql-9.4-postgis-2.4
+    - postgresql-9.5-postgis-2.4
     - osm2pgsql
 env:
-  - CARTO=0.18.0 MAPNIK='3.0.0 3.0.12'
+  - CARTO=1.2.0 MAPNIK='3.0.0 3.0.12'
 install:
   - npm install carto@$CARTO
   - pip install --user colormath
@@ -38,9 +38,7 @@ script:
   - diff -qu <(scripts/indexes.py) indexes.sql
   - diff -qu <(scripts/generate_road_colours.py) road-colors-generated.mss
   # Create the PostgreSQL tables
-  # Because we're not processing any data, we don't need to use the tag transform script,
-  # which the ancient verson of osm2pgsql on Travis' Ubuntu doesn't support
-  - osm2pgsql -G --hstore --style openstreetmap-carto.style -U postgres -d gis -r libxml2 <(echo '<osm version="0.6"/>')
+  - osm2pgsql -G --hstore --style openstreetmap-carto.style --tag-transform-script openstreetmap-carto.lua -U postgres -d gis -r xml <(echo '<osm version="0.6"/>')
   # Apply the custom indexes
   - psql -1Xq -v ON_ERROR_STOP=1 -d gis -f indexes.sql
   # Test for hstore operation not supported in PostgreSQL 9.3


### PR DESCRIPTION
I kept node back on 10 because [node-gdal doesn't support node v12](https://github.com/naturalatlas/node-gdal/issues/258).