### PR TITLE
Change quarry outline to 10% darkened quarry color

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -118,7 +118,7 @@
     polygon-pattern-file: url('symbols/quarry.svg');
     [zoom >= 13] {
       line-width: 0.5;
-      line-color: grey;
+      line-color: darken(@quarry, 10%);
     }
     [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
     [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }


### PR DESCRIPTION
### Fixes part of #3976

## Changes proposed in this pull request:
- Change quarry outline to 10% darkened quarry color rather than `gray`
- This makes the outline significantly lighter, and clearly different than a barrier

Currently the quarry outline looks similar to a fence or wall on untagged land. This makes it hard to tell if a quarry is surrounded by a wall or fence, or not.

I also tested `darken(@quarry, 15%)` and `darken(@quarry, 20%)` but these look too similar to the linear barrier rendering, while the current commit uses `darken(@quarry, 10%)` and this works well.

This should also make it easier to adapt the style or change the quarry color in the future (though it is always a good idea to adjust the darken percentage if the fill color is lighter or darker than before)

## Test rendering with links to the example places:


z16 Slate quarries in Wales - current
https://www.openstreetmap.org/#map=16/53.1243/-4.1475.png
- Note that there is a wall or fence which comes right up to the border between the quarries, but stops there. It appears to be the same color as the quarry outline right now. There are some parts of the quarry outline that also have a wall or fence in that position.
<img width="566" alt="slate-quarries-before-16:53 1243:-4 1475" src="https://user-images.githubusercontent.com/42757252/75515262-f5681c80-5a3c-11ea-92d7-eee4d01b9865.png">

z16 after - 10% darkened `@quarry` color outline
- Now the quarry outline is clearly lighter than the barrier
<img width="566" alt="slate-quarries-after-z16-10percent" src="https://user-images.githubusercontent.com/42757252/75515272-fc8f2a80-5a3c-11ea-938d-32de03db9d75.png">

z18 current
<img width="600" alt="z18-slate-quarries-current" src="https://user-images.githubusercontent.com/42757252/75515075-7377f380-5a3c-11ea-90b8-17650708c2b8.png">

z18 after
<img width="600" alt="slate-quarries-after-z18-10percent" src="https://user-images.githubusercontent.com/42757252/75515001-44618200-5a3c-11ea-9723-9d7920f6e7c3.png">
