### PR TITLE
Remove way_area filtering for low zoom water and simplify code

### DIFF
--- a/style/water.mss
+++ b/style/water.mss
@@ -17,67 +17,20 @@
     }
   }
 
-  [waterway = 'dock'] {
-    [zoom >= 9]::waterway {
+  [waterway = 'dock'],
+  [landuse = 'basin'],
+  [natural = 'water'],
+  [landuse = 'reservoir'],
+  [waterway = 'riverbank'] {
+    [int_intermittent = 'no'] {
       polygon-fill: @water-color;
-      [way_pixels >= 4] {
-        polygon-gamma: 0.75;
-      }
-      [way_pixels >= 64] {
-        polygon-gamma: 0.6;
-      }
+      [way_pixels >= 4] { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.6; }
     }
-  }
-
-  [landuse = 'basin']::landuse {
-    [zoom >= 7][way_pixels >= 32],
-    [zoom >= 8] {
-      [int_intermittent = 'no'] {
-        polygon-fill: @water-color;
-        [way_pixels >= 4] {
-          polygon-gamma: 0.75;
-        }
-        [way_pixels >= 64] {
-          polygon-gamma: 0.6;
-        }
-      }
-      [int_intermittent = 'yes'] {
-        polygon-pattern-file: url('symbols/intermittent_water.png');
-        [way_pixels >= 4] {
-          polygon-pattern-gamma: 0.75;
-        }
-        [way_pixels >= 64] {
-          polygon-pattern-gamma: 0.6;
-        }
-      }
-    }
-  }
-
-  [natural = 'water']::natural,
-  [landuse = 'reservoir']::landuse,
-  [waterway = 'riverbank']::waterway {
-    [zoom >= 0][zoom < 1][way_pixels >= 4],
-    [zoom >= 1][zoom < 2][way_pixels >= 16],
-    [zoom >= 2][zoom < 8][way_pixels >= 32],
-    [zoom >= 8] {
-      [int_intermittent = 'no'] {
-        polygon-fill: @water-color;
-        [way_pixels >= 4] {
-          polygon-gamma: 0.75;
-        }
-        [way_pixels >= 64] {
-          polygon-gamma: 0.6;
-        }
-      }
-      [int_intermittent = 'yes'] {
-        polygon-pattern-file: url('symbols/intermittent_water.png');
-        [way_pixels >= 4] {
-          polygon-pattern-gamma: 0.75;
-        }
-        [way_pixels >= 64] {
-          polygon-pattern-gamma: 0.6;
-        }
-      }
+    [int_intermittent = 'yes'] {
+      polygon-pattern-file: url('symbols/intermittent_water.png');
+      [way_pixels >= 4] { polygon-pattern-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-pattern-gamma: 0.6; }
     }
   }
 }


### PR DESCRIPTION
Partial Fix for #3273 
Revert of #2952

Changes proposed in this pull request:
- Remove >1 pixel way_area filtering for low zoom water
- Clean up code to simplify rendering of water areas. Now waterway=dock and landuse=basin will be the same as the other features.

There is still a 1 pixel limit in the SQL select which is probably necessary for z0 to z6 at least, but I would like to consider changing this in the future. See related discussion in #1604 and #754, however. Since the SQL code currently allows rendering down to 1 pixel without significant performance issues, this change should be a good first step. 

Filtering out some water areas at lower zoom, as done currently since v4.6.0, shows fewer lakes and rivers at low zoom level, without significantly improving performance. The 32 pixel limit at z2 to z7 causes moderately large lakes to appears suddently, and parts of rivers to appear at different zoom levels. 

While solving this issue entirely will require changing the limit in SQL from 1 pixel back to 0.1 or 0.01 pixel (which might cause performance problems), most of the visible problems can be fixed by this PR.

Simplyfing the code for water areas will make it much easier for me to add a rendering for `salt=yes` and intermittent + salt water lakes - I started that PR but realized this is needed first. Now (water) dock areas and basins are treated exactly the same as the other water area features in the water.mss file

Test rendering with links to the example places:

Alaska, Yukon delta
Before z6
<img width="501" alt="yukon-delta-z6-before" src="https://user-images.githubusercontent.com/42757252/76145374-4bd3fb80-60cc-11ea-9ece-52fcd5981fd0.png">
After z6
<img width="501" alt="yukon-delta-z6-after-1-pixel-limit" src="https://user-images.githubusercontent.com/42757252/76145376-555d6380-60cc-11ea-95be-7b7d39a04a39.png">

Before z2
<img width="115" alt="alaska-z2-before" src="https://user-images.githubusercontent.com/42757252/76145386-61492580-60cc-11ea-8d21-bcd2c4193183.png">
After z2
![Uploading alaska-z2-after-1-pixel-limit.png…]()

Before z2 - exported at 3x (e.g. retina tiles)
![alaska-z2-export3x-before](https://user-images.githubusercontent.com/42757252/76145397-7625b900-60cc-11ea-85d3-5928b5db6ad6.png)
After z2 at 3x
![alaska-z2-export3x-after-1-pixel-limit](https://user-images.githubusercontent.com/42757252/76145403-85a50200-60cc-11ea-991d-81503731229a.png)


Magadan Obast, eastern Siberia
https://www.openstreetmap.org/#map=7/62.472/152.644
Before
![water-magadan_obast-z5-before](https://user-images.githubusercontent.com/42757252/76145359-26df8880-60cc-11ea-862c-64a9f18e212e.png)
![water-magadan_oblast-before-7:62 472:152 644](https://user-images.githubusercontent.com/42757252/76145358-247d2e80-60cc-11ea-8174-c8e3a79698d6.png)

After
![water-magadan_obast-z5-after](https://user-images.githubusercontent.com/42757252/76145363-2a730f80-60cc-11ea-96cb-b3892d67c9c7.png)
![water-magadan_oblast-z7-after](https://user-images.githubusercontent.com/42757252/76145364-2b0ba600-60cc-11ea-9156-74349a3ba86f.png)


South Australia
- These are all intermittent lakes, which really don't work well with this pattern at low zoom level, but this is still an improvement:
https://www.openstreetmap.org/#map=7/-31.934/138.274

before z7
<img width="534" alt="water-area-limit-before-7:-31 934:138 274" src="https://user-images.githubusercontent.com/42757252/76145417-a2413a00-60cc-11ea-8281-589fb0e5542d.png">
after z7
<img width="534" alt="water-1-pixel-area-limit-after-7:-31 934:138 274" src="https://user-images.githubusercontent.com/42757252/76145424-aa997500-60cc-11ea-8c8c-4746eff2f85b.png">
