### PR TITLE
Rework admin boundaries and show admin_level=5/6/7 sooner, level=10 later

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1041,7 +1041,7 @@ Layer:
         ) AS admin_low_zoom
     properties:
       minzoom: 4
-      maxzoom: 10
+      maxzoom: 7
   - id: admin-mid-zoom
     geometry: linestring
     <<: *extents
@@ -1058,7 +1058,7 @@ Layer:
           ORDER BY admin_level DESC
         ) AS admin_mid_zoom
     properties:
-      minzoom: 11
+      minzoom: 8
       maxzoom: 12
   - id: admin-high-zoom
     geometry: linestring
@@ -1197,6 +1197,7 @@ Layer:
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name,
+            admin_level,
             ref
           FROM planet_osm_polygon
           WHERE way && !bbox!
@@ -1255,6 +1256,31 @@ Layer:
       cache-features: true
       minzoom: 4
       maxzoom: 15
+  - id: county-names
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            ST_PointOnSurface(way) AS way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            name,
+            admin_level
+          FROM planet_osm_polygon
+          WHERE way && !bbox!
+            AND boundary = 'administrative'
+            AND admin_level IN ('5', '6')
+            AND name IS NOT NULL
+            AND way_area > 3000*POW(!scale_denominator!*0.001*0.28,2)
+            AND way_area < 196000*POW(!scale_denominator!*0.001*0.28,2)
+            AND osm_id < 0
+          ORDER BY
+            admin_level,
+            way_area DESC
+        ) AS county_names
+    properties:
+      minzoom: 4
   - id: placenames-small
     geometry: point
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -2127,6 +2127,7 @@ Layer:
             AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
             AND name IS NOT NULL
             AND osm_id < 0
+            AND way_area > 196000*POW(!scale_denominator!*0.001*0.28,2)
           ORDER BY admin_level::integer ASC, way_area DESC
         ) AS admin_text
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1280,7 +1280,7 @@ Layer:
             way_area DESC
         ) AS county_names
     properties:
-      minzoom: 4
+      minzoom: 8
   - id: placenames-small
     geometry: point
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -1256,31 +1256,6 @@ Layer:
       cache-features: true
       minzoom: 4
       maxzoom: 15
-  - id: county-names
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            ST_PointOnSurface(way) AS way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            name,
-            admin_level
-          FROM planet_osm_polygon
-          WHERE way && !bbox!
-            AND boundary = 'administrative'
-            AND admin_level IN ('5', '6')
-            AND name IS NOT NULL
-            AND way_area > 3000*POW(!scale_denominator!*0.001*0.28,2)
-            AND way_area < 196000*POW(!scale_denominator!*0.001*0.28,2)
-            AND osm_id < 0
-          ORDER BY
-            admin_level,
-            way_area DESC
-        ) AS county_names
-    properties:
-      minzoom: 8
   - id: placenames-small
     geometry: point
     <<: *extents
@@ -1419,6 +1394,31 @@ Layer:
         ) AS bridge_text
     properties:
       minzoom: 11
+  - id: county-names
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            ST_PointOnSurface(way) AS way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            name,
+            admin_level
+          FROM planet_osm_polygon
+          WHERE way && !bbox!
+            AND boundary = 'administrative'
+            AND admin_level IN ('5', '6')
+            AND name IS NOT NULL
+            AND way_area > 12000*POW(!scale_denominator!*0.001*0.28,2)
+            AND way_area < 196000*POW(!scale_denominator!*0.001*0.28,2)
+            AND osm_id < 0
+          ORDER BY
+            admin_level,
+            way_area DESC
+        ) AS county_names
+    properties:
+      minzoom: 8
   - id: amenity-points
     geometry: point
     <<: *extents

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -9,45 +9,57 @@ For each zoomlevel, all borders come from a single attachment, to handle
 overlapping borders correctly.
 */
 
-#admin-low-zoom[zoom < 11],
-#admin-mid-zoom[zoom >= 11][zoom < 13],
+#admin-low-zoom[zoom < 8],
+#admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
   [admin_level = '2'] {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.2;
+      background/line-width: 1.0;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1.2;
+      line-width: 1.0;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 5] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    }
+    [zoom >= 6] {
       background/line-width: 1.5;
       line-width: 1.5;
     }
-    [zoom >= 6] {
+    [zoom >= 7] {
       background/line-width: 1.8;
       line-width: 1.8;
     }
-    [zoom >= 7] {
-      background/line-width: 2;
-      line-width: 2;
-    }
     [zoom >= 8] {
-      background/line-width: 3;
-      line-width: 3;
+      background/line-width: 2.5;
+      line-width: 2.5;
     }
     [zoom >= 9] {
-      background/line-width: 3.2;
-      line-width: 3.2;
+      background/line-width: 3.0;
+      line-width: 3.0;
     }
     [zoom >= 10] {
+      background/line-width: 4;
+      line-width: 4;
+    }
+    [zoom >= 11] {
+      background/line-width: 5;
+      line-width: 5;
+    }
+    [zoom >= 12] {
       background/line-width: 6;
       line-width: 6;
+    }
+    [zoom >= 15] {
+      background/line-width: 8;
+      line-width: 8;
     }
   }
 
@@ -64,15 +76,47 @@ overlapping borders correctly.
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
     }
+    [zoom >= 5] {
+      background/line-width: 0.8;
+      line-width: 0.8;
+    }
+    [zoom >= 6] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
     [zoom >= 7] {
       background/line-width: 1.2;
       line-width: 1.2;
     }
+    [zoom >= 8] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 9] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+    }
     [zoom >= 10] {
-      background/line-width: 4;
-      line-width: 4;
+      background/line-width: 2.5;
+      line-width: 2.5;
       line-dasharray: 4,2;
       line-clip: false;
+    }
+    [zoom >= 11] {
+      background/line-width: 3;
+      line-width: 3;
+    }
+    [zoom >= 12] {
+      background/line-width: 3.5;
+      line-width: 3.5;
+    }
+    [zoom >= 13] {
+      background/line-width: 4;
+      line-width: 4;
+    }
+    [zoom >= 15] {
+      background/line-width: 5;
+      line-width: 5;
     }
   }
 
@@ -99,21 +143,37 @@ overlapping borders correctly.
       line-width: 0.6;
     }
     [zoom >= 7] {
-      background/line-width: 1;
+      background/line-width: 0.8;
       line-dasharray: 4,3;
-      line-width: 1;
+      line-width: 0.8;
+    }
+    [zoom >= 8] {
+      background/line-width: 1.0;
+      line-width: 1.0;
     }
     [zoom >= 9] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 10] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 11] {
+      background/line-width: 2.0;
+      line-width: 2.0;
+    }
+    [zoom >= 12] {
       background/line-width: 2.5;
       line-width: 2.5;
     }
-    [zoom >= 12] {
+    [zoom >= 13] {
       background/line-width: 3;
       line-width: 3;
+    }
+    [zoom >= 15] {
+      background/line-width: 4;
+      line-width: 4;
     }
   }
   /*
@@ -131,73 +191,137 @@ overlapping borders correctly.
   comp-op: darken;
 }
 
-#admin-mid-zoom[zoom >= 11][zoom < 13],
+#admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
-  [admin_level = '5'][zoom >= 11] {
+  [admin_level = '5'][zoom >= 8] {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 2;
+    background/line-width: 0.5;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 2;
+    line-width: 0.5;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 6,3,2,3,2,3;
     line-clip: false;
+    [zoom >= 9] {
+      background/line-width: 0.8;
+      line-width: 0.8;
+    }
+    [zoom >= 10] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
+    [zoom >= 11] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+    }
+    [zoom >= 15] {
+      background/line-width: 2;
+      line-width: 2;
+    }
+    [zoom >= 16] {
+      background/line-width: 2.5;
+      line-width: 2.5;
+    }
   }
-  [admin_level = '6'][zoom >= 11] {
+  [admin_level = '6'][zoom >= 10] {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 2;
+    background/line-width: 0.5;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 2;
+    line-width: 1.2;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 6,3,2,3;
     line-clip: false;
+    [zoom >= 11] {
+      background/line-width: 0.8;
+      line-width: 0.8;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    }
+    [zoom >= 15] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 16] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+    }
   }
   [admin_level = '7'],
   [admin_level = '8'] {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.5;
+      background/line-width: 0.5;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1.5;
+      line-width: 0.5;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
       line-dasharray: 5,2;
       line-clip: false;
+    }
+    [zoom >= 13] {
+      background/line-width: 0.8;
+      line-width: 0.8;
+    }
+    [zoom >= 15] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
+    [zoom >= 16] {
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
   }
   opacity: 0.5;
   comp-op: darken;
 }
 
-#admin-high-zoom[zoom >= 13] {
+#admin-high-zoom[zoom >= 15] {
   [admin_level = '9'],
   [admin_level = '10'] {
-    [zoom >= 13] {
+    [zoom >= 15] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 2;
+      background/line-width: 0.6;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 2;
+      line-width: 0.6;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
       line-dasharray: 2,3;
       line-clip: false;
+    }
+    [zoom >= 16] {
+      background/line-width: 0.8;
+      line-width: 0.8;
     }
   }
   opacity: 0.5;
@@ -209,8 +333,8 @@ overlapping borders correctly.
   [admin_level = '2'][way_pixels >= 360000],
   [admin_level = '3'][way_pixels >= 196000],
   [admin_level = '4'][way_pixels >= 196000],
-  [zoom >= 12][admin_level = '5'],
-  [zoom >= 13][admin_level = '6'],
+  [admin_level = '5'][way_pixels >= 196000],
+  [zoom >= 12][admin_level = '6'][way_pixels >= 196000],
   [zoom >= 14][admin_level = '7'],
   [zoom >= 15][admin_level = '8'],
   [zoom >= 16] {

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,6 @@
-@admin-boundaries: #ac46ac; // Lch(47,65,327)
+@admin-boundaries: #8d618b; // Lch(47,30,327)
+@admin-boundaries-narrow: #884e87; // Lch(42,40,327)
+@admin-boundaries-wide: #90738f; // Lch(52,20,327)
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
@@ -30,7 +32,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 1.2;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-wide;
       line-width: 1.2;
     }
     [zoom >= 5] {
@@ -80,7 +82,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 0.6;
       thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
     }
     [zoom >= 9] {
@@ -99,7 +101,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.8;
       thin/line-width: 1.8;
-      thin/line-color: @admin-boundaries;
       thin/line-dasharray: 26,2,2,2,2,2;
     }
     [zoom >= 13] {
@@ -132,7 +133,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 0.6;
       line-join: bevel;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-wide;
       line-width: 0.6;
     }
     [zoom >= 5] {
@@ -185,7 +186,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 1;
       thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 1;
       thin/line-dasharray: 6.5,1.5,1.5,1.5,6.5,2;
     }
@@ -196,7 +197,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-color: @admin-boundaries;
       thin/line-dasharray: 9,2,2,2,9,3;
     }
     [zoom >= 13] {
@@ -228,7 +228,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 0.4;
-      line-color: @admin-boundaries;
+      line-color: @admin-boundaries-wide;
       line-join: bevel;
       line-width: 0.4;
       line-clip: false;
@@ -286,9 +286,9 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 0.6;
-      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,1,6,3;
+      thin/line-dasharray: 8,2;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -297,8 +297,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1;
       thin/line-width: 1;
-      thin/line-color: @admin-boundaries;
-      thin/line-dasharray: 0,1,8,4;
+      thin/line-dasharray: 10,3;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -307,19 +306,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,1.5,9,4.5;
+      thin/line-dasharray: 12,3;
     }
   }
-  ::firstline { opacity: 0.4;
-    [zoom >= 10] { opacity: 0.5; }
-  }
-  ::wideline { opacity: 0.4;
-    [zoom >= 10] { opacity: 0.35; }
-    [zoom >= 12] { opacity: 0.3; }
-  }
-  ::narrowline { opacity: 0.6;
-    [zoom >= 10] { opacity: 0.6; }
-    [zoom >= 12] { opacity: 0.6; }
+  ::firstline { opacity: 0.5; }
+  ::wideline { opacity: 0.5; }
+  ::narrowline { opacity: 0.6; }
   }
   /*
   The following code prevents admin boundaries from being rendered on top of

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -340,17 +340,17 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-dasharray: 10,1.5,4.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.7;
+      line-width: 1.7;
     }
     [zoom >= 12] {
-      background/line-width: 2;
-      line-width: 2;
+      background/line-width: 2.1;
+      line-width: 2.1;
       line-dasharray: 16,2,6,2;
     }
     [zoom >= 14] {
-      background/line-width: 2.2;
-      line-width: 2.2;
+      background/line-width: 2.4;
+      line-width: 2.4;
       line-dasharray: 20,2,8,2;
     }
   }
@@ -368,13 +368,13 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 1.4;
     }
     [zoom >= 12] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.8;
+      line-width: 1.8;
     line-dasharray: 12,1.5,2,1.5;
     }
     [zoom >= 14] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 2.1;
+      line-width: 2.1;
       line-dasharray: 16,2,3,2;
     }
   }
@@ -390,13 +390,13 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1.4;
-      line-width: 1.4;
+      background/line-width: 1.5;
+      line-width: 1.5;
       line-dasharray: 9,2,2,2,2,2;
     }
     [zoom >= 14] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.8;
+      line-width: 1.8;
       line-dasharray: 12,2,3,2,3,2;
     }
   }
@@ -404,42 +404,42 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.2;
+      background/line-width: 1.4;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1.2;
-      line-dasharray: 6,1.5,1.5,1.5,2,1.5,1.5,1.5;
+      line-width: 1.4;
+      line-dasharray: 8,2,2,2,2.5,2,2,2;
       line-clip: false;
     }
     [zoom >= 14] {
-      background/line-width: 1.4;
-      line-width: 1.4;
-      line-dasharray: 8,2,2,2,3,2,2,2;
+      background/line-width: 1.6;
+      line-width: 1.6;
+      line-dasharray: 10,2,2,2,3,2,2,2;
     }
   }
 
   [admin_level = '9'][zoom >= 13]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 1;
+    background/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 1;
+    line-width: 1.2;
     line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 14] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1.4;
+      line-width: 1.4;
       line-dasharray: 0,4,2,2,3,2,2,4;
     }
   }
   [admin_level = '10'][zoom >= 14]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 1;
+    background/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 1;
+    line-width: 1.2;
     line-dasharray: 0,3,2,2,2,3;
     line-clip: false;
   }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -16,7 +16,7 @@ overlapping borders correctly.
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.0;
+      background/line-width: 1.2;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
@@ -26,40 +26,57 @@ overlapping borders correctly.
       line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 5] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-    }
-    [zoom >= 6] {
       background/line-width: 1.5;
       line-width: 1.5;
     }
-    [zoom >= 7] {
+    [zoom >= 6] {
       background/line-width: 1.8;
       line-width: 1.8;
     }
+    [zoom >= 7] {
+      background/line-width: 2;
+      line-width: 2;
+    }
     [zoom >= 8] {
-      background/line-width: 2.5;
-      line-width: 2.5;
+      background/line-width: 2.8;
+      line-width: 2.8;
     }
     [zoom >= 9] {
-      background/line-width: 3.0;
-      line-width: 3.0;
+      background/line-width: 3.5;
+      line-width: 3.5;
     }
     [zoom >= 10] {
-      background/line-width: 4;
-      line-width: 4;
+      background/line-width: 4.5;
+      line-width: 4.5;
+      thin/line-width: 0.8;
+      thin/line-join: bevel;
+      thin/line-color: black;
+      thin/line-width: 0.8;
+      thin/line-dasharray: 18,1.5,1.5,1.5;
+      thin/line-simplify: @admin-simplify;
+      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 11] {
       background/line-width: 5;
       line-width: 5;
+      thin/line-width: 1.0;
     }
     [zoom >= 12] {
       background/line-width: 6;
       line-width: 6;
+      thin/line-width: 1.2;
+      thin/line-dasharray: 24,2,2,2;
+    }
+    [zoom >= 13] {
+      background/line-width: 7;
+      line-width: 7;
+      thin/line-width: 1.5;
     }
     [zoom >= 15] {
-      background/line-width: 8;
-      line-width: 8;
+      background/line-width: 9;
+      line-width: 9;
+      thin/line-width: 2.0;
+      thin/line-dasharray: 36,3,3,3;
     }
   }
 
@@ -93,30 +110,43 @@ overlapping borders correctly.
       line-width: 1.5;
     }
     [zoom >= 9] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 2.0;
+      line-width: 2.0;
     }
     [zoom >= 10] {
-      background/line-width: 2.5;
-      line-width: 2.5;
-      line-dasharray: 4,2;
-      line-clip: false;
+      background/line-width: 3.0;
+      line-width: 3.0;
+      line-dasharray: 0,1,6,1;
+      thin/line-join: bevel;
+      thin/line-color: black;
+      thin/line-width: 0.8;
+      thin/line-simplify: @admin-simplify;
+      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 11] {
-      background/line-width: 3;
-      line-width: 3;
-    }
-    [zoom >= 12] {
       background/line-width: 3.5;
       line-width: 3.5;
+      thin/line-width: 1.0;
+    }
+    [zoom >= 12] {
+      background/line-width: 4.0;
+      line-width: 4.0;
+      line-dasharray: 0,1.5,9,1.5;
+      thin/line-width: 1.0;
+      line-dasharray: 0,1.5,9,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 4;
-      line-width: 4;
-    }
-    [zoom >= 15] {
       background/line-width: 5;
       line-width: 5;
+      thin/line-width: 1.2;
+      thin/line-dasharray: 0,1.5,10,1.5;
+    }
+    [zoom >= 15] {
+      background/line-width: 6;
+      line-width: 6;
+      line-dasharray: 0,2,12,2;
+      thin/line-width: 1.5;
+      thin/line-dasharray: 0,2,12,2;
     }
   }
 
@@ -135,45 +165,61 @@ overlapping borders correctly.
       line-clip: false;
     }
     [zoom >= 5] {
-      background/line-width: 0.5;
-      line-width: 0.5;
-    }
-    [zoom >= 6] {
       background/line-width: 0.6;
       line-width: 0.6;
     }
-    [zoom >= 7] {
+    [zoom >= 6] {
       background/line-width: 0.8;
-      line-dasharray: 4,3;
       line-width: 0.8;
     }
-    [zoom >= 8] {
-      background/line-width: 1.0;
-      line-width: 1.0;
+    [zoom >= 7] {
+      background/line-width: 1;
+      line-width: 1;
+      line-dasharray: 4,2;
     }
-    [zoom >= 9] {
+    [zoom >= 8] {
       background/line-width: 1.2;
       line-width: 1.2;
+      line-dasharray: 6,2;
+
+    }
+    [zoom >= 9] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+      line-dasharray: 8,3;
+
     }
     [zoom >= 10] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-    }
-    [zoom >= 11] {
       background/line-width: 2.0;
       line-width: 2.0;
+      line-dasharray: 0,2,14,2;
     }
-    [zoom >= 12] {
+    [zoom >= 11] {
       background/line-width: 2.5;
       line-width: 2.5;
     }
-    [zoom >= 13] {
+    [zoom >= 12] {
       background/line-width: 3;
       line-width: 3;
+      line-dasharray: 0,3,21,3;
+      thin/line-join: bevel;
+      thin/line-color: black;
+      thin/line-width: 0.8;
+      thin/line-dasharray: 1.5,3,1.5,1.5,1.5,3,3,3,1.5,1.5,1.5,3,1.5,0;
+      thin/line-simplify: @admin-simplify;
+      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
-    [zoom >= 15] {
+    [zoom >= 13] {
       background/line-width: 4;
       line-width: 4;
+      thin/line-width: 1.0;
+    }
+    [zoom >= 15] {
+      background/line-width: 5;
+      line-width: 5;
+      line-dasharray: 0,4,28,4;
+      thin/line-width: 1.2;
+      thin/line-dasharray: 2,4,2,2,2,4,4,4,2,2,2,4,2,0;
     }
   }
   /*
@@ -187,7 +233,7 @@ overlapping borders correctly.
   The SQL has `ORDER BY admin_level`, so the boundary with the lowest
   admin_level is rendered on top, and therefore the only visible boundary.
   */
