### PR TITLE
Change bridge-text way_pixels minimum and maximum

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1411,8 +1411,8 @@ Layer:
           FROM planet_osm_polygon
           WHERE way && !bbox!
             AND man_made = 'bridge'
-            AND way_area > 62.5*POW(!scale_denominator!*0.001*0.28,2)
-            AND way_area < 64000*POW(!scale_denominator!*0.001*0.28,2)
+            AND way_area > 125*POW(!scale_denominator!*0.001*0.28,2)
+            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           ORDER BY way_area DESC
         ) AS bridge_text
     properties:

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2709,7 +2709,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #bridge-text  {
   [man_made = 'bridge'] {
-    [zoom >= 12][way_pixels > 62.5][way_pixels <= 64000] {
+    [zoom >= 12][way_pixels > 125][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: 10;
       text-wrap-width: 30; // 3 em


### PR DESCRIPTION
Fixes #4050
Fixes #4019 

Changes proposed in this pull request:
- Change bridge-text way_pixels minimum limit to 125 (previously 62.5) and maximum to 768000
- This doubles the minimum area in pixels from the current limit (equivalent to 1/2 zoom level), and increases the max pixel area limit to match other features, to prevent double-tagged features from showing a different text label style at low zoom.
- A higher limit of 187.5 pixels (2 zoom levels sooner than other area features) was also tested, but this excludes some mid-sized bridges. 

Test rendering with links to the example places:

Chicago before z15:
![chicago-bridges](https://user-images.githubusercontent.com/42757252/73586484-3d089080-44f1-11ea-8541-6b7dcaf75ba5.png)

After 125 way_pixel limit:
<img width="601" alt="chicago-after-125-z15" src="https://user-images.githubusercontent.com/42757252/76219543-553e9e80-6259-11ea-8236-5d135c19e6ce.png">

Bridge with landuse=railway before - https://www.openstreetmap.org/way/124882971
z18 (same)

<img width="614" alt="z18-after-railway-bridge" src="https://user-images.githubusercontent.com/42757252/76221781-eebb7f80-625c-11ea-860d-31def5e96d6f.png">

z19 before
<img width="614" alt="z19-before-railway-bridge" src="https://user-images.githubusercontent.com/42757252/76221108-e4e54c80-625b-11ea-8e9d-6d24932e3b73.png">

z19 after
<img width="614" alt="z19-after-railway-bridge" src="https://user-images.githubusercontent.com/42757252/76221126-ec0c5a80-625b-11ea-9bc6-84db80811c21.png">