### PR TITLE
Move natural=spring back to amenity-points layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -342,33 +342,6 @@ Layer:
         ) AS water_barriers_poly
     properties:
       minzoom: 13
-  - id: springs
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            "natural"
-          FROM
-          (SELECT
-              ST_PointOnSurface(way) AS way,
-              "natural"
-            FROM planet_osm_polygon
-            WHERE way && !bbox!
-            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
-          UNION ALL
-          SELECT
-              way,
-              "natural"
-            FROM planet_osm_point
-            WHERE way && !bbox!
-            ) _
-          WHERE "natural" IN ('spring')
-        ) AS springs
-    properties:
-      minzoom: 14
   - id: piers-poly
     geometry: polygon
     <<: *extents

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1382,6 +1382,11 @@
     marker-clip: false;
   }
 
+  [feature = 'natural_spring'][zoom >= 14] {
+    marker-file: url('symbols/spring.svg');
+    marker-clip: false;
+  }
+
   [feature = 'natural_cave_entrance'][zoom >= 15] {
     marker-file: url('symbols/natural/cave.svg');
     marker-clip: false;

--- a/style/water-features.mss
+++ b/style/water-features.mss
@@ -158,10 +158,3 @@
     }
   }
 }
-
-#springs {
-  [natural = 'spring'][zoom >= 14] {
-    marker-file: url('symbols/spring.svg');
-    marker-clip: false;
-  }
-}


### PR DESCRIPTION
Fixes #4011

Changes proposed in this pull request:
- Move `natural=spring` icon back to amenity-points layer, delete current `springs` layer
- Previously springs were rendered below water-lines. This is not longer the case, so springs can be rendered with other symbols again
- Springs now render above paths and highways, like other point symbols.
- This change should slightly improve performance, and springs will no longer render with priority to placenames such as hamlets and villages.

Test rendering with links to the example places:

z14 Before
![z14-japan-springs-before png](https://user-images.githubusercontent.com/42757252/76307875-ffc3c980-630c-11ea-9565-6cae6fee4b50.png)

z14 After - place label now seen (upper left)
![z14-japan-springs-after](https://user-images.githubusercontent.com/42757252/76307889-06ead780-630d-11ea-8498-207de5d4d9f1.png)

z15 before
![z15-japan-springs-before png](https://user-images.githubusercontent.com/42757252/76307924-1833e400-630d-11ea-87f8-abc93c8ad2c5.png)

z15 after
![z15-japan-springs-after](https://user-images.githubusercontent.com/42757252/76307959-271a9680-630d-11ea-84e4-16f9a61291c3.png)

z16 before
![z16-japan-springs-before-](https://user-images.githubusercontent.com/42757252/76308008-44e7fb80-630d-11ea-9193-4a71c3193d46.png)

z16 after
![z16-japan-springs-after](https://user-images.githubusercontent.com/42757252/76308015-474a5580-630d-11ea-8108-a868cdf6eda0.png)
- Shinto place of worship, place name, and funicular station now all show with priority over the springs.