-  opacity: 0.4;
+  opacity: 0.5;
   comp-op: darken;
 }
 
@@ -196,15 +242,15 @@ overlapping borders correctly.
   [admin_level = '5'][zoom >= 8] {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.5;
+    background/line-width: 0.6;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 0.5;
+    line-width: 0.6;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
-    line-dasharray: 6,3,2,3,2,3;
+    line-dasharray: 8,2,2,2;
     line-clip: false;
     [zoom >= 9] {
       background/line-width: 0.8;
@@ -213,6 +259,7 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 1.0;
       line-width: 1.0;
+      line-dasharray: 12,2,2,2;
     }
     [zoom >= 11] {
       background/line-width: 1.2;
@@ -221,6 +268,7 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 1.5;
       line-width: 1.5;
+      line-dasharray: 16,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 1.8;
@@ -229,28 +277,55 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2;
       line-width: 2;
-    }
-    [zoom >= 16] {
-      background/line-width: 2.5;
-      line-width: 2.5;
+      line-dasharray: 24,3,3,3;
     }
   }
   [admin_level = '6'][zoom >= 10] {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.5;
+    background/line-width: 0.8;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 1.2;
+    line-width: 0.8;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
-    line-dasharray: 6,3,2,3;
+    line-dasharray: 8,2,2,2,2,2;
     line-clip: false;
     [zoom >= 11] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    line-dasharray: 12,2,2,2,2,2;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 15] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+      line-dasharray: 18,3,3,3,3,3;
+    }
+  }
+  [admin_level = '7'] {
+    [zoom >= 11] {
+      background/line-join: bevel;
+      background/line-color: white;
       background/line-width: 0.8;
+      background/line-simplify: @admin-simplify;
+      background/line-simplify-algorithm: @admin-simplify-algorithm;
+      line-join: bevel;
+      line-color: @admin-boundaries;
       line-width: 0.8;
+      line-simplify: @admin-simplify;
+      line-simplify-algorithm: @admin-simplify-algorithm;
+      line-dasharray: 8,2,2,2,2,2,2,2;
+      line-clip: false;
     }
     [zoom >= 12] {
       background/line-width: 1.0;
@@ -263,68 +338,78 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.5;
       line-width: 1.5;
-    }
-    [zoom >= 16] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      line-dasharray: 12,3,3,3,3,3,3,3;
     }
   }
-  [admin_level = '7'],
-  [admin_level = '8'] {
+ [admin_level = '8'] {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.5;
+      background/line-width: 0.8;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.5;
+      line-width: 0.8;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
-      line-dasharray: 5,2;
+      line-dasharray: 6,2,2,2,2,2,2,2,2,2;
       line-clip: false;
     }
     [zoom >= 13] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-    }
-    [zoom >= 15] {
       background/line-width: 1.0;
       line-width: 1.0;
     }
-    [zoom >= 16] {
+    [zoom >= 15] {
       background/line-width: 1.2;
       line-width: 1.2;
+      line-dasharray: 9,3,3,3,3,3,3,3,3,3;
     }
   }
   opacity: 0.5;
   comp-op: darken;
 }
 
-#admin-high-zoom[zoom >= 15] {
-  [admin_level = '9'],
-  [admin_level = '10'] {
+#admin-high-zoom[zoom >= 13] {
+  [admin_level = '9'] {
+    background/line-join: bevel;
+    background/line-color: white;
+    background/line-width: 0.8;
+    background/line-simplify: @admin-simplify;
+    background/line-simplify-algorithm: @admin-simplify-algorithm;
+    line-join: bevel;
+    line-color: @admin-boundaries;
+    line-width: 0.8;
+    line-simplify: @admin-simplify;
+    line-simplify-algorithm: @admin-simplify-algorithm;
+    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
+    line-clip: false;
     [zoom >= 15] {
-      background/line-join: bevel;
-      background/line-color: white;
-      background/line-width: 0.6;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
-      line-join: bevel;
-      line-color: @admin-boundaries;
-      line-width: 0.6;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
-      line-dasharray: 2,3;
-      line-clip: false;
-    }
-    [zoom >= 16] {
-      background/line-width: 0.8;
-      line-width: 0.8;
+      background/line-width: 1.0;
+      line-width: 1.0;
+      line-dasharray: 0,4,3,3,3,3,3,3,3,4;
     }
   }
-  opacity: 0.5;
+  [admin_level = '10'][zoom >= 14] {
+    background/line-join: bevel;
+    background/line-color: white;
+    background/line-width: 0.6;
+    background/line-simplify: @admin-simplify;
+    background/line-simplify-algorithm: @admin-simplify-algorithm;
+    line-join: bevel;
+    line-color: @admin-boundaries;
+    line-width: 0.6;
+    line-simplify: @admin-simplify;
+    line-simplify-algorithm: @admin-simplify-algorithm;
+    line-dasharray: 0,3,2,2,2,2,2,3;
+    line-clip: false;
+    [zoom >= 15] {
+      background/line-width: 0.8;
+      line-width: 0.8;
+      line-dasharray: 0,4,3,3,3,3,3,4;
+    }
+  }
+  opacity: 0.6;
   comp-op: darken;
 }
 
@@ -335,9 +420,10 @@ overlapping borders correctly.
   [admin_level = '4'][way_pixels >= 196000],
   [admin_level = '5'][way_pixels >= 196000],
   [zoom >= 12][admin_level = '6'][way_pixels >= 196000],
-  [zoom >= 14][admin_level = '7'],
-  [zoom >= 15][admin_level = '8'],
-  [zoom >= 16] {
+  [zoom >= 13][admin_level = '7'],
+  [zoom >= 14][admin_level = '8'],
+  [zoom >= 16][admin_level = '9'],
+  [zoom >= 17] {
     text-name: "[name]";
     text-face-name: @book-fonts;
     text-fill: @admin-boundaries;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -32,7 +32,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 1.2;
       line-join: bevel;
-      line-color: @admin-boundaries-wide;
+      line-color: @admin-boundaries;
       line-width: 1.2;
     }
     [zoom >= 5] {
@@ -57,6 +57,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     }
     [zoom >= 10] {
       background/line-width: 4.5;
+      line-color: @admin-boundaries-wide;
       line-width: 4.5;
     }
     [zoom >= 11] {
@@ -133,7 +134,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 0.6;
       line-join: bevel;
-      line-color: @admin-boundaries-wide;
+      line-color: @admin-boundaries;
       line-width: 0.6;
     }
     [zoom >= 5] {
@@ -158,6 +159,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     }
     [zoom >= 10] {
       background/line-width: 3.5;
+      line-color: @admin-boundaries-wide;
       line-width: 3.5;
       line-dasharray: 17.5,2;
     }
@@ -228,7 +230,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 0.4;
-      line-color: @admin-boundaries-wide;
+      line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
       line-clip: false;
@@ -259,6 +261,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     }
     [zoom >= 10] {
       background/line-width: 2.5;
+      line-color: @admin-boundaries-wide;
       line-width: 2.5;
       line-dasharray: 8,2;
     }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -343,7 +343,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 0,3,2,2,2,2,2,2,2,3;
+      line-dasharray: 0,3,3,2,2,3,2,2,3,3;
     }
   }
   [admin_level = '10'][zoom >= 14] {
@@ -358,7 +358,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 0,2,2,2,2,2,2,3;
+      line-dasharray: 0,3,3,2,2,2,3,3;
     }
   }
   opacity: 0.6;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -158,9 +158,9 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 2.5;
     }
     [zoom >= 10] {
-      background/line-width: 3.5;
+      background/line-width: 3.2;
       line-color: @admin-boundaries-wide;
-      line-width: 3.5;
+      line-width: 3.2;
     }
     [zoom >= 11] {
       background/line-width: 4;
@@ -187,7 +187,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-join: bevel;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.8;
-      thin/line-dasharray: 12,1.5,1.5,1.5;
+      thin/line-dasharray: 12,2,1.5,2;
     }
     [zoom >= 11] {
       background/line-width: 1;
@@ -196,7 +196,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
-      thin/line-dasharray: 18,2,2,2;
+      thin/line-dasharray: 18,3,2,3;
     }
     [zoom >= 13] {
       background/line-width: 1.4;
@@ -205,7 +205,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.6;
       thin/line-width: 1.6;
-      thin/line-dasharray: 24,3,3,3;
+      thin/line-dasharray: 24,4,3,4;
     }
   }
 
@@ -245,32 +245,32 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 0.8;
     }
     [zoom >= 8] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1;
+      line-width: 1;
     }
     [zoom >= 9] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.5;
+      line-width: 1.5;
     }
     [zoom >= 10] {
-      background/line-width: 2.5;
+      background/line-width: 2;
       line-color: @admin-boundaries-wide;
-      line-width: 2.5;
+      line-width: 2;
     }
     [zoom >= 11] {
+      background/line-width: 2.5;
+      line-width: 2.8;
+    }
+    [zoom >= 12] {
       background/line-width: 3;
       line-width: 3;
     }
-    [zoom >= 12] {
+    [zoom >= 13] {
       background/line-width: 3.5;
       line-width: 3.5;
     }
-    [zoom >= 13] {
-      background/line-width: 4;
-      line-width: 4;
-    }
     [zoom >= 15] {
-      background/line-width: 4.5;
+      background/line-width: 4;
       line-width: 4;
     }
   }
@@ -281,7 +281,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 0.6;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
-      thin/line-dasharray: 9,1.5,1.5,1.5,1.5,1.5;
+      thin/line-dasharray: 9,2,1.5,2,1.5,2;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -290,7 +290,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1;
       thin/line-width: 1;
-      thin/line-dasharray: 14,2,2,2,2,2;
+      thin/line-dasharray: 14,3,2,3,2,3;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -299,7 +299,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.4;
       thin/line-width: 1.4;
-      thin/line-dasharray: 18,3,3,3,3,3;
+      thin/line-dasharray: 18,4,3,4,3,4;
     }
   }
   ::firstline { opacity: 0.5; }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -2,8 +2,10 @@
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
-For each zoomlevel, all borders come from a single attachment, to handle
-overlapping borders correctly.
+Three attachments are used, with minor borders before major ones, and the thin centerline last, to handle
+overlapping borders correctly and allow each type to have a different level of opacity.
+Overlapping borders are hidden by a white background line, rendered before each line.
+Then all three layers are added to the rendering with comp-op: darken, so that the white lines will not show
 */
 
 #admin-low-zoom[zoom < 8],
@@ -78,7 +80,7 @@ overlapping borders correctly.
       background/line-color: white;
       background/line-width: 0.6;
       thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 0.6;
     }
     [zoom >= 9] {
@@ -97,7 +99,7 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 1.8;
       thin/line-width: 1.8;
-      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-color: @admin-boundaries;
       thin/line-dasharray: 26,2,2,2,2,2;
     }
     [zoom >= 13] {
@@ -183,14 +185,12 @@ overlapping borders correctly.
       background/line-color: white;
       background/line-width: 0.4;
       thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 0.4;
-      thin/line-dasharray: 4.5,1,4.5,1,1,1;
     }
     [zoom >= 9] {
       background/line-width: 0.6;
       thin/line-width: 0.6;
-      thin/line-dasharray: 5.5,1.2,5.5,1.2,1.2,1.2;
     }
     [zoom >= 10] {
       background/line-width: 1;
@@ -204,7 +204,7 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-color: @admin-boundaries;
       thin/line-dasharray: 0,1.5,10,2,2,2,10,1.5;
     }
     [zoom >= 13] {
@@ -259,17 +259,17 @@ overlapping borders correctly.
     [zoom >= 8] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 0,1.2,8,1.2;
+      line-dasharray: 0,1,8,1;
     }
     [zoom >= 9] {
       background/line-width: 2;
       line-width: 2;
-      line-dasharray: 0,1.5,10,1.5;
+      line-dasharray: 0,1,10,1;
     }
     [zoom >= 10] {
       background/line-width: 2.5;
       line-width: 2.5;
-      line-dasharray: 0,1.2,12,1.2;
+      line-dasharray: 0,1.5,12,1.5;
     }
     [zoom >= 11] {
       background/line-width: 3;
@@ -291,30 +291,23 @@ overlapping borders correctly.
     }
   }
   [admin_level = '4']::narrowline {
-    [zoom >= 8] {
+    [zoom >= 10] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.4;
-      thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 10%);
-      thin/line-width: 0.4;
-      thin/line-dasharray: 0,1,8,1;
-    }
-    [zoom >= 9] {
       background/line-width: 0.6;
+      thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,1,10,1;
+      thin/line-dasharray: 0,2,4,3,4,2;
     }
-    [zoom >= 10] {
+    [zoom >= 11] {
       background/line-width: 0.8;
       thin/line-width: 0.8;
-      thin/line-dasharray: 0,1.2,5,2,5,1.2;
     }
     [zoom >= 12] {
       background/line-width: 1;
-      thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 1;
-      thin/line-dasharray: 0,1.5,7.5,3,7.5,1.5;
+      thin/line-color: @admin-boundaries;
+      thin/line-dasharray: 0,2,6.5,4,6.5,2,;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -323,16 +316,18 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,2,10,4,10,2;
+      thin/line-dasharray: 0,3,9,4,9,3;
     }
   }
-  ::firstline { opacity: 0.5; }
+  ::firstline { opacity: 0.4;
+    [zoom >= 10] { opacity: 0.5; }
+  }
   ::wideline { opacity: 0.4;
     [zoom >= 10] { opacity: 0.35; }
     [zoom >= 12] { opacity: 0.3; }
   }
