### PR TITLE
Add Github Actions in parallel to Travis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  syntax:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Set up Python
+      run: |
+        python -m pip install pyyaml colormath
+    - name: Set up xmllint
+      run: sudo apt-get install -qq --no-install-recommends libxml2-utils
+    - name: Set up shell
+      run: set -o pipefail
+    - name: Validate YAML files
+      run: |
+        find . \( -type f -name '*.yaml' -o -name '*.yml' -o -name '*.mml' \) \
+        -exec python -c "from yaml import safe_load; safe_load(file('{}'))" \;
+    - name: Validate SVGs for valid XML
+      run: find symbols/ -name '*.svg' | xargs xmllint --noout
+    - name: Check indexes are up to date
+      run: diff -qu <(scripts/indexes.py) indexes.sql
+    - name: Check road colours are up to date
+      run: diff -qu <(scripts/generate_road_colours.py) style/road-colors-generated.mss
+    - name: Check for unsupported class usage
+      run: '! grep "class:" project.mml > /dev/null'


### PR DESCRIPTION
GitHub actions are generally faster to run than Travis. There's been some reports of network problems in the chef and Vespucci repos, but I haven't encountered any, and we're relying on different network resources than they are.

Because this is new, I'm leaving Travis in place in parallel.

This only adds actions that don't require CartoCSS or a database.