### PR TITLE
Update keyserver URL for osmadmins PPA

### DIFF
--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -7,7 +7,7 @@ RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main\n\
 deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main' > \
     /etc/apt/sources.list.d/osmadmins-ppa.list
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Recent builds of the Dockerfile.import failed because they couldn't
download the key for the osmadmins PPA.  Specifying hkp and port 80
fixes this.

Fixes #3999

This commit makes no changes to rendering.

Note: This works on my machine in different parts of a corporate network. I was not able to test it more widely, but I expect other networks may be more open and may not have had the original issue.