-  ::narrowline { opacity: 0.7;
-    [zoom >= 10] { opacity: 0.65; }
+  ::narrowline { opacity: 0.6;
+    [zoom >= 10] { opacity: 0.6; }
     [zoom >= 12] { opacity: 0.6; }
   }
   /*

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -106,7 +106,7 @@ overlapping borders correctly.
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
-      thin/line-dasharray: 0,1,3,1;
+      thin/line-dasharray: 0,1,6,1;
     }
     [zoom >= 11] {
       background/line-width: 3.5;
@@ -141,6 +141,7 @@ overlapping borders correctly.
       line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
+      line-dasharray: 3,1;
       line-clip: false;
     }
     [zoom >= 5] {
@@ -150,21 +151,22 @@ overlapping borders correctly.
     [zoom >= 6] {
       background/line-width: 0.8;
       line-width: 0.8;
+      line-dasharray: 4,1.5;
     }
     [zoom >= 7] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 4,2;
+      line-dasharray: 6,2;
     }
     [zoom >= 8] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 6,2;
+      line-dasharray: 8,2;
     }
     [zoom >= 9] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 8,3;
+      line-dasharray: 0,1.5,10,1.5;
     }
     [zoom >= 10] {
       background/line-width: 2.0;
@@ -249,7 +251,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2.5;
       line-width: 2.5;
-      line-dasharray: 24,2,3,2;
+      line-dasharray: 20,2,3,2;
     }
   }
   [admin_level = '6'][zoom >= 10] {
@@ -277,7 +279,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2.0;
       line-width: 2.0;
-      line-dasharray: 18,2,3,2,3,2;
+      line-dasharray: 16,2,3,2,3,2;
     }
   }
   [admin_level = '7'] {
@@ -302,7 +304,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 12,2,3,2,3,2,3,2;
+      line-dasharray: 12,2,3,2,2,2,3,2;
     }
   }
  [admin_level = '8'] {
@@ -313,7 +315,7 @@ overlapping borders correctly.
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1;
-      line-dasharray: 6,2,2,2,2,2,2,2,2,2;
+      line-dasharray: 6,2,3,2,2,2,2,2,3,2;
       line-clip: false;
     }
     [zoom >= 13] {
@@ -323,7 +325,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 9,2,3,2,3,2,3,2,3,2;
+      line-dasharray: 10,2,2,2,3,2,3,2,2,2;
     }
   }
   opacity: 0.5;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -90,7 +90,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 10] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
-      thin/line-dasharray: 22,1.5,1.5,1.5,1.5,1.5;
+      thin/line-dasharray: 20,1.5,1.5,1.5,1.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 1.5;
@@ -109,7 +109,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 2.2;
       thin/line-width: 2.2;
-      thin/line-dasharray: 39,3,3,3,3,3;
+      thin/line-dasharray: 36,3,3,3,3,3;
     }
   }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -167,7 +167,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 4.5;
       line-width: 4.5;
-      line-dasharray: 26,3;
+      line-dasharray: 24,3;
     }
     [zoom >= 13] {
       background/line-width: 5;
@@ -176,7 +176,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 5.5;
       line-width: 5.5;
-      line-dasharray: 35,4;
+      line-dasharray: 33,3;
     }
   }
   [admin_level = '3']::narrowline {
@@ -197,7 +197,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.5;
       thin/line-width: 1.5;
       thin/line-color: @admin-boundaries;
-      thin/line-dasharray: 10,2,2,2,10,3;
+      thin/line-dasharray: 9,2,2,2,9,3;
     }
     [zoom >= 13] {
       background/line-width: 1.8;
@@ -206,7 +206,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 2;
       thin/line-width: 2;
-      thin/line-dasharray: 13,3,3,3,13,4;
+      thin/line-dasharray: 12,3,3,3,12,3;
     }
   }
 
@@ -241,27 +241,26 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 6] {
       background/line-width: 0.8;
       line-width: 0.8;
-      line-dasharray: 5,1.5;
+      line-dasharray: 4,1.5;
     }
     [zoom >= 7] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 6,2;
+      line-dasharray: 5,1.5;
     }
     [zoom >= 8] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 8,2;
+      line-dasharray: 6,2;
     }
     [zoom >= 9] {
       background/line-width: 2;
       line-width: 2;
-      line-dasharray: 10,2;
     }
     [zoom >= 10] {
       background/line-width: 2.5;
       line-width: 2.5;
-      line-dasharray: 12,3;
+      line-dasharray: 8,2;
     }
     [zoom >= 11] {
       background/line-width: 3;
@@ -270,7 +269,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 3.5;
       line-width: 3.5;
-      line-dasharray: 18,3;
+      line-dasharray: 10,3;
     }
     [zoom >= 13] {
       background/line-width: 4;
@@ -279,7 +278,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 4.5;
       line-width: 4;
-      line-dasharray: 24,4;
+      line-dasharray: 12,3;
     }
   }
   [admin_level = '4']::narrowline {
@@ -289,7 +288,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 0.6;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,0.5,4,3,4,3.5;
+      thin/line-dasharray: 0,1,6,3;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -299,7 +298,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1;
       thin/line-width: 1;
       thin/line-color: @admin-boundaries;
-      thin/line-dasharray: 0,0.5,6.5,4,6.5,3.5;
+      thin/line-dasharray: 0,1,8,4;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -308,7 +307,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,1,9,4,9,5;
+      thin/line-dasharray: 0,1.5,9,4.5;
     }
   }
   ::firstline { opacity: 0.4;
@@ -344,7 +343,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.6;
-    line-dasharray: 6,1.5,1.5,1.5;
+    line-dasharray: 10,1.5,1.5,1.5;
     line-clip: false;
     [zoom >= 9] {
       background/line-width: 0.8;
@@ -353,7 +352,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 10] {
       background/line-width: 1.0;
       line-width: 1.0;
-      line-dasharray: 10,2,2,2;
+      line-dasharray: 12,2,2,2;
     }
     [zoom >= 11] {
       background/line-width: 1.2;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -143,58 +143,57 @@ overlapping borders correctly.
     }
     [zoom >= 7] {
       background/line-width: 1.5;
-      line-width: 1.2;
+      line-width: 1.5;
     }
     [zoom >= 8] {
       background/line-width: 2.1;
-      line-width: 1.5;
+      line-width: 2.1;
     }
     [zoom >= 9] {
       background/line-width: 2.7;
-      line-width: 2;
+      line-width: 2.7;
     }
     [zoom >= 10] {
       background/line-width: 3.5;
-      line-width: 3;
+      line-width: 3.5;
       line-dasharray: 0,1,17.5,1;
     }
     [zoom >= 11] {
       background/line-width: 4;
-      line-width: 3.5;
+      line-width: 4;
     }
     [zoom >= 12] {
       background/line-width: 4.5;
-      line-width: 4.0;
+      line-width: 4.5;
       line-dasharray: 0,1.5,26,1.5;
     }
     [zoom >= 13] {
       background/line-width: 5;
-      line-width: 4.5;
+      line-width: 5;
     }
     [zoom >= 15] {
       background/line-width: 5.5;
-      line-width: 5;
+      line-width: 5.5;
       line-dasharray: 0,2,35,2;
     }
   }
   [admin_level = '3']::narrowline {
     [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.4;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.4;
       thin/line-dasharray: 4.5,1,4.5,1,1,1;
     }
     [zoom >= 9] {
+      background/line-width: 0.6;
       thin/line-width: 0.6;
       thin/line-dasharray: 5.5,1.2,5.5,1.2,1.2,1.2;
-
     }
     [zoom >= 10] {
-      background/line-join: bevel;
-      background/line-color: white;
       background/line-width: 1;
-      thin/line-join: bevel;
-      thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 1;
       thin/line-dasharray: 0,1,6.5,1.5,1.5,1.5,6.5,1;
     }
@@ -204,7 +203,7 @@ overlapping borders correctly.
     }
     [zoom >= 12] {
       background/line-width: 1.5;
-      thin/line-width: 1.2;
+      thin/line-width: 1.5;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-dasharray: 0,1.5,10,2,2,2,10,1.5;
     }
@@ -240,32 +239,32 @@ overlapping borders correctly.
       line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
-      line-dasharray: 3,1;
       line-clip: false;
     }
     [zoom >= 5] {
       background/line-width: 0.6;
       line-width: 0.6;
+      line-dasharray: 4,1;
     }
     [zoom >= 6] {
       background/line-width: 0.8;
       line-width: 0.8;
-      line-dasharray: 4,1.5;
+      line-dasharray: 5,1.5;
     }
     [zoom >= 7] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 6,1.5;
+      line-dasharray: 6,2;
     }
     [zoom >= 8] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 0,1,8,1;
+      line-dasharray: 0,1.2,8,1.2;
     }
     [zoom >= 9] {
       background/line-width: 2;
       line-width: 2;
-      line-dasharray: 0,1,10,1;
+      line-dasharray: 0,1.5,10,1.5;
     }
     [zoom >= 10] {
       background/line-width: 2.5;
@@ -293,28 +292,36 @@ overlapping borders correctly.
   }
   [admin_level = '4']::narrowline {
     [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.4;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.4;
-      thin/line-dasharray: 0,1,3,2,3,1;
+      thin/line-dasharray: 0,1,8,1;
     }
     [zoom >= 9] {
+      background/line-width: 0.6;
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,1,4,2,4,1;
+      thin/line-dasharray: 0,1,10,1;
     }
     [zoom >= 10] {
+      background/line-width: 0.8;
       thin/line-width: 0.8;
       thin/line-dasharray: 0,1.2,5,2,5,1.2;
     }
     [zoom >= 12] {
+      background/line-width: 1;
+      thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 1;
       thin/line-dasharray: 0,1.5,7.5,3,7.5,1.5;
     }
     [zoom >= 13] {
-      thin/line-color: darken(@admin-boundaries, 5%);
+      background/line-width: 1.2;
       thin/line-width: 1.2;
     }
     [zoom >= 15] {
+      background/line-width: 1.5;
       thin/line-width: 1.5;
       thin/line-dasharray: 0,2,10,4,10,2;
     }
@@ -324,8 +331,8 @@ overlapping borders correctly.
     [zoom >= 10] { opacity: 0.35; }
     [zoom >= 12] { opacity: 0.3; }
   }
-  ::narrowline { opacity: 0.8;
-    [zoom >= 10] { opacity: 0.7; }
+  ::narrowline { opacity: 0.7;
+    [zoom >= 10] { opacity: 0.65; }
     [zoom >= 12] { opacity: 0.6; }
   }
   /*
@@ -458,10 +465,10 @@ overlapping borders correctly.
   [admin_level = '9'][zoom >= 13]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 1.0;
+    background/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 1.0;
+    line-width: 1;
     line-dasharray: 0,3,2,2,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {
@@ -471,12 +478,16 @@ overlapping borders correctly.
     }
   }
   [admin_level = '10'][zoom >= 14]::firstline {
+    background/line-join: bevel;
+    background/line-color: white;
+    background/line-width: 0.8;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
     line-dasharray: 0,4,3,2,3,2,3,4;
     line-clip: false;
     [zoom >= 15] {
+      background/line-width: 1;
       line-width: 1;
       line-dasharray: 0,6,3,3,2,3,3,6;
     }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -211,7 +211,6 @@ overlapping borders correctly.
   admin_level is rendered on top, and therefore the only visible boundary.
   */
   opacity: 0.4;
-  [zoom >= 10] { opacity: 0.5; }
   comp-op: darken;
 }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -144,12 +144,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 1;
     }
     [zoom >= 7] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 8] {
-      background/line-width: 2.1;
-      line-width: 2.1;
+      background/line-width: 1.5;
+      line-width: 1.5;
     }
     [zoom >= 9] {
       background/line-width: 2.7;
@@ -158,7 +158,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 10] {
       background/line-width: 3.5;
       line-width: 3.5;
-      line-dasharray: 0,1,17.5,1;
+      line-dasharray: 17.5,2;
     }
     [zoom >= 11] {
       background/line-width: 4;
@@ -167,7 +167,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 4.5;
       line-width: 4.5;
-      line-dasharray: 0,1.5,26,1.5;
+      line-dasharray: 26,3;
     }
     [zoom >= 13] {
       background/line-width: 5;
@@ -176,26 +176,18 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 5.5;
       line-width: 5.5;
-      line-dasharray: 0,2,35,2;
+      line-dasharray: 35,4;
     }
   }
   [admin_level = '3']::narrowline {
-    [zoom >= 8] {
+    [zoom >= 10] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.4;
+      background/line-width: 1;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 5%);
-      thin/line-width: 0.4;
-    }
-    [zoom >= 9] {
-      background/line-width: 0.6;
-      thin/line-width: 0.6;
-    }
-    [zoom >= 10] {
-      background/line-width: 1;
       thin/line-width: 1;
-      thin/line-dasharray: 0,1,6.5,1.5,1.5,1.5,6.5,1;
+      thin/line-dasharray: 6.5,1.5,1.5,1.5,6.5,2;
     }
     [zoom >= 11] {
       background/line-width: 1.2;
@@ -205,7 +197,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.5;
       thin/line-width: 1.5;
       thin/line-color: @admin-boundaries;
-      thin/line-dasharray: 0,1.5,10,2,2,2,10,1.5;
+      thin/line-dasharray: 10,2,2,2,10,3;
     }
     [zoom >= 13] {
       background/line-width: 1.8;
@@ -214,7 +206,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 2;
       thin/line-width: 2;
-      thin/line-dasharray: 0,2,13,3,3,3,13,2;
+      thin/line-dasharray: 13,3,3,3,13,4;
     }
   }
 
@@ -224,7 +216,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-color: white;
       background/line-width: 1.2;
     }
-    [zoom >= 9] { background/line-width: 1.8;  }
+    [zoom >= 9] { background/line-width: 1.8; }
     [zoom >= 10] { background/line-width: 2.0; }
     [zoom >= 11] { background/line-width: 2.5; }
     [zoom >= 12] { background/line-width: 3; }
@@ -259,17 +251,17 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 8] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 0,1,8,1;
+      line-dasharray: 8,2;
     }
     [zoom >= 9] {
       background/line-width: 2;
       line-width: 2;
-      line-dasharray: 0,1,10,1;
+      line-dasharray: 10,2;
     }
     [zoom >= 10] {
       background/line-width: 2.5;
       line-width: 2.5;
-      line-dasharray: 0,1.5,12,1.5;
+      line-dasharray: 12,3;
     }
     [zoom >= 11] {
       background/line-width: 3;
@@ -278,7 +270,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 3.5;
       line-width: 3.5;
-      line-dasharray: 0,1.5,18,1.5;
+      line-dasharray: 18,3;
     }
     [zoom >= 13] {
       background/line-width: 4;
@@ -287,7 +279,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 4.5;
       line-width: 4;
-      line-dasharray: 0,2,24,2;
+      line-dasharray: 24,4;
     }
   }
   [admin_level = '4']::narrowline {
@@ -297,7 +289,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 0.6;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,2,4,3,4,2;
+      thin/line-dasharray: 0,0.5,4,3,4,3.5;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -307,7 +299,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1;
       thin/line-width: 1;
       thin/line-color: @admin-boundaries;
-      thin/line-dasharray: 0,2,6.5,4,6.5,2,;
+      thin/line-dasharray: 0,0.5,6.5,4,6.5,3.5;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -316,7 +308,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,3,9,4,9,3;
+      thin/line-dasharray: 0,1,9,4,9,5;
     }
   }
   ::firstline { opacity: 0.4;
@@ -348,28 +340,28 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '5'][zoom >= 8]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.8;
+    background/line-width: 0.6;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 0.8;
-    line-dasharray: 8,2,2,2;
+    line-width: 0.6;
+    line-dasharray: 6,1.5,1.5,1.5;
     line-clip: false;
     [zoom >= 9] {
-      background/line-width: 1.0;
-      line-width: 1.0;
+      background/line-width: 0.8;
+      line-width: 0.8;
     }
     [zoom >= 10] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-      line-dasharray: 12,2,2,2;
+      background/line-width: 1.0;
+      line-width: 1.0;
+      line-dasharray: 10,2,2,2;
     }
     [zoom >= 11] {
-      background/line-width: 1.4;
-      line-width: 1.4;
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 12] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.5;
+      line-width: 1.5;
       line-dasharray: 16,2,2,2;
     }
     [zoom >= 13] {
@@ -418,12 +410,13 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 0.8;
-      line-dasharray: 8,2,2,2,2,2,2,2;
+      line-dasharray: 6,2,2,2,2,2,2,2;
       line-clip: false;
     }
     [zoom >= 12] {
       background/line-width: 1;
       line-width: 1;
+      line-dasharray: 8,2,2,2,2,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 1.3;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #965b95; // Lch(47,40,327)
+@admin-boundaries: #ac46ac; // Lch(47,65,327)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #876390; // Lch(47,30,320)
+@admin-boundaries: #965b95; // Lch(47,40,327)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -50,7 +50,7 @@ overlapping borders correctly.
     [zoom >= 11] {
       background/line-width: 4.5;
       line-width: 4.5;
-      thin/line-width: 1.0;
+      thin/line-width: 1;
     }
     [zoom >= 12] {
       background/line-width: 5;
@@ -67,7 +67,6 @@ overlapping borders correctly.
       background/line-width: 7.5;
       line-width: 7.5;
       thin/line-width: 1.8;
-      thin/line-dasharray: 36,3,3,3;
     }
   }
 
@@ -85,8 +84,8 @@ overlapping borders correctly.
       line-width: 0.8;
     }
     [zoom >= 6] {
-      background/line-width: 1.0;
-      line-width: 1.0;
+      background/line-width: 1;
+      line-width: 1;
     }
     [zoom >= 7] {
       background/line-width: 1.2;
@@ -97,29 +96,29 @@ overlapping borders correctly.
       line-width: 1.5;
     }
     [zoom >= 9] {
-      background/line-width: 2.0;
-      line-width: 2.0;
+      background/line-width: 2;
+      line-width: 2;
     }
     [zoom >= 10] {
-      background/line-width: 3.0;
-      line-width: 3.0;
+      background/line-width: 3;
+      line-width: 3;
       line-dasharray: 0,1,6,1;
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
-      thin/line-dasharray: 0,1,6,1;
+      thin/line-dasharray: 0,1,3,1;
     }
     [zoom >= 11] {
       background/line-width: 3.5;
       line-width: 3.5;
-      thin/line-width: 1.0;
+      thin/line-width: 1;
     }
     [zoom >= 12] {
-      background/line-width: 4.0;
+      background/line-width: 4;
       line-width: 4.0;
-      line-dasharray: 0,1.5,9,1.5;
+      line-dasharray: 0,1.3,8,1.3;
       thin/line-width: 1.2;
-      thin/line-dasharray: 0,1.5,9,1.5;
+      thin/line-dasharray: 0,1.3,8,1.3;
     }
     [zoom >= 13] {
       background/line-width: 4.5;
@@ -128,9 +127,9 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 5;
       line-width: 5;
-      line-dasharray: 0,2,12,2;
+      line-dasharray: 0,1.5,10,1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,2,12,2;
+      thin/line-dasharray: 0,1.5,10,1.5;
     }
   }
 
@@ -170,7 +169,7 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 2.0;
       line-width: 2.0;
-      line-dasharray: 0,2,14,2;
+      line-dasharray: 0,2,12,2;
     }
     [zoom >= 11] {
       background/line-width: 2.5;
@@ -179,11 +178,11 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 3;
       line-width: 3;
-      line-dasharray: 0,3,21,3;
+      line-dasharray: 0,3,18,3;
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
-      thin/line-dasharray: 1.5,3,1.5,1.5,1.5,3,3,3,1.5,1.5,1.5,3,1.5,0;
+      thin/line-dasharray: 1.5,3,3,3,3,3,3,3,1.5,0;
     }
     [zoom >= 13] {
       background/line-width: 3.5;
@@ -193,9 +192,9 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 4;
       line-width: 4;
-      line-dasharray: 0,4,28,4;
+      line-dasharray: 0,4,24,4;
       thin/line-width: 1.2;
-      thin/line-dasharray: 2,4,2,2,2,4,4,4,2,2,2,4,2,0;
+      thin/line-dasharray: 2,4,4,4,4,4,4,4,2,0;
     }
   }
   /*
@@ -250,7 +249,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2.5;
       line-width: 2.5;
-      line-dasharray: 24,3,3,3;
+      line-dasharray: 24,2,3,2;
     }
   }
   [admin_level = '6'][zoom >= 10] {
@@ -278,7 +277,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2.0;
       line-width: 2.0;
-      line-dasharray: 18,3,3,3,3,3;
+      line-dasharray: 18,2,3,2,3,2;
     }
   }
   [admin_level = '7'] {
@@ -303,7 +302,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 12,3,3,3,3,3,3,3;
+      line-dasharray: 12,2,3,2,3,2,3,2;
     }
   }
  [admin_level = '8'] {
@@ -324,7 +323,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 9,3,3,3,3,3,3,3,3,3;
+      line-dasharray: 9,2,3,2,3,2,3,2,3,2;
     }
   }
   opacity: 0.5;
@@ -339,12 +338,12 @@ overlapping borders correctly.
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.0;
-    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
+    line-dasharray: 0,2,2,2,2,2,2,2,2,2;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 0,4,3,3,3,3,3,3,3,4;
+      line-dasharray: 0,3,2,2,2,2,2,2,2,3;
     }
   }
   [admin_level = '10'][zoom >= 14] {
@@ -354,12 +353,12 @@ overlapping borders correctly.
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
-    line-dasharray: 0,3,2,2,2,2,2,3;
+    line-dasharray: 0,2,2,2,2,2,2,2;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 0,4,3,3,3,3,3,4;
+      line-dasharray: 0,2,2,2,2,2,2,3;
     }
   }
   opacity: 0.6;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -24,7 +24,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 11] { background/line-width: 5.5; }
     [zoom >= 12] { background/line-width: 6; }
     [zoom >= 13] { background/line-width: 7; }
-    [zoom >= 15] { background/line-width: 8; }
+    [zoom >= 14] { background/line-width: 8; }
   }
   [admin_level = '2']::wideline {
     [zoom >= 4] {
@@ -72,7 +72,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 7;
       line-width: 7;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 8;
       line-width: 8;
     }
@@ -108,7 +108,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.6;
       thin/line-width: 1.6;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 1.8;
       thin/line-width: 1.8;
       thin/line-dasharray: 36,2,8,2;
@@ -126,7 +126,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 11] { background/line-width: 4; }
     [zoom >= 12] { background/line-width: 4.5; }
     [zoom >= 13] { background/line-width: 5; }
-    [zoom >= 15] { background/line-width: 5.5; }
+    [zoom >= 14] { background/line-width: 5.5; }
   }
   [admin_level = '3']::wideline {
     [zoom >= 4] {
@@ -174,7 +174,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 5;
       line-width: 5;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 5.5;
       line-width: 5.5;
     }
@@ -202,7 +202,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.4;
       thin/line-width: 1.4;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 1.6;
       thin/line-width: 1.6;
       thin/line-dasharray: 23,4,3,4;
@@ -220,7 +220,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 11] { background/line-width: 2.5; }
     [zoom >= 12] { background/line-width: 3; }
     [zoom >= 13] { background/line-width: 3.5; }
-    [zoom >= 15] { background/line-width: 4; }
+    [zoom >= 14] { background/line-width: 4; }
   }
   [admin_level = '4']::wideline {
     [zoom >= 4] {
@@ -269,7 +269,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 3.5;
       line-width: 3.5;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 4;
       line-width: 4;
     }
@@ -296,7 +296,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.2;
       thin/line-width: 1.2;
     }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 1.4;
       thin/line-width: 1.4;
       thin/line-dasharray: 16,4,3,4,3,4;
@@ -340,19 +340,15 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-dasharray: 10,1.5,4.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1.4;
-      line-width: 1.4;
-    }
-    [zoom >= 12] {
       background/line-width: 1.6;
       line-width: 1.6;
+    }
+    [zoom >= 12] {
+      background/line-width: 2;
+      line-width: 2;
       line-dasharray: 16,2,6,2;
     }
-    [zoom >= 13] {
-      background/line-width: 1.9;
-      line-width: 1.9;
-    }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 2.2;
       line-width: 2.2;
       line-dasharray: 20,2,8,2;
@@ -361,26 +357,22 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '6'][zoom >= 10]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.9;
+    background/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 0.9;
+    line-width: 1;
     line-dasharray: 8,1.5,1.5,1.5;
     line-clip: false;
     [zoom >= 11] {
-      background/line-width: 1.1;
-      line-width: 1.1;
+      background/line-width: 1.4;
+      line-width: 1.4;
     }
     [zoom >= 12] {
-      background/line-width: 1.3;
-      line-width: 1.3;
+      background/line-width: 1.6;
+      line-width: 1.6;
     line-dasharray: 12,1.5,2,1.5;
     }
-    [zoom >= 13] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-    }
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 1.8;
       line-width: 1.8;
       line-dasharray: 16,2,3,2;
@@ -390,25 +382,21 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 11] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.8;
+      line-width: 1.2;
       line-dasharray: 6,1.5,1.5,1.5,1.5,1.5;
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1;
-      line-width: 1;
+      background/line-width: 1.4;
+      line-width: 1.4;
       line-dasharray: 9,2,2,2,2,2;
     }
-    [zoom >= 13] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-    }
-    [zoom >= 15] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+    [zoom >= 14] {
+      background/line-width: 1.6;
+      line-width: 1.6;
       line-dasharray: 12,2,3,2,3,2;
     }
   }
@@ -416,20 +404,16 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.8;
+      line-width: 1.2;
       line-dasharray: 6,1.5,1.5,1.5,2,1.5,1.5,1.5;
       line-clip: false;
     }
-    [zoom >= 13] {
-      background/line-width: 1;
-      line-width: 1;
-    }
-    [zoom >= 15] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+    [zoom >= 14] {
+      background/line-width: 1.4;
+      line-width: 1.4;
       line-dasharray: 8,2,2,2,3,2,2,2;
     }
   }
@@ -443,7 +427,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-width: 1;
     line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
-    [zoom >= 15] {
+    [zoom >= 14] {
       background/line-width: 1.2;
       line-width: 1.2;
       line-dasharray: 0,4,2,2,3,2,2,4;
@@ -452,17 +436,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '10'][zoom >= 14]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.8;
+    background/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 0.8;
-    line-dasharray: 0,4,2,2,2,4;
+    line-width: 1;
+    line-dasharray: 0,3,2,2,2,3;
     line-clip: false;
-    [zoom >= 15] {
-      background/line-width: 1;
-      line-width: 1;
-      line-dasharray: 0,5,3,3,3,5;
-    }
   }
 }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -211,6 +211,8 @@ overlapping borders correctly.
   admin_level is rendered on top, and therefore the only visible boundary.
   */
   opacity: 0.4;
