### PR TITLE
Render bare_rock pattern from z13, same as shingle and scree

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -480,14 +480,12 @@
 
   [feature = 'natural_bare_rock'][zoom >= 5] {
     polygon-fill: @bare_ground;
-    polygon-pattern-file: url('symbols/rock_overlay.png');
-    [way_pixels >= 4] {
-      polygon-gamma: 0.75;
-      polygon-pattern-gamma: 0.75;
-    }
-    [way_pixels >= 64] {
-      polygon-gamma: 0.3;
-      polygon-pattern-gamma: 0.3;
+    [way_pixels >= 4]  { polygon-gamma: 0.75; }
+    [way_pixels >= 64] { polygon-gamma: 0.3;  }
+    [zoom >= 13] {
+      polygon-pattern-file: url('symbols/rock_overlay.png');
+      [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
     }
   }
 


### PR DESCRIPTION
### Fixes #3862
### Partial revert of #3458

## Changes proposed in this pull request:
- Renders `rock_overlay.png` pattern from z13 only, instead of z5, for `natural=bare_rock`
- This is the same level when the similar features `natural=scree` and `natural=shingle` are first distinguished from `natural=bare_rock` by a pattern.
- At mid and low zoom levels the great majority of bare_rock areas are too small for the pattern to be clearly seen, but the pattern adds noise and makes it harder to interprete the outline of these areas. For this reason, the pattern is not shown for scree or shingle before z13 (similarly, scrub, forest and other patterns are not shown before z13).
- Currently the only very large areas of bare_rock are coarsely-mapped desert areas, which really consist of a mix of sand, scree, bare_rock, heath, grass, etc, and our showing the pattern early gives unintentionaly encouragement to mapping really large areas like this coarsely, rather than showing the detailed landcover/surface in each spot.


## Test renderings with links to the example places:

### Wales - NW
- Most areas of bare rock in Wales are small patches on peaks or near quarries or along the ocean, as in most of Europe.

https://www.openstreetmap.org/#map=12/53.0707/-4.1940
z13 - unchanged
<img width="599" alt="wales-bare_rock-scree-z13-after" src="https://user-images.githubusercontent.com/42757252/76478812-2e48be00-644d-11ea-9f8d-8091402e791e.png">

**z12 before**
<img width="599" alt="wales-bare_rock-scree-before-12:53 0707:-4 1940" src="https://user-images.githubusercontent.com/42757252/76477795-c3e24e80-6449-11ea-84b1-82ab994b7fa6.png">

_z12 after_
<img width="599" alt="wales-bare_rock-scree-after-12:53 0707:-4 1940" src="https://user-images.githubusercontent.com/42757252/76478824-34d73580-644d-11ea-93ec-d23330476357.png">

**z11 before**
![wales-bare_rock-scree-before-z11](https://user-images.githubusercontent.com/42757252/76477808-ccd32000-6449-11ea-8639-8a2deb4735bf.png)

_z11 after_
![wales-bare_rock-scree-after-z11](https://user-images.githubusercontent.com/42757252/76478828-386abc80-644d-11ea-90f9-f300ba827293.png)


### Wales - Snowdonia National Park
- This is by far the largest area of bare_rock in Wales
https://www.openstreetmap.org/#map=13/52.9000/-4.0023

z13 Unchanged
![wales-bare_rock-scree-moors-after-13:52 9000:-4 0023 png](https://user-images.githubusercontent.com/42757252/76478844-47ea0580-644d-11ea-93ce-6a98f30bf83e.png)

**z12 before**
![wales-bare_rock-scree-moors-before-z12](https://user-images.githubusercontent.com/42757252/76478850-4b7d8c80-644d-11ea-9fa9-4c1f156b4bd6.png)

_z12 after_
![wales-bare_rock-scree-moors-after-z12](https://user-images.githubusercontent.com/42757252/76478859-4fa9aa00-644d-11ea-8e4b-0cb5701e8612.png)

**z11 before**
![wales-bare_rock-scree-moors-before-z11](https://user-images.githubusercontent.com/42757252/76478874-589a7b80-644d-11ea-93a5-2e6e6d392a69.png)

_z11 after_
![wales-bare_rock-scree-moors-after-z11](https://user-images.githubusercontent.com/42757252/76478883-5c2e0280-644d-11ea-8811-728d078cc401.png)


### Corsica - South
- Like most of Metropolitan France, Corisica has somewhat complete landcover mapping from imports, so it's not very high resolution.
- This is the largest bare_rock area in Corscia:
https://www.openstreetmap.org/#map=12/41.6185/9.1643.png

z13 same
![north-corsica-rock-scree-z13](https://user-images.githubusercontent.com/42757252/76478927-7e278500-644d-11ea-8bfa-6c74a2446df4.png)

**z12 before**
![south-corsica-rock-scree-before-12:41 6185:9 1643](https://user-images.githubusercontent.com/42757252/76478936-82ec3900-644d-11ea-9027-a0998e3537d0.png)

_z12 after_
![south-corsica-rock-scree-after-12:41 6185:9 1643](https://user-images.githubusercontent.com/42757252/76478943-88e21a00-644d-11ea-893b-eeffcfb45893.png)

**z11 before**
![south-corsica-rock-scree-before-z11](https://user-images.githubusercontent.com/42757252/76479029-ccd51f00-644d-11ea-8cf8-01f366d34864.png)

_z11 after_
![south-corsica-rock-scree-after-z11](https://user-images.githubusercontent.com/42757252/76478954-913a5500-644d-11ea-81e2-f81f8e61fb02.png)


### Corsica - North
- These areas of bare_rock are average-sized for Corsica
https://www.openstreetmap.org/#map=12/42.5801/9.3068

z13 same
![north-corsica-rock-scree-z13](https://user-images.githubusercontent.com/42757252/76478965-98f9f980-644d-11ea-8c94-73edfaa6a8e9.png)

**z12 before**
![north-corsica-rock-scree-before-12:42 5801:9 3068](https://user-images.githubusercontent.com/42757252/76479002-b5963180-644d-11ea-8816-cc19fe69226b.png)

_z12 after_
![north-corsica-rock-scree-after-12:42 5801:9 3068](https://user-images.githubusercontent.com/42757252/76479007-bc24a900-644d-11ea-9a62-dd409f7e7132.png)

**z11 before**
![north-corsica-rock-scree-before-z11](https://user-images.githubusercontent.com/42757252/76478948-8d0e3780-644d-11ea-866c-1bc8e9335323.png)

_z11 after_
![north-corsica-rock-scree-after-z11](https://user-images.githubusercontent.com/42757252/76479024-c9da2e80-644d-11ea-8c69-8239c308ef8c.png)