### PR TITLE
WIP: update: moving to the postgis/postgis:10-2.5 docker image

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM mdillon/postgis:10
+FROM postgis/postgis:10-2.5
 
 ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d


### PR DESCRIPTION
imho:  It is a simple Postgres/Postgis Security Fix & Update

Changes proposed in this pull request:
- moving from ~1y old `mdillon/postgis:10` image to the new postgis image  

Before
* `mdillon/postgis:10`:  PG10.7  ;  POSTGIS=2.5.2  (  ~1y old ; without the latest fixes )

After
* `postgis/postgis:10-2.5`  PG10.12 ; POSTGIS=2.5.4  ( with the latest patches )
    * in theory it should work with current docker volumes.
   
Background:
* The original repo has a new maintainers:  https://github.com/postgis/docker-postgis/issues/143
  and the new docker hub is different  : https://registry.hub.docker.com/r/postgis/postgis/

Alternative:
* moving to the latest PG/Postgis :  `postgis/postgis:12-3.0`   ( see the other images:  https://github.com/postgis/docker-postgis ) 


