### PR TITLE
Change wetland pattern initial zoom to z10 again

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -291,7 +291,7 @@ Layer:
         ) AS landcover_area_symbols
     properties:
       cache-features: true
-      minzoom: 5
+      minzoom: 9
   - id: icesheet-outlines
     geometry: linestring
     <<: *extents

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -725,7 +725,7 @@
     }
   }
 
-  [int_wetland != null][zoom >= 5] {
+  [int_wetland != null][zoom >= 10] {
     polygon-pattern-file: url('symbols/wetland.png');
     polygon-pattern-alignment: global;
   }


### PR DESCRIPTION
### Fixes #3862

## Changes proposed in this pull request:
- Change wetland pattern initial zoom back to z10
- Change landcover-area-symbols intial zoom back to z9

## Test rendering with links to the example places:

### Wales
https://www.openstreetmap.org/#map=9/53.0313/-3.1421
Before z9
![wetland-before-wales-9:53 0313:-3 1421](https://user-images.githubusercontent.com/42757252/77814551-627ed880-70f5-11ea-83b0-986394f3dd5d.png)

After z9
![wetland-after-wales-9:53 0313:-3 1421](https://user-images.githubusercontent.com/42757252/77814552-63b00580-70f5-11ea-993d-19a2e6f2999c.png)

Before z8
![wetland-before-wales-8](https://user-images.githubusercontent.com/42757252/77814557-690d5000-70f5-11ea-8088-70e3e2e95d5d.png)

After z8
![wetland-after-wales-8](https://user-images.githubusercontent.com/42757252/77814560-6d396d80-70f5-11ea-8bac-09d5ccd03455.png)

Before z7
![wetland-before-wales-7](https://user-images.githubusercontent.com/42757252/77814588-978b2b00-70f5-11ea-88ed-16b13c06c757.png)

After z7
![wetland-after-wales-7](https://user-images.githubusercontent.com/42757252/77814564-70ccf480-70f5-11ea-8970-779c7a6c2199.png)

### Latvia
https://www.openstreetmap.org/#map=9/56.5125/26.4606
Before z9
![wetland-before-latvia-9:56 5125:26 4606](https://user-images.githubusercontent.com/42757252/77814578-77f40280-70f5-11ea-8584-91ece9239586.png)

After z9
![wetland-after-latvia-9:56 5125:26 4606](https://user-images.githubusercontent.com/42757252/77814581-7b878980-70f5-11ea-897a-6fa41225fd9b.png)

Before z8
![wetland-before-latvia-8:56 792:26 889](https://user-images.githubusercontent.com/42757252/77822880-f70b2a00-7139-11ea-9b04-ae1e282b9dd4.png)

After z8
![wetland-after-latvia-8:56 792:26 889](https://user-images.githubusercontent.com/42757252/77814584-83472e00-70f5-11ea-9256-e13d940a2213.png)