### PR TITLE
Remove duplicate selection of cave_entrance, peak, volcano and saddle

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1477,8 +1477,8 @@ Layer:
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
                                                     'construction', 'military', 'plant_nursery') THEN landuse ELSE NULL END,
                 'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" ELSE NULL END,
-                'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'bay', 'spring',
-                                                      'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
+                'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
+                                                      'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" ELSE NULL END,
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway ELSE NULL END,
                 'place_' || CASE WHEN place IN ('island', 'islet') THEN place ELSE NULL END,


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove duplicate selection of natural = cave_entrance, peak, volcano and saddle
- The features `natural=cave_entrance`, `natural=peak`, `natural=volcano` and `natural=saddle` are always mapped as nodes, so they should not be selected when mapped as areas
- They are selected in the previous line when way_area is null. It appears that this was accidentally duplicated when text-poly, text-point, amenity-points etc were merged into one layer.

We could consider still rendering `natural=cave_entrance` on areas. JOSM allows it, but this is only done 1% of the time. However, I'm keeping it simple and just removing this bug now. If someone is in favor of rendering `natural=cave_entrance` areas, that can be done in a separate PR.

Test rendering with links to the example places:

https://www.openstreetmap.org/#map=16/56.3770/22.6305
https://www.openstreetmap.org/way/187727062
https://www.openstreetmap.org/way/187727047
- Two peaks mapped as closed ways

Before - render currently
<img width="496" alt="natural-peak-areas-before" src="https://user-images.githubusercontent.com/42757252/76285757-d9d5ff00-62e3-11ea-907f-7109e941675c.png">

After
<img width="496" alt="natural-peak-areas-after" src="https://user-images.githubusercontent.com/42757252/76285943-4ea93900-62e4-11ea-8253-ed17ea3ea40f.png">