### PR TITLE
Remove information=tactile_model rendering

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -386,8 +386,7 @@
       marker-fill: @amenity-brown;
     }
     [information = 'map'],
-    [information = 'tactile_map'],
-    [information = 'tactile_model'] {
+    [information = 'tactile_map'] {
       marker-file: url('symbols/tourism/map.svg');
     }
     [information = 'terminal'] {


### PR DESCRIPTION
The symbol used for tactile_model is the same as that used for a map, which is misleading

Fixes #4021

Changes proposed in this pull request:
- Remove `information=tactile_model` rendering

The symbol used for `tactile_model` is the same as that used for a map, which is misleading