### PR TITLE
Remove power=sub_station/station rendering, add power=plant fill color

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -111,7 +111,7 @@ Layer:
               ('man_made_' || (CASE WHEN man_made IN ('works', 'wastewater_plant', 'water_works') THEN man_made END)) AS man_made,
               ('natural_' || (CASE WHEN "natural" IN ('beach', 'shoal', 'heath', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub') THEN "natural" END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" = 'mud' THEN "natural" ELSE tags->'wetland' END) END)) AS wetland,
-              ('power_' || (CASE WHEN power IN ('substation', 'generator') THEN power END)) AS power,
+              ('power_' || (CASE WHEN power IN ('plant', 'substation', 'generator') THEN power END)) AS power,
               ('tourism_' || (CASE WHEN tourism IN ('camp_site', 'caravan_site', 'picnic_site') THEN tourism END)) AS tourism,
               ('highway_' || (CASE WHEN highway IN ('services', 'rest_area') THEN highway END)) AS highway,
               ('railway_' || (CASE WHEN railway = 'station' THEN railway END)) AS railway,
@@ -1456,13 +1456,8 @@ Layer:
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
                                                     'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
-<<<<<<< HEAD
                                                     'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure END,
-                'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power END,
-=======
-                                                    'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure ELSE NULL END,
-                'power_' || CASE WHEN power IN ('plant', 'generator', 'substation') THEN power ELSE NULL END,
->>>>>>> fa40886... Remove rendering of power=station and power=sub_station
+                'power_' || CASE WHEN power IN ('plant', 'generator', 'substation') THEN power END,
                 'man_made_' || CASE WHEN (man_made IN ('chimney', 'communications_tower', 'crane', 'lighthouse', 'mast', 'obelisk', 'silo', 'storage_tank',
                                                        'telescope', 'tower', 'wastewater_plant', 'water_tower', 'water_works', 'windmill', 'works')
                                             AND (tags->'location' NOT IN ('roof', 'rooftop') OR NOT (tags ? 'location'))) THEN man_made END,

--- a/project.mml
+++ b/project.mml
@@ -111,7 +111,7 @@ Layer:
               ('man_made_' || (CASE WHEN man_made IN ('works', 'wastewater_plant', 'water_works') THEN man_made END)) AS man_made,
               ('natural_' || (CASE WHEN "natural" IN ('beach', 'shoal', 'heath', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub') THEN "natural" END)) AS "natural",
               ('wetland_' || (CASE WHEN "natural" IN ('wetland', 'mud') THEN (CASE WHEN "natural" = 'mud' THEN "natural" ELSE tags->'wetland' END) END)) AS wetland,
-              ('power_' || (CASE WHEN power IN ('station', 'sub_station', 'substation', 'generator') THEN power END)) AS power,
+              ('power_' || (CASE WHEN power IN ('substation', 'generator') THEN power END)) AS power,
               ('tourism_' || (CASE WHEN tourism IN ('camp_site', 'caravan_site', 'picnic_site') THEN tourism END)) AS tourism,
               ('highway_' || (CASE WHEN highway IN ('services', 'rest_area') THEN highway END)) AS highway,
               ('railway_' || (CASE WHEN railway = 'station' THEN railway END)) AS railway,
@@ -128,7 +128,7 @@ Layer:
                              'arts_centre', 'parking_space', 'bus_station', 'fire_station', 'police')
               OR man_made IN ('works', 'wastewater_plant','water_works')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')
-              OR power IN ('station', 'sub_station', 'substation', 'generator')
+              OR power IN ('plant', 'substation', 'generator')
               OR shop IN ('mall')
               OR tourism IN ('camp_site', 'caravan_site', 'picnic_site')
               OR highway IN ('services', 'rest_area')
@@ -1456,8 +1456,13 @@ Layer:
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
                                                     'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
+<<<<<<< HEAD
                                                     'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure END,
                 'power_' || CASE WHEN power IN ('plant', 'station', 'generator', 'sub_station', 'substation') THEN power END,
+=======
+                                                    'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure ELSE NULL END,
+                'power_' || CASE WHEN power IN ('plant', 'generator', 'substation') THEN power ELSE NULL END,
+>>>>>>> fa40886... Remove rendering of power=station and power=sub_station
                 'man_made_' || CASE WHEN (man_made IN ('chimney', 'communications_tower', 'crane', 'lighthouse', 'mast', 'obelisk', 'silo', 'storage_tank',
                                                        'telescope', 'tower', 'wastewater_plant', 'water_tower', 'water_works', 'windmill', 'works')
                                             AND (tags->'location' NOT IN ('roof', 'rooftop') OR NOT (tags ? 'location'))) THEN man_made END,

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2686,9 +2686,7 @@
   }
 
   [feature = 'power_plant'][is_building = 'no'][zoom >= 10],
-  [feature = 'power_station'][is_building = 'no'][zoom >= 10],
   [feature = 'power_generator'][is_building = 'no']["generator:source" != 'wind'][zoom >= 10],
-  [feature = 'power_sub_station'][is_building = 'no'][zoom >= 13],
   [feature = 'power_substation'][is_building = 'no'][zoom >= 13]{
     [way_pixels > 3000],
     [zoom >= 17] {

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -427,6 +427,7 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
+  [feature = 'power_plant'][zoom >= 10],
   [feature = 'power_generator'][zoom >= 10],
   [feature = 'power_substation'][zoom >= 13] {
     polygon-fill: @industrial;

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -427,9 +427,7 @@
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
-  [feature = 'power_station'][zoom >= 10],
   [feature = 'power_generator'][zoom >= 10],
-  [feature = 'power_sub_station'][zoom >= 13],
   [feature = 'power_substation'][zoom >= 13] {
     polygon-fill: @industrial;
     [zoom >= 15] {


### PR DESCRIPTION
Fixes #3871
Fixes #3405

Changes proposed in this pull request:
- Remove rendering of power=sub_station - this tag has been replaced by power=substation
- Remove rendering of power=station - this tag has been replaced by power=plant
- Render the `@power` fill color for `power=plant`, same as with `power=substation`

Currently we still render the old tags power=sub_station and power=station, but the new tags power=substation and power=plant are many times more common now: 

power=sub_station is much less popular than power=substation ([300k](https://taginfo.openstreetmap.org//search?q=power%3Dsub_station) > [13k](https://taginfo.openstreetmap.org//search?q=power%3Dsubstation))

power=station has dropped steadily ([3k](https://taginfo.openstreetmap.org//search?q=power%3Dstation)) vs  power=plant ([19k](https://taginfo.openstreetmap.org//search?q=power%3Dplant)).

The newer tags `power=substation` and `power=plant` are already rendered, except `power=plant` does not have an outline or fill color. 

An alternative would be to only render an outline, but I found this was confusing with `shop=mall` areas in a previous PR. The fill color works better. 