+  [zoom >= 10] { opacity: 0.35; }
+  [zoom >= 12] { opacity: 0.3; }
   comp-op: darken;
 }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,8 +1,5 @@
 @admin-boundaries: #ac46ac; // Lch(47,65,327)
 
-@admin-simplify: 4;
-@admin-simplify-algorithm: visvalingam-whyatt;
-
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
 For each zoomlevel, all borders come from a single attachment, to handle
@@ -17,13 +14,9 @@ overlapping borders correctly.
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 1.2;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1.2;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 5] {
       background/line-width: 1.5;
@@ -53,8 +46,6 @@ overlapping borders correctly.
       thin/line-color: black;
       thin/line-width: 0.8;
       thin/line-dasharray: 18,1.5,1.5,1.5;
-      thin/line-simplify: @admin-simplify;
-      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 11] {
       background/line-width: 4.5;
@@ -85,13 +76,9 @@ overlapping borders correctly.
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 0.6;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 0.6;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 5] {
       background/line-width: 0.8;
@@ -121,8 +108,6 @@ overlapping borders correctly.
       thin/line-color: black;
       thin/line-width: 0.8;
       thin/line-dasharray: 0,1,6,1;
-      thin/line-simplify: @admin-simplify;
-      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 11] {
       background/line-width: 3.5;
@@ -154,13 +139,9 @@ overlapping borders correctly.
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 0.4;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
       line-clip: false;
     }
     [zoom >= 5] {
@@ -203,8 +184,6 @@ overlapping borders correctly.
       thin/line-color: black;
       thin/line-width: 0.8;
       thin/line-dasharray: 1.5,3,1.5,1.5,1.5,3,3,3,1.5,1.5,1.5,3,1.5,0;
-      thin/line-simplify: @admin-simplify;
-      thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 13] {
       background/line-width: 3.5;
@@ -241,13 +220,9 @@ overlapping borders correctly.
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 0.8;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 8,2,2,2;
     line-clip: false;
     [zoom >= 9] {
@@ -282,13 +257,9 @@ overlapping borders correctly.
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 1.0;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.0;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 8,2,2,2,2,2;
     line-clip: false;
     [zoom >= 11] {
@@ -315,13 +286,9 @@ overlapping borders correctly.
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 1;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
       line-dasharray: 8,2,2,2,2,2,2,2;
       line-clip: false;
     }
@@ -344,13 +311,9 @@ overlapping borders correctly.
       background/line-join: bevel;
       background/line-color: white;
       background/line-width: 1;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
       line-dasharray: 6,2,2,2,2,2,2,2,2,2;
       line-clip: false;
     }
@@ -373,13 +336,9 @@ overlapping borders correctly.
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 1.0;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.0;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 0,3,2,2,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {
@@ -392,13 +351,9 @@ overlapping borders correctly.
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 0.8;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -48,8 +48,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 2.2;
     }
     [zoom >= 8] {
-      background/line-width: 2.8;
-      line-width: 2.8;
+      background/line-width: 3;
+      line-width: 3;
     }
     [zoom >= 9] {
       background/line-width: 3.5;
@@ -91,27 +91,27 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-width: 0.8;
     }
     [zoom >= 10] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
-      thin/line-dasharray: 20,1.5,1.5,1.5,1.5,1.5;
+      background/line-width: 1;
+      thin/line-width: 1;
+      thin/line-dasharray: 18,1.5,4.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
+      background/line-width: 1.2;
+      thin/line-width: 1.2;
     }
     [zoom >= 12] {
-      background/line-width: 1.8;
-      thin/line-width: 1.8;
-      thin/line-dasharray: 26,2,2,2,2,2;
+      background/line-width: 1.5;
+      thin/line-width: 1.5;
+      thin/line-dasharray: 27,2,6,2;
     }
     [zoom >= 13] {
-      background/line-width: 2;
-      thin/line-width: 2;
+      background/line-width: 1.8;
+      thin/line-width: 1.8;
     }
     [zoom >= 15] {
-      background/line-width: 2.2;
-      thin/line-width: 2.2;
-      thin/line-dasharray: 36,3,3,3,3,3;
+      background/line-width: 2;
+      thin/line-width: 2;
+      thin/line-dasharray: 36,3,9,3;
     }
   }
 
@@ -161,7 +161,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 3.5;
       line-color: @admin-boundaries-wide;
       line-width: 3.5;
-      line-dasharray: 17.5,2;
     }
     [zoom >= 11] {
       background/line-width: 4;
@@ -170,7 +169,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 4.5;
       line-width: 4.5;
-      line-dasharray: 24,3;
     }
     [zoom >= 13] {
       background/line-width: 5;
@@ -179,7 +177,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 5.5;
       line-width: 5.5;
-      line-dasharray: 33,3;
     }
   }
   [admin_level = '3']::narrowline {
@@ -190,7 +187,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-join: bevel;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 1;
-      thin/line-dasharray: 6.5,1.5,1.5,1.5,6.5,2;
+      thin/line-dasharray: 12,1.5,1.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 1.2;
@@ -199,7 +196,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 9,2,2,2,9,3;
+      thin/line-dasharray: 18,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 1.8;
@@ -208,7 +205,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 2;
       thin/line-width: 2;
-      thin/line-dasharray: 12,3,3,3,12,3;
+      thin/line-dasharray: 24,3,3,3;
     }
   }
 
@@ -236,24 +233,20 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-clip: false;
     }
     [zoom >= 5] {
-      background/line-width: 0.6;
-      line-width: 0.6;
-      line-dasharray: 4,1;
+      background/line-width: 0.5;
+      line-width: 0.5;
     }
     [zoom >= 6] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-      line-dasharray: 4,1.5;
+      background/line-width: 0.6;
+      line-width: 0.6;
     }
     [zoom >= 7] {
-      background/line-width: 1;
-      line-width: 1;
-      line-dasharray: 5,1.5;
+      background/line-width: 0.8;
+      line-width: 0.8;
     }
     [zoom >= 8] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 6,2;
     }
     [zoom >= 9] {
       background/line-width: 1.8;
@@ -263,7 +256,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 2.5;
       line-color: @admin-boundaries-wide;
       line-width: 2.5;
-      line-dasharray: 8,2;
     }
     [zoom >= 11] {
       background/line-width: 3;
@@ -272,7 +264,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 3.5;
       line-width: 3.5;
-      line-dasharray: 10,3;
     }
     [zoom >= 13] {
       background/line-width: 4;
@@ -281,7 +272,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 4.5;
       line-width: 4;
-      line-dasharray: 12,3;
     }
   }
   [admin_level = '4']::narrowline {
@@ -291,7 +281,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 0.6;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
-      thin/line-dasharray: 8,2;
+      thin/line-dasharray: 9,1.5,1.5,1.5,1.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -300,7 +290,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1;
       thin/line-width: 1;
-      thin/line-dasharray: 10,3;
+      thin/line-dasharray: 14,2,2,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -309,7 +299,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.5;
       thin/line-width: 1.5;
-      thin/line-dasharray: 12,3;
+      thin/line-dasharray: 18,3,3,3,3,3;
     }
   }
   ::firstline { opacity: 0.5; }
@@ -337,24 +327,25 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.6;
-    line-dasharray: 10,2,2,2;
+    line-dasharray: 4,2;
     line-clip: false;
     [zoom >= 9] {
       background/line-width: 0.8;
       line-width: 0.8;
+      line-dasharray: 6,3;
     }
     [zoom >= 10] {
-      background/line-width: 1.0;
-      line-width: 1.0;
-      line-dasharray: 12,2,2,2;
-    }
-    [zoom >= 11] {
       background/line-width: 1.2;
       line-width: 1.2;
+      line-dasharray: 10,2,2,2;
+    }
+    [zoom >= 11] {
+      background/line-width: 1.4;
+      line-width: 1.4;
     }
     [zoom >= 12] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.6;
+      line-width: 1.6;
       line-dasharray: 16,2,2,2;
     }
     [zoom >= 13] {
@@ -370,24 +361,24 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '6'][zoom >= 10]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.8;
+    background/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 0.8;
+    line-width: 1;
     line-dasharray: 8,2,2,2,2,2;
     line-clip: false;
     [zoom >= 11] {
-      background/line-width: 1;
-      line-width: 1;
-    }
-    [zoom >= 12] {
       background/line-width: 1.2;
       line-width: 1.2;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.4;
+      line-width: 1.4;
     line-dasharray: 12,2,2,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.6;
+      line-width: 1.6;
     }
     [zoom >= 15] {
       background/line-width: 1.8;
@@ -399,21 +390,21 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 11] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 1;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.8;
+      line-width: 1;
       line-dasharray: 6,2,2,2,2,2,2,2;
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1;
-      line-width: 1;
+      background/line-width: 1.2;
+      line-width: 1.2;
       line-dasharray: 8,2,2,2,2,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.3;
-      line-width: 1.3;
+      background/line-width: 1.4;
+      line-width: 1.4;
     }
     [zoom >= 15] {
       background/line-width: 1.6;
@@ -425,16 +416,16 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.9;
+      background/line-width: 1;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.9;
+      line-width: 1;
       line-dasharray: 6,2,2,2,3,2,3,2,2,2;
       line-clip: false;
     }
     [zoom >= 13] {
-      background/line-width: 1.1;
-      line-width: 1.1;
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 15] {
       background/line-width: 1.4;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #3c7a72; // Lch(47,22,185)
+@admin-boundaries: #8d618b; // Lch(47,30,327)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -16,10 +16,10 @@ overlapping borders correctly.
       background/line-width: 2.8;
     }
     [zoom >= 9] { background/line-width: 3.5; }
-    [zoom >= 10] { background/line-width: 4; }
-    [zoom >= 11] { background/line-width: 4.5; }
-    [zoom >= 12] { background/line-width: 5; }
-    [zoom >= 13] { background/line-width: 6; }
+    [zoom >= 10] { background/line-width: 4.5; }
+    [zoom >= 11] { background/line-width: 4; }
+    [zoom >= 12] { background/line-width: 5.5; }
+    [zoom >= 13] { background/line-width: 6.5; }
     [zoom >= 15] { background/line-width: 7.5; }
   }
   [admin_level = '2']::wideline {
@@ -76,16 +76,14 @@ overlapping borders correctly.
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 0.6;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
-      thin/line-width: 0.8;
-      thin/line-dasharray: 14,1,1,1,1,1;
+      thin/line-width: 0.6;
     }
     [zoom >= 9] {
-      background/line-width: 1.0;
-      thin/line-width: 1.0;
-      thin/line-dasharray: 18,1.2,1.2,1.2,1.2,1.2;
+      background/line-width: 0.8;
+      thin/line-width: 0.8;
     }
     [zoom >= 10] {
       background/line-width: 1.2;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #ac46ac;
+@admin-boundaries: #965b95; // Lch(47,40,327)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;
@@ -427,6 +427,7 @@ overlapping borders correctly.
     text-name: "[name]";
     text-face-name: @book-fonts;
     text-fill: @state-labels;
+    [admin_level = '6'] { text-fill: @county-labels; }
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-largest-bbox-only: false;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -102,11 +102,11 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 3;
       line-width: 3;
-      line-dasharray: 0,1,6,1;
+      line-dasharray: 0,1,17,1;
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
-      thin/line-dasharray: 0,1,6,1;
+      thin/line-dasharray: 0,1,4.75,1.5,1.5,1.5,1.5,1.5,4.75,1;
     }
     [zoom >= 11] {
       background/line-width: 3.5;
@@ -116,9 +116,9 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 4;
       line-width: 4.0;
-      line-dasharray: 0,1.3,8,1.3;
+      line-dasharray: 0,1.5,26,1.5;
       thin/line-width: 1.2;
-      thin/line-dasharray: 0,1.3,8,1.3;
+      thin/line-dasharray: 0,1.5,8,2,2,2,2,2,8,1.5;
     }
     [zoom >= 13] {
       background/line-width: 4.5;
@@ -127,9 +127,9 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 5;
       line-width: 5;
-      line-dasharray: 0,1.5,10,1.5;
+      line-dasharray: 0,2,35,2;
       thin/line-width: 1.5;
-      thin/line-dasharray: 0,1.5,10,1.5;
+      thin/line-dasharray: 0,2,10,3,3,3,3,3,10,2;
     }
   }
 
@@ -171,7 +171,7 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 2.0;
       line-width: 2.0;
-      line-dasharray: 0,2,12,2;
+      line-dasharray: 0,1.5,12,1.5;
     }
     [zoom >= 11] {
       background/line-width: 2.5;
@@ -180,11 +180,11 @@ overlapping borders correctly.
     [zoom >= 12] {
       background/line-width: 3;
       line-width: 3;
-      line-dasharray: 0,3,18,3;
+      line-dasharray: 0,2,18,2;
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
-      thin/line-dasharray: 1.5,3,3,3,3,3,3,3,1.5,0;
+      thin/line-dasharray: 1,3,3,3,2,3,3,3,1,0;
     }
     [zoom >= 13] {
       background/line-width: 3.5;
@@ -194,9 +194,9 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 4;
       line-width: 4;
-      line-dasharray: 0,4,24,4;
+      line-dasharray: 0,3,24,3;
       thin/line-width: 1.2;
-      thin/line-dasharray: 2,4,4,4,4,4,4,4,2,0;
+      thin/line-dasharray: 1.5,4,4,4,3,4,4,4,1.5,0;
     }
   }
   /*
@@ -304,7 +304,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 12,2,3,2,2,2,3,2;
+      line-dasharray: 12,2,2,2,3,2,2,2;
     }
   }
  [admin_level = '8'] {
@@ -315,7 +315,7 @@ overlapping borders correctly.
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1;
-      line-dasharray: 6,2,3,2,2,2,2,2,3,2;
+      line-dasharray: 6,2,2,2,3,2,3,2,2,2;
       line-clip: false;
     }
     [zoom >= 13] {
@@ -340,12 +340,12 @@ overlapping borders correctly.
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.0;
-    line-dasharray: 0,2,2,2,2,2,2,2,2,2;
+    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 0,3,3,2,2,3,2,2,3,3;
+      line-dasharray: 0,4,3,2,2,3,2,2,3,4;
     }
   }
   [admin_level = '10'][zoom >= 14] {
@@ -355,12 +355,12 @@ overlapping borders correctly.
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
-    line-dasharray: 0,2,2,2,2,2,2,2;
+    line-dasharray: 0,4,3,2,3,2,3,4;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 0,3,3,2,2,2,3,3;
+      line-dasharray: 0,6,3,3,2,3,3,6;
     }
   }
   opacity: 0.6;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -9,7 +9,7 @@ overlapping borders correctly.
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
-  [admin_level = '2'] {
+  [admin_level = '2']::wideline  {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
@@ -41,36 +41,53 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 4;
       line-width: 4;
-      thin/line-width: 0.8;
-      thin/line-join: bevel;
-      thin/line-color: black;
-      thin/line-width: 0.8;
-      thin/line-dasharray: 18,1.5,1.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 4.5;
       line-width: 4.5;
-      thin/line-width: 1;
     }
     [zoom >= 12] {
       background/line-width: 5;
       line-width: 5;
-      thin/line-width: 1.2;
-      thin/line-dasharray: 24,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 6;
       line-width: 6;
-      thin/line-width: 1.5;
     }
     [zoom >= 15] {
       background/line-width: 7.5;
       line-width: 7.5;
+    }
+  }
+
+  [admin_level = '2']::narrowline  {
+    [zoom >= 8] {
+      thin/line-join: bevel;
+      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-width: 0.6;
+      thin/line-dasharray: 12,1,1,1;
+    }
+    [zoom >= 10] {
+      thin/line-width: 0.8;
+      thin/line-dasharray: 18,1.5,1.5,1.5;
+    }
+    [zoom >= 11] {
+      thin/line-width: 1;
+    }
+    [zoom >= 12] {
+      thin/line-width: 1.2;
+      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-dasharray: 24,2,2,2;
+    }
+    [zoom >= 13] {
+      thin/line-width: 1.5;
+    }
+    [zoom >= 15] {
       thin/line-width: 1.8;
     }
   }
 
-  [admin_level = '3'] {
+  [admin_level = '3']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
@@ -103,22 +120,15 @@ overlapping borders correctly.
       background/line-width: 3;
       line-width: 3;
       line-dasharray: 0,1,17,1;
-      thin/line-join: bevel;
-      thin/line-color: black;
-      thin/line-width: 0.8;
-      thin/line-dasharray: 0,1,4.75,1.5,1.5,1.5,1.5,1.5,4.75,1;
     }
     [zoom >= 11] {
       background/line-width: 3.5;
       line-width: 3.5;
-      thin/line-width: 1;
     }
     [zoom >= 12] {
       background/line-width: 4;
       line-width: 4.0;
       line-dasharray: 0,1.5,26,1.5;
-      thin/line-width: 1.2;
-      thin/line-dasharray: 0,1.5,8,2,2,2,2,2,8,1.5;
     }
     [zoom >= 13] {
       background/line-width: 4.5;
@@ -128,12 +138,30 @@ overlapping borders correctly.
       background/line-width: 5;
       line-width: 5;
       line-dasharray: 0,2,35,2;
+    }
+  }
+  [admin_level = '3']::narrowline {
+    [zoom >= 10] {
+      thin/line-join: bevel;
+      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-width: 0.8;
+      thin/line-dasharray: 0,1,4.75,1.5,1.5,1.5,1.5,1.5,4.75,1;
+    }
+    [zoom >= 11] {
+      thin/line-width: 1;
+    }
+    [zoom >= 12] {
+      thin/line-width: 1.2;
+      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-dasharray: 0,1.5,8,2,2,2,2,2,8,1.5;
+    }
+    [zoom >= 15] {
       thin/line-width: 1.5;
       thin/line-dasharray: 0,2,10,3,3,3,3,3,10,2;
     }
   }
 
-  [admin_level = '4'] {
+  [admin_level = '4']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
@@ -181,20 +209,34 @@ overlapping borders correctly.
       background/line-width: 3;
       line-width: 3;
       line-dasharray: 0,2,18,2;
-      thin/line-join: bevel;
-      thin/line-color: black;
-      thin/line-width: 0.8;
-      thin/line-dasharray: 1,3,3,3,2,3,3,3,1,0;
     }
     [zoom >= 13] {
       background/line-width: 3.5;
       line-width: 3.5;
-      thin/line-width: 1.0;
     }
     [zoom >= 15] {
       background/line-width: 4;
       line-width: 4;
       line-dasharray: 0,3,24,3;
+    }
+  }
+
+  [admin_level = '4']::narrowline {
+    [zoom >= 10] {
+      thin/line-join: bevel;
+      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-width: 0.6;
+      thin/line-dasharray: 0,2.5,2,2,2,2,2,2.5;
+    }
+    [zoom >= 12] {
+      thin/line-width: 0.8;
+      thin/line-dasharray: 1,3,3,3,2,3,3,3,1,0;
+    }
+    [zoom >= 13] {
+      thin/line-color: darken(@admin-boundaries, 5%);
+      thin/line-width: 1.0;
+    }
+    [zoom >= 15] {
       thin/line-width: 1.2;
       thin/line-dasharray: 1.5,4,4,4,3,4,4,4,1.5,0;
     }
@@ -211,8 +253,10 @@ overlapping borders correctly.
   admin_level is rendered on top, and therefore the only visible boundary.
   */
   opacity: 0.4;
