### PR TITLE
Remove the rendering of waterways with tunnel=flooded

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -176,6 +176,7 @@ Layer:
             CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('stream', 'drain', 'ditch')
+            AND tunnel NOT IN ('flooded')
         ) AS water_lines_casing
     properties:
       minzoom: 13

--- a/project.mml
+++ b/project.mml
@@ -2122,7 +2122,7 @@ Layer:
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
                  OR "natural" IN ('bay', 'strait'))
-            AND (tunnel IS NULL or tunnel NOT IN ('culvert', 'flooded'))
+            AND (tunnel IS NULL OR tunnel NOT IN ('culvert', 'flooded'))
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)
         ) AS water_lines_text

--- a/project.mml
+++ b/project.mml
@@ -215,6 +215,7 @@ Layer:
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
             AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
+            AND (tunnel IS NULL OR tunnel NOT IN ('flooded'))
           ORDER BY COALESCE(layer,0)
         ) AS water_lines
     properties:
@@ -2121,7 +2122,7 @@ Layer:
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
                  OR "natural" IN ('bay', 'strait'))
-            AND (tunnel IS NULL or tunnel != 'culvert')
+            AND (tunnel IS NULL or tunnel NOT IN ('culvert', 'flooded'))
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)
         ) AS water_lines_text

--- a/project.mml
+++ b/project.mml
@@ -173,10 +173,11 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway='canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('stream', 'drain', 'ditch')
-            AND tunnel NOT IN ('flooded')
         ) AS water_lines_casing
     properties:
       minzoom: 13
@@ -211,12 +212,13 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway = 'canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel,
             'no' AS bridge
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
             AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
-            AND (tunnel IS NULL OR tunnel NOT IN ('flooded'))
           ORDER BY COALESCE(layer,0)
         ) AS water_lines
     properties:
@@ -897,7 +899,9 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel,
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway = 'canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel,
             'yes' AS bridge
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
@@ -2119,11 +2123,13 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') THEN 'yes' ELSE 'no' END AS int_tunnel
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway = 'canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
                  OR "natural" IN ('bay', 'strait'))
-            AND (tunnel IS NULL OR tunnel NOT IN ('culvert', 'flooded'))
+            AND (tunnel IS NULL OR tunnel != 'culvert')
             AND name IS NOT NULL
           ORDER BY COALESCE(layer,0)
         ) AS water_lines_text


### PR DESCRIPTION
Fixes #3179

Changes proposed in this pull request:
- exclude `tunnel=flooded` for waterways

Test rendering with links to the example places:
https://www.openstreetmap.org/way/369442787
Before
![flooded_before_z15](https://user-images.githubusercontent.com/9897203/77195455-f17e6600-6ae1-11ea-97d0-03cc8294dbb5.png)

After
![flooded_after_z15](https://user-images.githubusercontent.com/9897203/77195468-f6431a00-6ae1-11ea-84c0-8e61460fe293.png)
