### PR TITLE
Render place=square in amenity-points layer with placenames style from z17

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1279,25 +1279,21 @@ Layer:
         (SELECT
             way,
             place,
-            leisure,
             name
           FROM planet_osm_point
           WHERE place IN ('village', 'hamlet')
              AND name IS NOT NULL
              AND NOT tags @> 'capital=>yes'
              OR (place IN ('suburb', 'quarter', 'neighbourhood', 'isolated_dwelling', 'farm')
-                 OR (place IN ('square')
-                     AND (leisure is NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden')))
              ) AND name IS NOT NULL
           ORDER BY CASE
-              WHEN place = 'suburb' THEN 8
-              WHEN place = 'village' THEN 7
-              WHEN place = 'hamlet' THEN 6
-              WHEN place = 'quarter' THEN 5
-              WHEN place = 'neighbourhood' THEN 4
-              WHEN place = 'isolated_dwelling' THEN 3
-              WHEN place = 'farm' THEN 2
-              WHEN place = 'square' THEN 1
+              WHEN place = 'suburb' THEN 7
+              WHEN place = 'village' THEN 6
+              WHEN place = 'hamlet' THEN 5
+              WHEN place = 'quarter' THEN 4
+              WHEN place = 'neighbourhood' THEN 3
+              WHEN place = 'isolated_dwelling' THEN 2
+              WHEN place = 'farm' THEN 1
             END DESC,
             length(name) DESC,
             name
@@ -1468,11 +1464,11 @@ Layer:
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
                                                     'construction', 'military', 'plant_nursery') THEN landuse END,
                 'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" END,
-                'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
-                                                      'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
+                'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'bay', 'spring',
+                                                      'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" END,
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway END,
-                'place_' || CASE WHEN place IN ('island', 'islet') THEN place END,
+                'place_' || CASE WHEN place IN ('island', 'islet', 'square') THEN place END,
                 'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'fort', 'castle', 'manor', 'city_gate')
                               THEN historic END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military END,
@@ -1768,8 +1764,6 @@ Layer:
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             highway,
-            place,
-            leisure,
             name
           FROM planet_osm_polygon
           WHERE way && !bbox!
@@ -1777,9 +1771,7 @@ Layer:
               OR (railway IN ('platform')
                   AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                   AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                  AND (covered NOT IN ('yes') OR covered IS NULL))
-              OR (place IN ('square')
-                  AND (leisure IS NULL OR NOT leisure IN ('park', 'recreation_ground', 'garden'))))
+                  AND (covered NOT IN ('yes') OR covered IS NULL)))
             AND name IS NOT NULL
             AND way_area > 3000*POW(!scale_denominator!*0.001*0.28,2)
             AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)

--- a/project.mml
+++ b/project.mml
@@ -1464,8 +1464,8 @@ Layer:
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
                                                     'construction', 'military', 'plant_nursery') THEN landuse END,
                 'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" END,
-                'natural_' || CASE WHEN "natural" IN ('wood', 'peak', 'volcano', 'saddle', 'cave_entrance', 'water', 'mud', 'wetland', 'bay', 'spring',
-                                                      'scree', 'shingle', 'bare_rock', 'sand', 'heath', 'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
+                'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
+                                                      'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
                                                       THEN "natural" END,
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway END,
                 'place_' || CASE WHEN place IN ('island', 'islet', 'square') THEN place END,

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1620,6 +1620,17 @@
     }
   }
 
+  [feature = 'place_square'][zoom >= 17] {
+    text-name: "[name]";
+    text-size: 11;
+    text-face-name: @book-fonts;
+    text-halo-fill: @standard-halo-fill;
+    text-halo-radius: @standard-halo-radius * 1.5;
+    text-wrap-width: 45; // 4.5 em
+    text-line-spacing: -0.8; // -0.08 em
+    text-margin: 7.0; // 0.7 em
+  }
+
   [feature = 'amenity_pub'][zoom >= 18],
   [feature = 'amenity_restaurant'][zoom >= 18],
   [feature = 'amenity_food_court'][zoom >= 17],

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -454,13 +454,4 @@
       text-halo-fill: white;
     }
   }
-  [place = 'square'] {
-    [zoom >= 17] {
-      text-name: "[name]";
-      text-size: 11;
-      text-face-name: @book-fonts;
-      text-wrap-width: 30; // 2.7 em
-      text-line-spacing: -1.7; // -0.15 em
-    }
-  }
 }


### PR DESCRIPTION
Fixes  #4043

Changes proposed in this pull request:
- Removes rendering of `place=square` areas from roads_area_text_name and moves rendering from placenames to amenity-points like place=locality, since the text label is only rendered at z17 and above. 
- This change improves the rendering priority system, since now place=square features will not block icons which are rendered at z15 and z16. 
- The text style is slightly adjusted to match `place=locality` and `place=neighborhood` features

This makes place=square rendering consistent with `place=locality`, and more similar to `place=neighborhood` and `place=quarter`, with the rendering starting at a fixed zoom level.

Currently, very large place=square areas will render sooner than z17, and very small features will ony render from z18. Now all will initially render at z17, if they are not blocked by a higher-priority feature (such as a `highway=pedestrian` area label or a junction=yes node, or by an amenity=marketplace or leisure=park tag on the same feature)

However, unlike those other "place" features, this will still render `place=square` when mapped as an area or as a node. (Most place=square features are mapped as areas)