-  [zoom >= 10] { opacity: 0.35; }
-  [zoom >= 12] { opacity: 0.3; }
+  [zoom >= 10]::wideline { opacity: 0.35; }
+  [zoom >= 10]::narrowline { opacity: 0.8; }
+  [zoom >= 12]::wideline { opacity: 0.3; }
+  [zoom >= 12]::narrowline { opacity: 0.6; }
   comp-op: darken;
 }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,6 +1,6 @@
 @admin-boundaries: #8d618b; // Lch(47,30,327)
-@admin-boundaries-narrow: #884e87; // Lch(42,40,327)
-@admin-boundaries-wide: #90738f; // Lch(52,20,327)
+@admin-boundaries-narrow: #845283; // Lch(42,35,327)
+@admin-boundaries-wide: #a37da1; // Lch(57,25,327)
 
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -21,10 +21,10 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     }
     [zoom >= 9] { background/line-width: 3.5; }
     [zoom >= 10] { background/line-width: 4.5; }
-    [zoom >= 11] { background/line-width: 5; }
-    [zoom >= 12] { background/line-width: 5.5; }
-    [zoom >= 13] { background/line-width: 6.5; }
-    [zoom >= 15] { background/line-width: 7.5; }
+    [zoom >= 11] { background/line-width: 5.5; }
+    [zoom >= 12] { background/line-width: 6; }
+    [zoom >= 13] { background/line-width: 7; }
+    [zoom >= 15] { background/line-width: 8; }
   }
   [admin_level = '2']::wideline {
     [zoom >= 4] {
@@ -122,7 +122,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 1.8;
     }
     [zoom >= 9] { background/line-width: 2.5; }
-    [zoom >= 10] { background/line-width: 3.5; }
+    [zoom >= 10] { background/line-width: 3.2; }
     [zoom >= 11] { background/line-width: 4; }
     [zoom >= 12] { background/line-width: 4.5; }
     [zoom >= 13] { background/line-width: 5; }
@@ -213,10 +213,10 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.2;
+      background/line-width: 1;
     }
-    [zoom >= 9] { background/line-width: 1.8; }
-    [zoom >= 10] { background/line-width: 2.0; }
+    [zoom >= 9] { background/line-width: 1.5; }
+    [zoom >= 10] { background/line-width: 2; }
     [zoom >= 11] { background/line-width: 2.5; }
     [zoom >= 12] { background/line-width: 3; }
     [zoom >= 13] { background/line-width: 3.5; }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -426,7 +426,7 @@ overlapping borders correctly.
   [zoom >= 17] {
     text-name: "[name]";
     text-face-name: @book-fonts;
-    text-fill: @admin-boundaries;
+    text-fill: @state-labels;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
     text-largest-bbox-only: false;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -21,7 +21,7 @@ overlapping borders correctly.
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1.0;
+      line-width: 1.2;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
     }
@@ -46,8 +46,8 @@ overlapping borders correctly.
       line-width: 3.5;
     }
     [zoom >= 10] {
-      background/line-width: 4.5;
-      line-width: 4.5;
+      background/line-width: 4;
+      line-width: 4;
       thin/line-width: 0.8;
       thin/line-join: bevel;
       thin/line-color: black;
@@ -57,25 +57,25 @@ overlapping borders correctly.
       thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 11] {
-      background/line-width: 5;
-      line-width: 5;
+      background/line-width: 4.5;
+      line-width: 4.5;
       thin/line-width: 1.0;
     }
     [zoom >= 12] {
-      background/line-width: 6;
-      line-width: 6;
+      background/line-width: 5;
+      line-width: 5;
       thin/line-width: 1.2;
       thin/line-dasharray: 24,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 7;
-      line-width: 7;
+      background/line-width: 6;
+      line-width: 6;
       thin/line-width: 1.5;
     }
     [zoom >= 15] {
-      background/line-width: 9;
-      line-width: 9;
-      thin/line-width: 2.0;
+      background/line-width: 7.5;
+      line-width: 7.5;
+      thin/line-width: 1.8;
       thin/line-dasharray: 36,3,3,3;
     }
   }
@@ -133,17 +133,16 @@ overlapping borders correctly.
       background/line-width: 4.0;
       line-width: 4.0;
       line-dasharray: 0,1.5,9,1.5;
-      thin/line-width: 1.0;
+      thin/line-width: 1.2;
       thin/line-dasharray: 0,1.5,9,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 5;
-      line-width: 5;
-      thin/line-width: 1.2;
+      background/line-width: 4.5;
+      line-width: 4.5;
     }
     [zoom >= 15] {
-      background/line-width: 6;
-      line-width: 6;
+      background/line-width: 5;
+      line-width: 5;
       line-dasharray: 0,2,12,2;
       thin/line-width: 1.5;
       thin/line-dasharray: 0,2,12,2;
@@ -181,13 +180,11 @@ overlapping borders correctly.
       background/line-width: 1.2;
       line-width: 1.2;
       line-dasharray: 6,2;
-
     }
     [zoom >= 9] {
       background/line-width: 1.8;
       line-width: 1.8;
       line-dasharray: 8,3;
-
     }
     [zoom >= 10] {
       background/line-width: 2.0;
@@ -210,13 +207,13 @@ overlapping borders correctly.
       thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
     [zoom >= 13] {
-      background/line-width: 4;
-      line-width: 4;
+      background/line-width: 3.5;
+      line-width: 3.5;
       thin/line-width: 1.0;
     }
     [zoom >= 15] {
-      background/line-width: 5;
-      line-width: 5;
+      background/line-width: 4;
+      line-width: 4;
       line-dasharray: 0,4,28,4;
       thin/line-width: 1.2;
       thin/line-dasharray: 2,4,2,2,2,4,4,4,2,2,2,4,2,0;
@@ -243,47 +240,6 @@ overlapping borders correctly.
   [admin_level = '5'][zoom >= 8] {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 0.6;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
-    line-join: bevel;
-    line-color: @admin-boundaries;
-    line-width: 0.6;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
-    line-dasharray: 8,2,2,2;
-    line-clip: false;
-    [zoom >= 9] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-    }
-    [zoom >= 10] {
-      background/line-width: 1.0;
-      line-width: 1.0;
-      line-dasharray: 12,2,2,2;
-    }
-    [zoom >= 11] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-    }
-    [zoom >= 12] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-      line-dasharray: 16,2,2,2;
-    }
-    [zoom >= 13] {
-      background/line-width: 1.8;
-      line-width: 1.8;
-    }
-    [zoom >= 15] {
-      background/line-width: 2;
-      line-width: 2;
-      line-dasharray: 24,3,3,3;
-    }
-  }
-  [admin_level = '6'][zoom >= 10] {
-    background/line-join: bevel;
-    background/line-color: white;
     background/line-width: 0.8;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
@@ -292,16 +248,86 @@ overlapping borders correctly.
     line-width: 0.8;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
+    line-dasharray: 8,2,2,2;
+    line-clip: false;
+    [zoom >= 9] {
+      background/line-width: 1.0;
+      line-width: 1.0;
+    }
+    [zoom >= 10] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+      line-dasharray: 12,2,2,2;
+    }
+    [zoom >= 11] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+      line-dasharray: 16,2,2,2;
+    }
+    [zoom >= 13] {
+      background/line-width: 2;
+      line-width: 2;
+    }
+    [zoom >= 15] {
+      background/line-width: 2.5;
+      line-width: 2.5;
+      line-dasharray: 24,3,3,3;
+    }
+  }
+  [admin_level = '6'][zoom >= 10] {
+    background/line-join: bevel;
+    background/line-color: white;
+    background/line-width: 1.0;
+    background/line-simplify: @admin-simplify;
+    background/line-simplify-algorithm: @admin-simplify-algorithm;
+    line-join: bevel;
+    line-color: @admin-boundaries;
+    line-width: 1.0;
+    line-simplify: @admin-simplify;
+    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 8,2,2,2,2,2;
     line-clip: false;
     [zoom >= 11] {
-      background/line-width: 1.0;
-      line-width: 1.0;
+      background/line-width: 1.2;
+      line-width: 1.2;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    line-dasharray: 12,2,2,2,2,2;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.8;
+      line-width: 1.8;
+    }
+    [zoom >= 15] {
+      background/line-width: 2.0;
+      line-width: 2.0;
+      line-dasharray: 18,3,3,3,3,3;
+    }
+  }
+  [admin_level = '7'] {
+    [zoom >= 11] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 1;
+      background/line-simplify: @admin-simplify;
+      background/line-simplify-algorithm: @admin-simplify-algorithm;
+      line-join: bevel;
+      line-color: @admin-boundaries;
+      line-width: 1;
+      line-simplify: @admin-simplify;
+      line-simplify-algorithm: @admin-simplify-algorithm;
+      line-dasharray: 8,2,2,2,2,2,2,2;
+      line-clip: false;
     }
     [zoom >= 12] {
       background/line-width: 1.2;
       line-width: 1.2;
-    line-dasharray: 12,2,2,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 1.5;
@@ -310,27 +336,23 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 18,3,3,3,3,3;
+      line-dasharray: 12,3,3,3,3,3,3,3;
     }
   }
-  [admin_level = '7'] {
-    [zoom >= 11] {
+ [admin_level = '8'] {
+    [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 1;
       background/line-simplify: @admin-simplify;
       background/line-simplify-algorithm: @admin-simplify-algorithm;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 0.8;
+      line-width: 1;
       line-simplify: @admin-simplify;
       line-simplify-algorithm: @admin-simplify-algorithm;
-      line-dasharray: 8,2,2,2,2,2,2,2;
+      line-dasharray: 6,2,2,2,2,2,2,2,2,2;
       line-clip: false;
-    }
-    [zoom >= 12] {
-      background/line-width: 1.0;
-      line-width: 1.0;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -339,31 +361,6 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 12,3,3,3,3,3,3,3;
-    }
-  }
- [admin_level = '8'] {
-    [zoom >= 12] {
-      background/line-join: bevel;
-      background/line-color: white;
-      background/line-width: 0.8;
-      background/line-simplify: @admin-simplify;
-      background/line-simplify-algorithm: @admin-simplify-algorithm;
-      line-join: bevel;
-      line-color: @admin-boundaries;
-      line-width: 0.8;
-      line-simplify: @admin-simplify;
-      line-simplify-algorithm: @admin-simplify-algorithm;
-      line-dasharray: 6,2,2,2,2,2,2,2,2,2;
-      line-clip: false;
-    }
-    [zoom >= 13] {
-      background/line-width: 1.0;
-      line-width: 1.0;
-    }
-    [zoom >= 15] {
-      background/line-width: 1.2;
-      line-width: 1.2;
       line-dasharray: 9,3,3,3,3,3,3,3,3,3;
     }
   }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -80,16 +80,17 @@ overlapping borders correctly.
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.8;
-      thin/line-dasharray: 12,1,1,1;
+      thin/line-dasharray: 14,1,1,1,1,1;
     }
     [zoom >= 9] {
       background/line-width: 1.0;
       thin/line-width: 1.0;
+      thin/line-dasharray: 18,1.2,1.2,1.2,1.2,1.2;
     }
     [zoom >= 10] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
-      thin/line-dasharray: 18,1.5,1.5,1.5;
+      thin/line-dasharray: 22,1.5,1.5,1.5,1.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 1.5;
@@ -99,7 +100,7 @@ overlapping borders correctly.
       background/line-width: 1.8;
       thin/line-width: 1.8;
       thin/line-color: darken(@admin-boundaries, 5%);
-      thin/line-dasharray: 24,2,2,2;
+      thin/line-dasharray: 26,2,2,2,2,2;
     }
     [zoom >= 13] {
       background/line-width: 2;
@@ -108,6 +109,7 @@ overlapping borders correctly.
     [zoom >= 15] {
       background/line-width: 2.2;
       thin/line-width: 2.2;
+      thin/line-dasharray: 39,3,3,3,3,3;
     }
   }
 
@@ -156,7 +158,7 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-width: 3.5;
       line-width: 3;
-      line-dasharray: 0,1,17,1;
+      line-dasharray: 0,1,17.5,1;
     }
     [zoom >= 11] {
       background/line-width: 4;
@@ -178,6 +180,17 @@ overlapping borders correctly.
     }
   }
   [admin_level = '3']::narrowline {
+    [zoom >= 8] {
+      thin/line-join: bevel;
+      thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-width: 0.4;
+      thin/line-dasharray: 4.5,1,4.5,1,1,1;
+    }
+    [zoom >= 9] {
+      thin/line-width: 0.6;
+      thin/line-dasharray: 5.5,1.2,5.5,1.2,1.2,1.2;
+
+    }
     [zoom >= 10] {
       background/line-join: bevel;
       background/line-color: white;
@@ -185,7 +198,7 @@ overlapping borders correctly.
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 1;
-      thin/line-dasharray: 0,1,6.25,1.5,1.5,1.5,6.25,1;
+      thin/line-dasharray: 0,1,6.5,1.5,1.5,1.5,6.5,1;
     }
     [zoom >= 11] {
       background/line-width: 1.2;
@@ -249,7 +262,7 @@ overlapping borders correctly.
     [zoom >= 8] {
       background/line-width: 1.5;
       line-width: 1.5;
-      line-dasharray: 8,2;
+      line-dasharray: 0,1,8,1;
     }
     [zoom >= 9] {
       background/line-width: 2;
@@ -285,7 +298,7 @@ overlapping borders correctly.
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.4;
-      thin/line-dasharray: 3,2,3,2;
+      thin/line-dasharray: 0,1,3,2,3,1;
     }
     [zoom >= 9] {
       thin/line-width: 0.6;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -148,12 +148,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 1.2;
     }
     [zoom >= 8] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.8;
+      line-width: 1.8;
     }
     [zoom >= 9] {
-      background/line-width: 2.7;
-      line-width: 2.7;
+      background/line-width: 2.5;
+      line-width: 2.5;
     }
     [zoom >= 10] {
       background/line-width: 3.5;
@@ -249,13 +249,13 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-dasharray: 5,1.5;
     }
     [zoom >= 8] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.2;
+      line-width: 1.2;
       line-dasharray: 6,2;
     }
     [zoom >= 9] {
-      background/line-width: 2;
-      line-width: 2;
+      background/line-width: 1.8;
+      line-width: 1.8;
     }
     [zoom >= 10] {
       background/line-width: 2.5;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -343,7 +343,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.6;
-    line-dasharray: 10,1.5,1.5,1.5;
+    line-dasharray: 10,2,2,2;
     line-clip: false;
     [zoom >= 9] {
       background/line-width: 0.8;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -312,7 +312,6 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   ::firstline { opacity: 0.5; }
   ::wideline { opacity: 0.5; }
   ::narrowline { opacity: 0.6; }
-  }
   /*
   The following code prevents admin boundaries from being rendered on top of
   each other. Comp-op works on the entire attachment, not on the individual

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #965b95; // Lch(47,40,327)
+@admin-boundaries: #3c7a72; // Lch(47,22,185)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;
@@ -120,6 +120,7 @@ overlapping borders correctly.
       thin/line-join: bevel;
       thin/line-color: black;
       thin/line-width: 0.8;
+      thin/line-dasharray: 0,1,6,1;
       thin/line-simplify: @admin-simplify;
       thin/line-simplify-algorithm: @admin-simplify-algorithm;
     }
@@ -133,13 +134,12 @@ overlapping borders correctly.
       line-width: 4.0;
       line-dasharray: 0,1.5,9,1.5;
       thin/line-width: 1.0;
-      line-dasharray: 0,1.5,9,1.5;
+      thin/line-dasharray: 0,1.5,9,1.5;
     }
     [zoom >= 13] {
       background/line-width: 5;
       line-width: 5;
       thin/line-width: 1.2;
-      thin/line-dasharray: 0,1.5,10,1.5;
     }
     [zoom >= 15] {
       background/line-width: 6;
@@ -374,6 +374,25 @@ overlapping borders correctly.
   [admin_level = '9'] {
     background/line-join: bevel;
     background/line-color: white;
+    background/line-width: 1.0;
+    background/line-simplify: @admin-simplify;
+    background/line-simplify-algorithm: @admin-simplify-algorithm;
+    line-join: bevel;
+    line-color: @admin-boundaries;
+    line-width: 1.0;
+    line-simplify: @admin-simplify;
+    line-simplify-algorithm: @admin-simplify-algorithm;
+    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
+    line-clip: false;
+    [zoom >= 15] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+      line-dasharray: 0,4,3,3,3,3,3,3,3,4;
+    }
+  }
+  [admin_level = '10'][zoom >= 14] {
+    background/line-join: bevel;
+    background/line-color: white;
     background/line-width: 0.8;
     background/line-simplify: @admin-simplify;
     background/line-simplify-algorithm: @admin-simplify-algorithm;
@@ -382,30 +401,11 @@ overlapping borders correctly.
     line-width: 0.8;
     line-simplify: @admin-simplify;
     line-simplify-algorithm: @admin-simplify-algorithm;
-    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
-    line-clip: false;
-    [zoom >= 15] {
-      background/line-width: 1.0;
-      line-width: 1.0;
-      line-dasharray: 0,4,3,3,3,3,3,3,3,4;
-    }
-  }
-  [admin_level = '10'][zoom >= 14] {
-    background/line-join: bevel;
-    background/line-color: white;
-    background/line-width: 0.6;
-    background/line-simplify: @admin-simplify;
-    background/line-simplify-algorithm: @admin-simplify-algorithm;
-    line-join: bevel;
-    line-color: @admin-boundaries;
-    line-width: 0.6;
-    line-simplify: @admin-simplify;
-    line-simplify-algorithm: @admin-simplify-algorithm;
     line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {
-      background/line-width: 0.8;
-      line-width: 0.8;
+      background/line-width: 1;
+      line-width: 1;
       line-dasharray: 0,4,3,3,3,3,3,4;
     }
   }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -9,7 +9,20 @@ overlapping borders correctly.
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
-  [admin_level = '2']::wideline  {
+  [admin_level = '2']::firstline {
+    [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 2.8;
+    }
+    [zoom >= 9] { background/line-width: 3.5; }
+    [zoom >= 10] { background/line-width: 4; }
+    [zoom >= 11] { background/line-width: 4.5; }
+    [zoom >= 12] { background/line-width: 5; }
+    [zoom >= 13] { background/line-width: 6; }
+    [zoom >= 15] { background/line-width: 7.5; }
+  }
+  [admin_level = '2']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
@@ -59,34 +72,54 @@ overlapping borders correctly.
       line-width: 7.5;
     }
   }
-
-  [admin_level = '2']::narrowline  {
+  [admin_level = '2']::narrowline {
     [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.6;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.6;
       thin/line-dasharray: 12,1,1,1;
     }
     [zoom >= 10] {
+      background/line-width: 0.8;
       thin/line-width: 0.8;
       thin/line-dasharray: 18,1.5,1.5,1.5;
     }
     [zoom >= 11] {
+      background/line-width: 1;
       thin/line-width: 1;
     }
     [zoom >= 12] {
+      background/line-width: 1.2;
       thin/line-width: 1.2;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-dasharray: 24,2,2,2;
     }
     [zoom >= 13] {
+      background/line-width: 1.5;
       thin/line-width: 1.5;
     }
     [zoom >= 15] {
+      background/line-width: 1.8;
       thin/line-width: 1.8;
     }
   }
 
+  [admin_level = '3']::firstline {
+    [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 1.5;
+    }
+    [zoom >= 9] { background/line-width: 2; }
+    [zoom >= 10] { background/line-width: 3; }
+    [zoom >= 11] { background/line-width: 3.5; }
+    [zoom >= 12] { background/line-width: 4; }
+    [zoom >= 13] { background/line-width: 4.5; }
+    [zoom >= 15] { background/line-width: 5; }
+  }
   [admin_level = '3']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
@@ -142,25 +175,44 @@ overlapping borders correctly.
   }
   [admin_level = '3']::narrowline {
     [zoom >= 10] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.8;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.8;
       thin/line-dasharray: 0,1,4.75,1.5,1.5,1.5,1.5,1.5,4.75,1;
     }
     [zoom >= 11] {
+      background/line-width: 1;
       thin/line-width: 1;
     }
     [zoom >= 12] {
+      background/line-width: 1.2;
       thin/line-width: 1.2;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-dasharray: 0,1.5,8,2,2,2,2,2,8,1.5;
     }
     [zoom >= 15] {
+      background/line-width: 1.5;
       thin/line-width: 1.5;
       thin/line-dasharray: 0,2,10,3,3,3,3,3,10,2;
     }
   }
 
+  [admin_level = '4']::firstline {
+    [zoom >= 8] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 1.2;
+    }
+    [zoom >= 9] { background/line-width: 1.8;  }
+    [zoom >= 10] { background/line-width: 2.0; }
+    [zoom >= 11] { background/line-width: 2.5; }
+    [zoom >= 12] { background/line-width: 3; }
+    [zoom >= 13] { background/line-width: 3.5; }
+    [zoom >= 15] { background/line-width: 4; }
+  }
   [admin_level = '4']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
@@ -220,23 +272,28 @@ overlapping borders correctly.
       line-dasharray: 0,3,24,3;
     }
   }
-
   [admin_level = '4']::narrowline {
     [zoom >= 10] {
+      background/line-join: bevel;
+      background/line-color: white;
+      background/line-width: 0.6;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
       thin/line-width: 0.6;
       thin/line-dasharray: 0,2.5,2,2,2,2,2,2.5;
     }
     [zoom >= 12] {
+      background/line-width: 0.8;
       thin/line-width: 0.8;
       thin/line-dasharray: 1,3,3,3,2,3,3,3,1,0;
     }
     [zoom >= 13] {
+      background/line-width: 1;
       thin/line-color: darken(@admin-boundaries, 5%);
-      thin/line-width: 1.0;
+      thin/line-width: 1;
     }
     [zoom >= 15] {
+      background/line-width: 1.2;
       thin/line-width: 1.2;
       thin/line-dasharray: 1.5,4,4,4,3,4,4,4,1.5,0;
     }
@@ -257,11 +314,13 @@ overlapping borders correctly.
   [zoom >= 10]::narrowline { opacity: 0.8; }
   [zoom >= 12]::wideline { opacity: 0.3; }
   [zoom >= 12]::narrowline { opacity: 0.6; }
-  comp-op: darken;
+  ::firstline,
+  ::wideline,
+  ::narrowline { comp-op: darken; }
 }
 
-#admin-mid-zoom[zoom >= 8][zoom < 13],
-#admin-high-zoom[zoom >= 13] {
+#admin-mid-zoom[zoom >= 8][zoom < 13]::firstline,
+#admin-high-zoom[zoom >= 13]::firstline {
   [admin_level = '5'][zoom >= 8] {
     background/line-join: bevel;
     background/line-color: white;
@@ -295,7 +354,7 @@ overlapping borders correctly.
     }
     [zoom >= 15] {
       background/line-width: 2.5;
-      line-width: 2.5;
+      line-width: 2.2;
       line-dasharray: 20,2,3,2;
     }
   }
@@ -352,7 +411,7 @@ overlapping borders correctly.
       line-dasharray: 12,2,2,2,3,2,2,2;
     }
   }
- [admin_level = '8'] {
+  [admin_level = '8'] {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
@@ -377,7 +436,7 @@ overlapping borders correctly.
   comp-op: darken;
 }
 
-#admin-high-zoom[zoom >= 13] {
+#admin-high-zoom[zoom >= 13]::firstline {
   [admin_level = '9'] {
     background/line-join: bevel;
     background/line-color: white;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -196,7 +196,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
-      thin/line-dasharray: 18,3,2,3;
+      thin/line-dasharray: 16,3,2,3;
     }
     [zoom >= 13] {
       background/line-width: 1.4;
@@ -205,7 +205,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.6;
       thin/line-width: 1.6;
-      thin/line-dasharray: 24,4,3,4;
+      thin/line-dasharray: 22,4,3,4;
     }
   }
 
@@ -281,7 +281,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       background/line-width: 0.6;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
-      thin/line-dasharray: 9,2,1.5,2,1.5,2;
+      thin/line-dasharray: 8,2,1.5,2,1.5,2;
     }
     [zoom >= 11] {
       background/line-width: 0.8;
@@ -290,7 +290,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1;
       thin/line-width: 1;
-      thin/line-dasharray: 14,3,2,3,2,3;
+      thin/line-dasharray: 12,3,2,3,2,3;
     }
     [zoom >= 13] {
       background/line-width: 1.2;
@@ -299,7 +299,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.4;
       thin/line-width: 1.4;
-      thin/line-dasharray: 18,4,3,4,3,4;
+      thin/line-dasharray: 16,4,3,4,3,4;
     }
   }
   ::firstline { opacity: 0.5; }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -40,8 +40,8 @@ overlapping borders correctly.
       line-width: 1.8;
     }
     [zoom >= 7] {
-      background/line-width: 2;
-      line-width: 2;
+      background/line-width: 2.2;
+      line-width: 2.2;
     }
     [zoom >= 8] {
       background/line-width: 2.8;
@@ -52,20 +52,20 @@ overlapping borders correctly.
       line-width: 3.5;
     }
     [zoom >= 10] {
-      background/line-width: 4;
-      line-width: 4;
-    }
-    [zoom >= 11] {
       background/line-width: 4.5;
       line-width: 4.5;
     }
-    [zoom >= 12] {
+    [zoom >= 11] {
       background/line-width: 5;
       line-width: 5;
     }
+    [zoom >= 12] {
+      background/line-width: 5.5;
+      line-width: 5.5;
+    }
     [zoom >= 13] {
-      background/line-width: 6;
-      line-width: 6;
+      background/line-width: 6.5;
+      line-width: 6.5;
     }
     [zoom >= 15] {
       background/line-width: 7.5;
@@ -76,34 +76,38 @@ overlapping borders correctly.
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.6;
+      background/line-width: 0.8;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
-      thin/line-width: 0.6;
+      thin/line-width: 0.8;
       thin/line-dasharray: 12,1,1,1;
     }
+    [zoom >= 9] {
+      background/line-width: 1.0;
+      thin/line-width: 1.0;
+    }
     [zoom >= 10] {
-      background/line-width: 0.8;
-      thin/line-width: 0.8;
+      background/line-width: 1.2;
+      thin/line-width: 1.2;
       thin/line-dasharray: 18,1.5,1.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1;
-      thin/line-width: 1;
+      background/line-width: 1.5;
+      thin/line-width: 1.5;
     }
     [zoom >= 12] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
+      background/line-width: 1.8;
+      thin/line-width: 1.8;
       thin/line-color: darken(@admin-boundaries, 5%);
       thin/line-dasharray: 24,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
+      background/line-width: 2;
+      thin/line-width: 2;
     }
     [zoom >= 15] {
-      background/line-width: 1.8;
-      thin/line-width: 1.8;
+      background/line-width: 2.2;
+      thin/line-width: 2.2;
     }
   }
 
@@ -138,37 +142,37 @@ overlapping borders correctly.
       line-width: 1;
     }
     [zoom >= 7] {
-      background/line-width: 1.2;
+      background/line-width: 1.5;
       line-width: 1.2;
     }
     [zoom >= 8] {
-      background/line-width: 1.5;
+      background/line-width: 2.1;
       line-width: 1.5;
     }
     [zoom >= 9] {
-      background/line-width: 2;
+      background/line-width: 2.7;
       line-width: 2;
     }
     [zoom >= 10] {
-      background/line-width: 3;
+      background/line-width: 3.5;
       line-width: 3;
       line-dasharray: 0,1,17,1;
     }
     [zoom >= 11] {
-      background/line-width: 3.5;
+      background/line-width: 4;
       line-width: 3.5;
     }
     [zoom >= 12] {
-      background/line-width: 4;
+      background/line-width: 4.5;
       line-width: 4.0;
       line-dasharray: 0,1.5,26,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 4.5;
+      background/line-width: 5;
       line-width: 4.5;
     }
     [zoom >= 15] {
-      background/line-width: 5;
+      background/line-width: 5.5;
       line-width: 5;
       line-dasharray: 0,2,35,2;
     }
@@ -177,26 +181,30 @@ overlapping borders correctly.
     [zoom >= 10] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 0.8;
+      background/line-width: 1;
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
-      thin/line-width: 0.8;
-      thin/line-dasharray: 0,1,4.75,1.5,1.5,1.5,1.5,1.5,4.75,1;
+      thin/line-width: 1;
+      thin/line-dasharray: 0,1,6.25,1.5,1.5,1.5,6.25,1;
     }
     [zoom >= 11] {
-      background/line-width: 1;
-      thin/line-width: 1;
-    }
-    [zoom >= 12] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.5;
+      thin/line-width: 1.2;
       thin/line-color: darken(@admin-boundaries, 5%);
-      thin/line-dasharray: 0,1.5,8,2,2,2,2,2,8,1.5;
+      thin/line-dasharray: 0,1.5,10,2,2,2,10,1.5;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.8;
+      thin/line-width: 1.8;
     }
     [zoom >= 15] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
-      thin/line-dasharray: 0,2,10,3,3,3,3,3,10,2;
+      background/line-width: 2;
+      thin/line-width: 2;
+      thin/line-dasharray: 0,2,13,3,3,3,13,2;
     }
   }
 
@@ -236,67 +244,78 @@ overlapping borders correctly.
     [zoom >= 7] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 6,2;
+      line-dasharray: 6,1.5;
     }
     [zoom >= 8] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1.5;
+      line-width: 1.5;
       line-dasharray: 8,2;
     }
     [zoom >= 9] {
-      background/line-width: 1.8;
-      line-width: 1.8;
-      line-dasharray: 0,1.5,10,1.5;
+      background/line-width: 2;
+      line-width: 2;
+      line-dasharray: 0,1,10,1;
     }
     [zoom >= 10] {
-      background/line-width: 2.0;
-      line-width: 2.0;
-      line-dasharray: 0,1.5,12,1.5;
-    }
-    [zoom >= 11] {
       background/line-width: 2.5;
       line-width: 2.5;
+      line-dasharray: 0,1.2,12,1.2;
     }
-    [zoom >= 12] {
+    [zoom >= 11] {
       background/line-width: 3;
       line-width: 3;
-      line-dasharray: 0,2,18,2;
     }
-    [zoom >= 13] {
+    [zoom >= 12] {
       background/line-width: 3.5;
       line-width: 3.5;
+      line-dasharray: 0,1.5,18,1.5;
     }
-    [zoom >= 15] {
+    [zoom >= 13] {
       background/line-width: 4;
       line-width: 4;
-      line-dasharray: 0,3,24,3;
+    }
+    [zoom >= 15] {
+      background/line-width: 4.5;
+      line-width: 4;
+      line-dasharray: 0,2,24,2;
     }
   }
   [admin_level = '4']::narrowline {
-    [zoom >= 10] {
-      background/line-join: bevel;
-      background/line-color: white;
-      background/line-width: 0.6;
+    [zoom >= 8] {
       thin/line-join: bevel;
       thin/line-color: darken(@admin-boundaries, 10%);
+      thin/line-width: 0.4;
+      thin/line-dasharray: 3,2,3,2;
+    }
+    [zoom >= 9] {
       thin/line-width: 0.6;
-      thin/line-dasharray: 0,2.5,2,2,2,2,2,2.5;
+      thin/line-dasharray: 0,1,4,2,4,1;
+    }
+    [zoom >= 10] {
+      thin/line-width: 0.8;
+      thin/line-dasharray: 0,1.2,5,2,5,1.2;
     }
     [zoom >= 12] {
-      background/line-width: 0.8;
-      thin/line-width: 0.8;
-      thin/line-dasharray: 1,3,3,3,2,3,3,3,1,0;
+      thin/line-width: 1;
+      thin/line-dasharray: 0,1.5,7.5,3,7.5,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 1;
       thin/line-color: darken(@admin-boundaries, 5%);
-      thin/line-width: 1;
+      thin/line-width: 1.2;
     }
     [zoom >= 15] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
-      thin/line-dasharray: 1.5,4,4,4,3,4,4,4,1.5,0;
+      thin/line-width: 1.5;
+      thin/line-dasharray: 0,2,10,4,10,2;
     }
+  }
+  ::firstline { opacity: 0.5; }
+  ::wideline { opacity: 0.4;
+    [zoom >= 10] { opacity: 0.35; }
+    [zoom >= 12] { opacity: 0.3; }
+  }
+  ::narrowline { opacity: 0.8;
+    [zoom >= 10] { opacity: 0.7; }
+    [zoom >= 12] { opacity: 0.6; }
   }
   /*
   The following code prevents admin boundaries from being rendered on top of
@@ -309,19 +328,11 @@ overlapping borders correctly.
   The SQL has `ORDER BY admin_level`, so the boundary with the lowest
   admin_level is rendered on top, and therefore the only visible boundary.
   */
-  opacity: 0.4;
-  [zoom >= 10]::wideline { opacity: 0.35; }
-  [zoom >= 10]::narrowline { opacity: 0.8; }
-  [zoom >= 12]::wideline { opacity: 0.3; }
-  [zoom >= 12]::narrowline { opacity: 0.6; }
   ::firstline,
   ::wideline,
   ::narrowline { comp-op: darken; }
-}
 
-#admin-mid-zoom[zoom >= 8][zoom < 13]::firstline,
-#admin-high-zoom[zoom >= 13]::firstline {
-  [admin_level = '5'][zoom >= 8] {
+  [admin_level = '5'][zoom >= 8]::firstline {
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 0.8;
@@ -340,104 +351,100 @@ overlapping borders correctly.
       line-dasharray: 12,2,2,2;
     }
     [zoom >= 11] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.4;
+      line-width: 1.4;
     }
     [zoom >= 12] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 1.6;
+      line-width: 1.6;
       line-dasharray: 16,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 2;
-      line-width: 2;
-    }
-    [zoom >= 15] {
-      background/line-width: 2.5;
-      line-width: 2.2;
-      line-dasharray: 20,2,3,2;
-    }
-  }
-  [admin_level = '6'][zoom >= 10] {
-    background/line-join: bevel;
-    background/line-color: white;
-    background/line-width: 1.0;
-    line-join: bevel;
-    line-color: @admin-boundaries;
-    line-width: 1.0;
-    line-dasharray: 8,2,2,2,2,2;
-    line-clip: false;
-    [zoom >= 11] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-    }
-    [zoom >= 12] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-    line-dasharray: 12,2,2,2,2,2;
-    }
-    [zoom >= 13] {
       background/line-width: 1.8;
       line-width: 1.8;
     }
     [zoom >= 15] {
-      background/line-width: 2.0;
-      line-width: 2.0;
+      background/line-width: 2;
+      line-width: 2;
+      line-dasharray: 20,2,3,2;
+    }
+  }
+  [admin_level = '6'][zoom >= 10]::firstline {
+    background/line-join: bevel;
+    background/line-color: white;
+    background/line-width: 0.8;
+    line-join: bevel;
+    line-color: @admin-boundaries;
+    line-width: 0.8;
+    line-dasharray: 8,2,2,2,2,2;
+    line-clip: false;
+    [zoom >= 11] {
+      background/line-width: 1;
+      line-width: 1;
+    }
+    [zoom >= 12] {
+      background/line-width: 1.2;
+      line-width: 1.2;
+    line-dasharray: 12,2,2,2,2,2;
+    }
+    [zoom >= 13] {
+      background/line-width: 1.5;
+      line-width: 1.5;
+    }
+    [zoom >= 15] {
+      background/line-width: 1.8;
+      line-width: 1.8;
       line-dasharray: 16,2,3,2,3,2;
     }
   }
-  [admin_level = '7'] {
+  [admin_level = '7']::firstline {
     [zoom >= 11] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1;
+      background/line-width: 0.8;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1;
+      line-width: 0.8;
       line-dasharray: 8,2,2,2,2,2,2,2;
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1;
+      line-width: 1;
     }
     [zoom >= 13] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.3;
+      line-width: 1.3;
     }
     [zoom >= 15] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 1.6;
+      line-width: 1.6;
       line-dasharray: 12,2,2,2,3,2,2,2;
     }
   }
-  [admin_level = '8'] {
+  [admin_level = '8']::firstline {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1;
+      background/line-width: 0.9;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1;
+      line-width: 0.9;
       line-dasharray: 6,2,2,2,3,2,3,2,2,2;
       line-clip: false;
     }
     [zoom >= 13] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1.1;
+      line-width: 1.1;
     }
     [zoom >= 15] {
-      background/line-width: 1.5;
-      line-width: 1.5;
+      background/line-width: 1.4;
+      line-width: 1.4;
       line-dasharray: 10,2,2,2,3,2,3,2,2,2;
     }
   }
-  opacity: 0.5;
-  comp-op: darken;
-}
 
-#admin-high-zoom[zoom >= 13]::firstline {
-  [admin_level = '9'] {
+  [admin_level = '9'][zoom >= 13]::firstline {
     background/line-join: bevel;
     background/line-color: white;
     background/line-width: 1.0;
@@ -452,23 +459,17 @@ overlapping borders correctly.
       line-dasharray: 0,4,3,2,2,3,2,2,3,4;
     }
   }
-  [admin_level = '10'][zoom >= 14] {
-    background/line-join: bevel;
-    background/line-color: white;
-    background/line-width: 0.8;
+  [admin_level = '10'][zoom >= 14]::firstline {
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
     line-dasharray: 0,4,3,2,3,2,3,4;
     line-clip: false;
     [zoom >= 15] {
-      background/line-width: 1;
       line-width: 1;
       line-dasharray: 0,6,3,3,2,3,3,6;
     }
   }
-  opacity: 0.6;
-  comp-op: darken;
 }
 
 #admin-text[zoom >= 11][way_pixels >= 48000] {

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -17,11 +17,11 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 2.8;
+      background/line-width: 3;
     }
     [zoom >= 9] { background/line-width: 3.5; }
     [zoom >= 10] { background/line-width: 4.5; }
-    [zoom >= 11] { background/line-width: 4; }
+    [zoom >= 11] { background/line-width: 5; }
     [zoom >= 12] { background/line-width: 5.5; }
     [zoom >= 13] { background/line-width: 6.5; }
     [zoom >= 15] { background/line-width: 7.5; }
@@ -61,20 +61,20 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 4.5;
     }
     [zoom >= 11] {
-      background/line-width: 5;
+      background/line-width: 5.5;
       line-width: 5;
     }
     [zoom >= 12] {
-      background/line-width: 5.5;
-      line-width: 5.5;
+      background/line-width: 6;
+      line-width: 6;
     }
     [zoom >= 13] {
-      background/line-width: 6.5;
-      line-width: 6.5;
+      background/line-width: 7;
+      line-width: 7;
     }
     [zoom >= 15] {
-      background/line-width: 7.5;
-      line-width: 7.5;
+      background/line-width: 8;
+      line-width: 8;
     }
   }
   [admin_level = '2']::narrowline {
@@ -100,17 +100,17 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-width: 1.2;
     }
     [zoom >= 12] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
+      background/line-width: 1.4;
+      thin/line-width: 1.4;
       thin/line-dasharray: 27,2,6,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.8;
-      thin/line-width: 1.8;
+      background/line-width: 1.6;
+      thin/line-width: 1.6;
     }
     [zoom >= 15] {
-      background/line-width: 2;
-      thin/line-width: 2;
+      background/line-width: 1.8;
+      thin/line-width: 1.8;
       thin/line-dasharray: 36,3,9,3;
     }
   }
@@ -119,14 +119,14 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1.5;
+      background/line-width: 1.8;
     }
-    [zoom >= 9] { background/line-width: 2; }
-    [zoom >= 10] { background/line-width: 3; }
-    [zoom >= 11] { background/line-width: 3.5; }
-    [zoom >= 12] { background/line-width: 4; }
-    [zoom >= 13] { background/line-width: 4.5; }
-    [zoom >= 15] { background/line-width: 5; }
+    [zoom >= 9] { background/line-width: 2.5; }
+    [zoom >= 10] { background/line-width: 3.5; }
+    [zoom >= 11] { background/line-width: 4; }
+    [zoom >= 12] { background/line-width: 4.5; }
+    [zoom >= 13] { background/line-width: 5; }
+    [zoom >= 15] { background/line-width: 5.5; }
   }
   [admin_level = '3']::wideline {
     [zoom >= 4] {
@@ -183,28 +183,28 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 10] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1;
+      background/line-width: 0.8;
       thin/line-join: bevel;
       thin/line-color: @admin-boundaries-narrow;
-      thin/line-width: 1;
+      thin/line-width: 0.8;
       thin/line-dasharray: 12,1.5,1.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
+      background/line-width: 1;
+      thin/line-width: 1;
     }
     [zoom >= 12] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
+      background/line-width: 1.2;
+      thin/line-width: 1.2;
       thin/line-dasharray: 18,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.8;
-      thin/line-width: 1.8;
+      background/line-width: 1.4;
+      thin/line-width: 1.4;
     }
     [zoom >= 15] {
-      background/line-width: 2;
-      thin/line-width: 2;
+      background/line-width: 1.6;
+      thin/line-width: 1.6;
       thin/line-dasharray: 24,3,3,3;
     }
   }
@@ -249,8 +249,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       line-width: 1.2;
     }
     [zoom >= 9] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 1.6;
+      line-width: 1.6;
     }
     [zoom >= 10] {
       background/line-width: 2.5;
@@ -297,8 +297,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-width: 1.2;
     }
     [zoom >= 15] {
-      background/line-width: 1.5;
-      thin/line-width: 1.5;
+      background/line-width: 1.4;
+      thin/line-width: 1.4;
       thin/line-dasharray: 18,3,3,3,3,3;
     }
   }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #7d6696; // Lch(47,30,310)
+@admin-boundaries: #876390; // Lch(47,30,320)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;
@@ -420,8 +420,8 @@ overlapping borders correctly.
   [zoom >= 12][admin_level = '6'][way_pixels >= 196000],
   [zoom >= 13][admin_level = '7'],
   [zoom >= 14][admin_level = '8'],
-  [zoom >= 16][admin_level = '9'],
-  [zoom >= 17] {
+  [zoom >= 15][admin_level = '9'],
+  [zoom >= 16] {
     text-name: "[name]";
     text-face-name: @book-fonts;
     text-fill: @state-labels;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -1,4 +1,4 @@
-@admin-boundaries: #8d618b; // Lch(47,30,327)
+@admin-boundaries: #7d6696; // Lch(47,30,310)
 
 @admin-simplify: 4;
 @admin-simplify-algorithm: visvalingam-whyatt;
@@ -233,7 +233,8 @@ overlapping borders correctly.
   The SQL has `ORDER BY admin_level`, so the boundary with the lowest
   admin_level is rendered on top, and therefore the only visible boundary.
   */
-  opacity: 0.5;
+  opacity: 0.4;
+  [zoom >= 10] { opacity: 0.5; }
   comp-op: darken;
 }
 

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -93,7 +93,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 10] {
       background/line-width: 1;
       thin/line-width: 1;
-      thin/line-dasharray: 18,1.5,4.5,1.5;
+      thin/line-dasharray: 18,1,4,1;
     }
     [zoom >= 11] {
       background/line-width: 1.2;
@@ -102,7 +102,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.4;
       thin/line-width: 1.4;
-      thin/line-dasharray: 27,2,6,2;
+      thin/line-dasharray: 27,1.5,6,1.5;
     }
     [zoom >= 13] {
       background/line-width: 1.6;
@@ -111,7 +111,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.8;
       thin/line-width: 1.8;
-      thin/line-dasharray: 36,3,9,3;
+      thin/line-dasharray: 36,2,8,2;
     }
   }
 
@@ -196,7 +196,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.2;
       thin/line-width: 1.2;
-      thin/line-dasharray: 16,3,2,3;
+      thin/line-dasharray: 17,3,2,3;
     }
     [zoom >= 13] {
       background/line-width: 1.4;
@@ -205,7 +205,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 15] {
       background/line-width: 1.6;
       thin/line-width: 1.6;
-      thin/line-dasharray: 22,4,3,4;
+      thin/line-dasharray: 23,4,3,4;
     }
   }
 
@@ -327,17 +327,17 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.6;
-    line-dasharray: 4,2;
+    line-dasharray: 4,0.6,2,0.6;
     line-clip: false;
     [zoom >= 9] {
       background/line-width: 0.8;
       line-width: 0.8;
-      line-dasharray: 6,3;
+      line-dasharray: 6,1,3,1;
     }
     [zoom >= 10] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 10,2,2,2;
+      line-dasharray: 10,1.5,4.5,1.5;
     }
     [zoom >= 11] {
       background/line-width: 1.4;
@@ -346,91 +346,91 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     [zoom >= 12] {
       background/line-width: 1.6;
       line-width: 1.6;
-      line-dasharray: 16,2,2,2;
+      line-dasharray: 16,2,6,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.8;
-      line-width: 1.8;
+      background/line-width: 1.9;
+      line-width: 1.9;
     }
     [zoom >= 15] {
-      background/line-width: 2;
-      line-width: 2;
-      line-dasharray: 20,2,3,2;
+      background/line-width: 2.2;
+      line-width: 2.2;
+      line-dasharray: 20,2,8,2;
     }
   }
   [admin_level = '6'][zoom >= 10]::firstline {
     background/line-join: bevel;
     background/line-color: white;
-    background/line-width: 1;
+    background/line-width: 0.9;
     line-join: bevel;
     line-color: @admin-boundaries;
-    line-width: 1;
-    line-dasharray: 8,2,2,2,2,2;
+    line-width: 0.9;
+    line-dasharray: 8,1.5,1.5,1.5;
     line-clip: false;
     [zoom >= 11] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1.1;
+      line-width: 1.1;
     }
     [zoom >= 12] {
-      background/line-width: 1.4;
-      line-width: 1.4;
-    line-dasharray: 12,2,2,2,2,2;
+      background/line-width: 1.3;
+      line-width: 1.3;
+    line-dasharray: 12,1.5,2,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 1.6;
-      line-width: 1.6;
+      background/line-width: 1.5;
+      line-width: 1.5;
     }
     [zoom >= 15] {
       background/line-width: 1.8;
       line-width: 1.8;
-      line-dasharray: 16,2,3,2,3,2;
+      line-dasharray: 16,2,3,2;
     }
   }
   [admin_level = '7']::firstline {
     [zoom >= 11] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1;
+      background/line-width: 0.8;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1;
-      line-dasharray: 6,2,2,2,2,2,2,2;
+      line-width: 0.8;
+      line-dasharray: 6,1.5,1.5,1.5,1.5,1.5;
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-      line-dasharray: 8,2,2,2,2,2,2,2;
+      background/line-width: 1;
+      line-width: 1;
+      line-dasharray: 9,2,2,2,2,2;
     }
     [zoom >= 13] {
-      background/line-width: 1.4;
-      line-width: 1.4;
+      background/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 15] {
-      background/line-width: 1.6;
-      line-width: 1.6;
-      line-dasharray: 12,2,2,2,3,2,2,2;
+      background/line-width: 1.5;
+      line-width: 1.5;
+      line-dasharray: 12,2,3,2,3,2;
     }
   }
   [admin_level = '8']::firstline {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-color: white;
-      background/line-width: 1;
+      background/line-width: 0.8;
       line-join: bevel;
       line-color: @admin-boundaries;
-      line-width: 1;
-      line-dasharray: 6,2,2,2,3,2,3,2,2,2;
+      line-width: 0.8;
+      line-dasharray: 6,1.5,1.5,1.5,2,1.5,1.5,1.5;
       line-clip: false;
     }
     [zoom >= 13] {
-      background/line-width: 1.2;
-      line-width: 1.2;
+      background/line-width: 1;
+      line-width: 1;
     }
     [zoom >= 15] {
-      background/line-width: 1.4;
-      line-width: 1.4;
-      line-dasharray: 10,2,2,2,3,2,3,2,2,2;
+      background/line-width: 1.2;
+      line-width: 1.2;
+      line-dasharray: 8,2,2,2,3,2,2,2;
     }
   }
 
@@ -441,12 +441,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1;
-    line-dasharray: 0,3,2,2,2,2,2,2,2,3;
+    line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1.2;
       line-width: 1.2;
-      line-dasharray: 0,4,3,2,2,3,2,2,3,4;
+      line-dasharray: 0,4,2,2,3,2,2,4;
     }
   }
   [admin_level = '10'][zoom >= 14]::firstline {
@@ -456,12 +456,12 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.8;
-    line-dasharray: 0,4,3,2,3,2,3,4;
+    line-dasharray: 0,4,2,2,2,4;
     line-clip: false;
     [zoom >= 15] {
       background/line-width: 1;
       line-width: 1;
-      line-dasharray: 0,6,3,3,2,3,3,6;
+      line-dasharray: 0,5,3,3,3,5;
     }
   }
 }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -466,13 +466,10 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   }
 }
 
-#admin-text[zoom >= 11][way_pixels >= 48000] {
+#admin-text[zoom >= 11][way_pixels >= 196000] {
   [admin_level = '1'][way_pixels >= 360000],
   [admin_level = '2'][way_pixels >= 360000],
-  [admin_level = '3'][way_pixels >= 196000],
-  [admin_level = '4'][way_pixels >= 196000],
-  [admin_level = '5'][way_pixels >= 196000],
-  [zoom >= 12][admin_level = '6'][way_pixels >= 196000],
+  [zoom >= 12][admin_level = '6'],
   [zoom >= 13][admin_level = '7'],
   [zoom >= 14][admin_level = '8'],
   [zoom >= 15][admin_level = '9'],

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -45,20 +45,28 @@
 #state-names {
   [zoom >= 5][zoom < 7][way_pixels > 3000],
   [zoom >= 7][way_pixels > 3000][way_pixels < 196000] {
-    text-name: "[name]";
-    text-size: 10;
-    text-wrap-width: 30; // 3.0 em
-    text-line-spacing: -1.5; // -0.15 em
-    text-margin: 7.0; // 0.7 em
-    text-fill: @state-labels;
-    text-face-name: @oblique-fonts;
-    text-halo-fill: @standard-halo-fill;
-    text-halo-radius: @standard-halo-radius * 1.5;
-    [zoom >= 7] {
-      text-size: 11;
-      text-wrap-width: 50; // 4.5 em
-      text-line-spacing: -0.6; // -0.05 em
-      text-margin: 7.7; // 0.7 em
+    [admin_level = '4'][zoom >= 5],
+    [admin_level = '5'][zoom >= 8],
+    [admin_level = '6'][zoom >= 10] {
+      text-name: "[name]";
+      text-size: 10;
+      text-wrap-width: 30; // 3.0 em
+      text-line-spacing: -1.5; // -0.15 em
+      text-margin: 7.0; // 0.7 em
+      text-fill: @state-labels;
+      text-face-name: @oblique-fonts;
+      text-halo-fill: @standard-halo-fill;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      [admin_level = '4'][zoom >= 7],
+      [admin_level = '5'][zoom >= 10] {
+        text-size: 11;
+        text-wrap-width: 50; // 4.5 em
+        text-line-spacing: -0.6; // -0.05 em
+        text-margin: 7.7; // 0.7 em
+        [zoom >= 10] {
+          text-size: 12;
+        }
+      }
     }
   }
 }
@@ -258,6 +266,30 @@
     }
   }
 }
+
+#county-names {
+  [zoom >= 8][way_pixels > 3000][way_pixels < 196000] {
+    [admin_level = '5'][zoom >= 8],
+    [admin_level = '6'][zoom >= 10] {
+      text-name: "[name]";
+      text-size: 10;
+      text-wrap-width: 30; // 3.0 em
+      text-line-spacing: -1.5; // -0.15 em
+      text-margin: 7.0; // 0.7 em
+      text-fill: @state-labels;
+      text-face-name: @oblique-fonts;
+      text-halo-fill: @standard-halo-fill;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      [admin_level = '5'][zoom >= 10] {
+        text-size: 11;
+        text-wrap-width: 50; // 4.5 em
+        text-line-spacing: -0.6; // -0.05 em
+        text-margin: 7.7; // 0.7 em
+      }
+    }
+  }
+}
+
 
 #placenames-medium::low-importance {
   [category = 2] {

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,8 +1,8 @@
 @placenames: #222;
 @placenames-light: #777777;
-@country-labels: (darken(@admin-boundaries, 15%);
-@state-labels: desaturate(darken(@admin-boundaries, 5%), 5%);
-@county-labels: @admin-boundaries;
+@country-labels: darken(@admin-boundaries, 15%);
+@state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
+@county-labels: desaturate(@admin-boundaries, 20%);
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,7 +1,7 @@
 @placenames: #222;
 @placenames-light: #777777;
-@country-labels: saturate(darken(@admin-boundaries, 15%), 5%);
-@state-labels: darken(@admin-boundaries, 5%);
+@country-labels: (darken(@admin-boundaries, 15%);
+@state-labels: desaturate(darken(@admin-boundaries, 5%), 5%);
 @county-labels: @admin-boundaries;
 
 #country-names {

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,7 +1,7 @@
 @placenames: #222;
 @placenames-light: #777777;
 @country-labels: darken(@admin-boundaries-narrow, 10%);
-@state-labels: desaturate(@admin-boundaries-narrow, 5%), 15%);
+@state-labels: desaturate(@admin-boundaries-narrow, 10%);
 @county-labels: @admin-boundaries-wide;
 
 #country-names {

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -2,7 +2,7 @@
 @placenames-light: #777777;
 @country-labels: darken(@admin-boundaries, 15%);
 @state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
-@county-labels: desaturate(@admin-boundaries, 20%);
+@county-labels: desaturate(@admin-boundaries, 25%);
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],
@@ -20,7 +20,7 @@
     }
     [zoom >= 5] {
       text-size: 12;
-      text-wrap-width: 45; // 3.8 em
+      text-wrap-width: 45; // 3.7 em
       text-line-spacing: -1.2; // -0.10 em
       text-margin: 8.4; // 0.7 em
     }
@@ -30,10 +30,15 @@
       text-line-spacing: -1.0; // -0.08 em
       text-margin: 9.1; // 0.7 em
     }
-    [zoom >= 10] {
+    [zoom >= 9] {
       text-size: 14;
       text-wrap-width: 55; // 3.9 em
       text-line-spacing: -0.7; // -0.05 em
+    }
+    [zoom >= 10] {
+      text-size: 15;
+      text-wrap-width: 60; // 4.0 em
+      text-line-spacing: -0.4; // -0.02 em
     }
     text-fill: @country-labels;
     text-face-name: @book-fonts;
@@ -46,28 +51,39 @@
 #state-names {
   [zoom >= 5][zoom < 7][way_pixels > 3000],
   [zoom >= 7][way_pixels > 3000][way_pixels < 196000] {
-    [admin_level = '4'][zoom >= 5],
-    [admin_level = '5'][zoom >= 8],
-    [admin_level = '6'][zoom >= 10] {
-      text-name: "[name]";
-      text-size: 10;
-      text-wrap-width: 30; // 3.0 em
-      text-line-spacing: -1.5; // -0.15 em
-      text-margin: 7.0; // 0.7 em
-      text-fill: @state-labels;
-      text-face-name: @oblique-fonts;
-      text-halo-fill: @standard-halo-fill;
-      text-halo-radius: @standard-halo-radius * 1.5;
-      [admin_level = '4'][zoom >= 7],
-      [admin_level = '5'][zoom >= 10] {
-        text-size: 11;
-        text-wrap-width: 50; // 4.5 em
-        text-line-spacing: -0.6; // -0.05 em
-        text-margin: 7.7; // 0.7 em
-        [zoom >= 10] {
-          text-size: 12;
-        }
-      }
+    text-name: "[name]";
+    text-size: 10;
+    text-wrap-width: 35; // 3.5 em
+    text-line-spacing: -1.5; // -0.15 em
+    text-margin: 7.0; // 0.7 em
+    text-fill: @state-labels;
+    text-face-name: @oblique-fonts;
+    text-halo-fill: @standard-halo-fill;
+    text-halo-radius: @standard-halo-radius * 1.5;
+    text-placement: interior;
+    [zoom >= 7] {
+      text-size: 11;
+      text-wrap-width: 40; // 3.6 em
+      text-line-spacing: -1.4; // -0.13 em
+      text-margin: 7.7; // 0.7 em
+    }
+    [zoom >= 9] {
+      text-size: 12;
+      text-wrap-width: 45; // 3.7 em
+      text-line-spacing: -1.2; // -0.10 em
+      text-margin: 8.4; // 0.7 em
+    }
+    [zoom >= 10] {
+      text-size: 13;
+      text-wrap-width: 50; // 3.8 em
+      text-line-spacing: -1.0; // -0.08 em
+      text-margin: 9.1; // 0.7 em
+    }
+    [zoom >= 12] {
+      text-size: 15;
+      text-wrap-width: 50; // 3.8 em
+      text-line-spacing: -1.0; // -0.08 em
+      text-margin: 9.1; // 0.7 em
     }
   }
 }
@@ -315,10 +331,31 @@
       text-face-name: @oblique-fonts;
       text-halo-fill: @standard-halo-fill;
       text-halo-radius: @standard-halo-radius * 1.5;
-      [admin_level = '5'][zoom >= 10] {
-        text-size: 11;
-        text-wrap-width: 50; // 4.5 em
-        text-line-spacing: -0.6; // -0.05 em
+      [admin_level = '5'] {
+        text-face-name: @book-fonts;
+        [zoom >= 9] {
+          text-size: 11;
+          text-wrap-width: 40; // 3.6 em
+          text-line-spacing: -1.4; // -0.13 em
+          text-margin: 7.7; // 0.7 em
+        }
+        [zoom >= 10] {
+          text-size: 12;
+          text-wrap-width: 45; // 3.7 em
+          text-line-spacing: -1.2; // -0.10 em
+          text-margin: 8.4; // 0.7 em
+        }
+        [zoom >= 12] {
+          text-size: 14;
+          text-wrap-width: 40; // 3.6 em
+          text-line-spacing: -1.4; // -0.13 em
+          text-margin: 7.7; // 0.7 em
+        }
+      }
+      [admin_level = '6'][zoom >= 12] {
+        text-size: 12;
+        text-wrap-width: 40; // 3.6 em
+        text-line-spacing: -1.4; // -0.13 em
         text-margin: 7.7; // 0.7 em
       }
     }

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,8 +1,8 @@
 @placenames: #222;
 @placenames-light: #777777;
 @country-labels: darken(@admin-boundaries-narrow, 10%);
-@state-labels: desaturate(@admin-boundaries-narrow, 10%);
-@county-labels: @admin-boundaries-wide;
+@state-labels: desaturate(@admin-boundaries-narrow, 5%);
+@county-labels: darken(@admin-boundaries-wide, 5%);
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],
@@ -318,50 +318,6 @@
   }
 }
 
-#county-names {
-  [zoom >= 8][way_pixels > 3000][way_pixels < 196000] {
-    [admin_level = '5'][zoom >= 8],
-    [admin_level = '6'][zoom >= 10] {
-      text-name: "[name]";
-      text-size: 10;
-      text-wrap-width: 30; // 3.0 em
-      text-line-spacing: -1.5; // -0.15 em
-      text-margin: 7.0; // 0.7 em
-      text-fill: @county-labels;
-      text-face-name: @oblique-fonts;
-      text-halo-fill: @standard-halo-fill;
-      text-halo-radius: @standard-halo-radius * 1.5;
-      [admin_level = '5'] {
-        text-face-name: @book-fonts;
-        [zoom >= 9] {
-          text-size: 11;
-          text-wrap-width: 40; // 3.6 em
-          text-line-spacing: -1.4; // -0.13 em
-          text-margin: 7.7; // 0.7 em
-        }
-        [zoom >= 10] {
-          text-size: 12;
-          text-wrap-width: 45; // 3.7 em
-          text-line-spacing: -1.2; // -0.10 em
-          text-margin: 8.4; // 0.7 em
-        }
-        [zoom >= 12] {
-          text-size: 14;
-          text-wrap-width: 40; // 3.6 em
-          text-line-spacing: -1.4; // -0.13 em
-          text-margin: 7.7; // 0.7 em
-        }
-      }
-      [admin_level = '6'][zoom >= 12] {
-        text-size: 12;
-        text-wrap-width: 40; // 3.6 em
-        text-line-spacing: -1.4; // -0.13 em
-        text-margin: 7.7; // 0.7 em
-      }
-    }
-  }
-}
-
 #placenames-small::suburb {
   [place = 'suburb'][zoom >= 12][zoom < 17] {
     text-name: "[name]";
@@ -530,6 +486,46 @@
       text-face-name: @book-fonts;
       text-wrap-width: 30; // 2.7 em
       text-line-spacing: -1.7; // -0.15 em
+    }
+  }
+}
+
+#county-names {
+  [zoom >= 8][way_pixels > 12000][way_pixels < 196000] {
+    [admin_level = '5'][zoom >= 8],
+    [admin_level = '6'][zoom >= 10] {
+      text-name: "[name]";
+      text-size: 10;
+      text-wrap-width: 30; // 3.0 em
+      text-line-spacing: -1.5; // -0.15 em
+      text-margin: 7.0; // 0.7 em
+      text-fill: @county-labels;
+      text-face-name: @oblique-fonts;
+      text-halo-fill: @standard-halo-fill;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      text-placement-type: simple;
+      text-placements: "S,SE,SW,E,NE,W,NW,N";
+      [admin_level = '5'] {
+        text-face-name: @book-fonts;
+        [zoom >= 10] {
+          text-size: 12;
+          text-wrap-width: 45; // 3.7 em
+          text-line-spacing: -1.2; // -0.10 em
+          text-margin: 8.4; // 0.7 em
+        }
+        [zoom >= 12] {
+          text-size: 13;
+          text-wrap-width: 50; // 3.8 em
+          text-line-spacing: -1.0; // -0.08 em
+          text-margin: 9.1; // 0.7 em
+        }
+      }
+      [admin_level = '6'][zoom >= 12] {
+        text-size: 11;
+        text-wrap-width: 40; // 3.6 em
+        text-line-spacing: -1.4; // -0.13 em
+        text-margin: 7.7; // 0.7 em
+      }
     }
   }
 }

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -2,6 +2,7 @@
 @placenames-light: #777777;
 @country-labels: darken(@admin-boundaries, 15%);
 @state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
+@county-labels: desaturate(@admin-boundaries, 25%);
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],
@@ -267,30 +268,6 @@
   }
 }
 
-#county-names {
-  [zoom >= 8][way_pixels > 3000][way_pixels < 196000] {
-    [admin_level = '5'][zoom >= 8],
-    [admin_level = '6'][zoom >= 10] {
-      text-name: "[name]";
-      text-size: 10;
-      text-wrap-width: 30; // 3.0 em
-      text-line-spacing: -1.5; // -0.15 em
-      text-margin: 7.0; // 0.7 em
-      text-fill: @state-labels;
-      text-face-name: @oblique-fonts;
-      text-halo-fill: @standard-halo-fill;
-      text-halo-radius: @standard-halo-radius * 1.5;
-      [admin_level = '5'][zoom >= 10] {
-        text-size: 11;
-        text-wrap-width: 50; // 4.5 em
-        text-line-spacing: -0.6; // -0.05 em
-        text-margin: 7.7; // 0.7 em
-      }
-    }
-  }
-}
-
-
 #placenames-medium::low-importance {
   [category = 2] {
     [zoom >= 9][zoom < 16] {
@@ -320,6 +297,29 @@
         text-wrap-width: 75; // 5.0 em
         text-line-spacing: -0.75; // -0.05 em
         text-margin: 10.5; // 0.7 em
+      }
+    }
+  }
+}
+
+#county-names {
+  [zoom >= 8][way_pixels > 3000][way_pixels < 196000] {
+    [admin_level = '5'][zoom >= 8],
+    [admin_level = '6'][zoom >= 10] {
+      text-name: "[name]";
+      text-size: 10;
+      text-wrap-width: 30; // 3.0 em
+      text-line-spacing: -1.5; // -0.15 em
+      text-margin: 7.0; // 0.7 em
+      text-fill: @county-labels;
+      text-face-name: @oblique-fonts;
+      text-halo-fill: @standard-halo-fill;
+      text-halo-radius: @standard-halo-radius * 1.5;
+      [admin_level = '5'][zoom >= 10] {
+        text-size: 11;
+        text-wrap-width: 50; // 4.5 em
+        text-line-spacing: -0.6; // -0.05 em
+        text-margin: 7.7; // 0.7 em
       }
     }
   }

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,8 +1,8 @@
 @placenames: #222;
 @placenames-light: #777777;
-@country-labels: darken(@admin-boundaries, 15%);
-@state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
-@county-labels: desaturate(@admin-boundaries, 25%);
+@country-labels: darken(@admin-boundaries-narrow, 10%);
+@state-labels: desaturate(@admin-boundaries-narrow, 5%), 15%);
+@county-labels: @admin-boundaries-wide;
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],

--- a/style/placenames.mss
+++ b/style/placenames.mss
@@ -1,8 +1,8 @@
 @placenames: #222;
 @placenames-light: #777777;
-@country-labels: darken(@admin-boundaries, 15%);
-@state-labels: desaturate(darken(@admin-boundaries, 5%), 20%);
-@county-labels: desaturate(@admin-boundaries, 25%);
+@country-labels: saturate(darken(@admin-boundaries, 15%), 5%);
+@state-labels: darken(@admin-boundaries, 5%);
+@county-labels: @admin-boundaries;
 
 #country-names {
   [zoom >= 3][zoom < 5][way_pixels > 1000],


### PR DESCRIPTION
### Fixes:
**Part of #4004 potentially**
**Fixes #310**
**Fixes #3698**
**Partially addresses #3678**
**Partially addresses #4016**

## Changes proposed in this pull request:
- Change line rendering for admin boundaries: thinner and more consistent steps in most cases
- Adds central dark line for admin_level=2,3,4 at mid and high zoom levels
- Use lower opacity for the admin_level=2,3,4 wide line, but high opacity for thinner, minor boundaries
- Render admin_level=5 from z8 (3 zoom levels sooner) - makes it possible to add central label
- Render admin_level=6 from z10 (1 zoom level sooner) - possible to add central text label
- Render admin_level=7 from z11 (1 zoom level sooner)
- Render admin_level=10 from z14 (1 zoom level later)
- Change admin boundaries color to be less saturated - final color selection is still a work in progress, and could be continued in another PR if needed.
- Remove line-simplification for admin-boundaries lines

### Discussion

The administrative boundaries are challenging, because we should try to distinguish 9 different levels. While admin_level=2 is clearly more significant, and admin_level=3/4 are also different enough from the others to deserve a special rendering, the remaining levels are quite similar, from a global perspective, but each level should be distinguished. Since there are 6 levels, this is quite challenging.

Currently admin_level=5 and 6 have only a slightly different pattern, while admin_level=7/8 are identical, as are admin_levels=9/10, so there are only 7 different patterns in the current style.

In this PR, admin_level=2 has been changed to have a more gradual progression of widths. At z10 and above (where more features began to be rendered), it is wide enough that I've introduced a centerline with long dashes and short dots. This helps make it clear where the geometry is precisely, and makes it harder to confuse these boundaries with roads or other features. 

A similar style is used for admin_level=3 from z10 and for admin_level=4 from z12: a dashed wide line with lower opacity and also a dashed and dotted inner line, with higher opacity (and slightly darker). This requires using separate `::narrowline` and `::wideline` attachments. Admin_level=2 has 2 dots but is continuous, admin_level=3 has one dot and long dashes, and admin_level=4 has no dots, but shorter dashes.

At low zoom levels, I've extended the dashes for admin_level=4 back to z5, so that it's possible to distinguish admin_level=3 and 4 - currently the subtle difference in width alone is not very clear. This also makes the admin_level=4 rendering more consistent. I would also consider showing the dashes at z4, but this needs testing. 

These use a separate attachment `::firstline` so they will render behind the more important boundaries, and so they can have a higher opacity tha the wideline but lower opacity than the narrowline. When using `comp-op: darken` (which we use along with a white background line, so that the different patterns will not overlap), it's not possible to adjust the opacity of each line or feature separately, as far as I can tell, so I've done it in each attachment.

I've used a progressive pattern for levels 5 to 8: each is slightly thinner, and has more dots (up to 4) but shorter lines between. This worked out quite well. However, it cannot be extended to admin_level=9 and 10, since 5 dots or more are too hard to count without thinking about it.

Instead, admin_level=9 and 10 have dropped the dash, using a longer gap instead. The are also much thinner than before. 

At levels 7 to 10 the 3 and 4 dot patterns have a subtle difference, where two dots are longer and 1 or 2 are shorter - this helps make it easier to distinguish the 3 and 4 dot varients.

These changes make it feasible to render admin_level=5 from z8 and admin_level=6 from z10, while admin_level=7 is also rendered one zoom level sooner. In contrast, admin_level=10 is moved one later to z14. This will fix issues #310 and #3698

Currently this PR includes rendering a central text label for the names of admin_level=5 and =6, as requested in issue #4004 - but this needs further testing for level 6 especially, since often these are municipalities with the same name as the central `place=town` or `place=city`. It may be best to remove this change from the PR, and then add it in a separate PR, but I wanted to include it for testing.

I've tested these changes with several different colors of admin-boundaries, but this PR does not include changes to the color, this that would distract from the other changes. However, I will show some examples in the comments, rendered with less saturated purple or less saturated green, to show that these line signatures will work with other colors.

# Test renderings

### Examples with test data, compared to different landcovers and lines (Railways, paths, etc)

**Before z15**
![z15-borders-master-test](https://user-images.githubusercontent.com/42757252/78127964-11057f00-7450-11ea-9952-95a24d289f45.png)

After z15
![z15-borders-test](https://user-images.githubusercontent.com/42757252/78128230-8bce9a00-7450-11ea-970d-6cc61976e52e.png)

** Before z13**
![z13-border-master-test](https://user-images.githubusercontent.com/42757252/78127968-1367d900-7450-11ea-9be6-333e1fd395a9.png)

After z13
![z13-borders-test](https://user-images.githubusercontent.com/42757252/78128267-925d1180-7450-11ea-8ade-df3b2dcc6c70.png)

** Before z12**
![z12-borders-master-test](https://user-images.githubusercontent.com/42757252/78127976-16fb6000-7450-11ea-9dae-840492ab42ca.png)

After z12
![z12-test-borders](https://user-images.githubusercontent.com/42757252/78128312-a30d8780-7450-11ea-9d09-af157bfd4c9f.png)

** Before z10**
![z10-borders-master-test](https://user-images.githubusercontent.com/42757252/78127983-195dba00-7450-11ea-9ab5-a53f3cbfc1dd.png)

After z10
![z10-borderst-test](https://user-images.githubusercontent.com/42757252/78128297-9db03d00-7450-11ea-8724-210a8d57bdb1.png)

** Before z8**
![z8-borders-master-test](https://user-images.githubusercontent.com/42757252/78128000-2084c800-7450-11ea-8ca2-8ab66c430ee8.png)

After z8
![z8-borders-test](https://user-images.githubusercontent.com/42757252/78128338-adc81c80-7450-11ea-9db2-96ba5051b19d.png)

### Luxembourg
- Shows admin_level=2, 6, 8 and 9
**Before z16**
![master-borders-luxembourg-z16](https://user-images.githubusercontent.com/42757252/78128520-0a2b3c00-7451-11ea-933a-64ca7a1ff699.png)

After z16
![z16-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78128893-a6554300-7451-11ea-85af-b494d48b38ec.png)

** Before z14**
![master-borders-luxembourg-z14](https://user-images.githubusercontent.com/42757252/78128546-157e6780-7451-11ea-84dd-5450c43ad341.png)

After z14
![z14-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78128871-9c334480-7451-11ea-9bd6-f9e32d35fcf7.png)

** Before z12**
![master-borders-luxembourg-z12](https://user-images.githubusercontent.com/42757252/78128704-51b1c800-7451-11ea-9323-cb890dc16c06.png)

After z12
![z12-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78128856-950c3680-7451-11ea-86df-d010ecc2cbb2.png)

** Before z11**
![master-borders-luxembourg-z11](https://user-images.githubusercontent.com/42757252/78128721-5a0a0300-7451-11ea-80ce-348b1d6b839e.png)

After z11
![z11-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78128770-6c843c80-7451-11ea-8993-67b69cba9579.png)

** Before z10 **
![master-borders-luxembourg-z10](https://user-images.githubusercontent.com/42757252/78128835-89207480-7451-11ea-985a-921ab5f4b560.png)

After z10
![z10-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78129038-e4eafd80-7451-11ea-9833-282b9cce1fdd.png)

** Before z9**
![master-borders-luxembourg-z9](https://user-images.githubusercontent.com/42757252/78128728-5c6c5d00-7451-11ea-9b84-af059f861904.png)

After z9
![z9-luxembourg-borders-after](https://user-images.githubusercontent.com/42757252/78128758-6726f200-7451-11ea-8c09-dbc93baf1eb9.png)