### PR TITLE
Move aerialways and amenity-line layers text labels to text-line layer

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1970,7 +1970,7 @@ Layer:
                  OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
               OR tags @> 'attraction=>water_slide'
               OR aerialway IN ('cable_car', 'gondola', 'mixed_lift', 'goods', 'chair_lift', 'drag_lift', 't-bar', 'j-bar', 'platter', 'rope_tow', 'zip_line')
-              OR leisure = 'track'
+              OR leisure IN ('slipway', 'track')
               OR waterway IN ('dam', 'weir')
               OR "natural" IN ('arete', 'cliff', 'ridge'))
             AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -1956,7 +1956,7 @@ Layer:
         (SELECT
           way,
             NULL as way_pixels,
-            COALESCE('aerialway_' || aerialway, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural") AS feature,
+            COALESCE('aerialway_' || aerialway, 'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END, 'leisure_' || leisure, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural") AS feature,
             access,
             name,
             tags->'operator' as operator,
@@ -1968,7 +1968,9 @@ Layer:
               OR (man_made = 'pipeline'
                  AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
                  OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+              OR tags @> 'attraction=>water_slide'
               OR aerialway IN ('cable_car', 'gondola', 'mixed_lift', 'goods', 'chair_lift', 'drag_lift', 't-bar', 'j-bar', 'platter', 'rope_tow', 'zip_line')
+              OR leisure = 'track'
               OR waterway IN ('dam', 'weir')
               OR "natural" IN ('arete', 'cliff', 'ridge'))
             AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -812,8 +812,7 @@ Layer:
             way,
             aerialway,
             man_made,
-            tags->'substance' AS substance,
-            name
+            tags->'substance' AS substance
           FROM planet_osm_line
           WHERE aerialway IS NOT NULL
             OR (man_made = 'pipeline'
@@ -1957,7 +1956,7 @@ Layer:
         (SELECT
           way,
             NULL as way_pixels,
-            COALESCE('man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural") AS feature,
+            COALESCE('aerialway_' || aerialway, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural") AS feature,
             access,
             name,
             tags->'operator' as operator,
@@ -1966,6 +1965,10 @@ Layer:
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
           FROM planet_osm_line
           WHERE (man_made IN ('pier', 'breakwater', 'groyne', 'embankment')
+              OR (man_made = 'pipeline'
+                 AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
+                 OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+              OR aerialway IN ('cable_car', 'gondola', 'mixed_lift', 'goods', 'chair_lift', 'drag_lift', 't-bar', 'j-bar', 'platter', 'rope_tow', 'zip_line')
               OR waterway IN ('dam', 'weir')
               OR "natural" IN ('arete', 'cliff', 'ridge'))
             AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -1611,8 +1611,6 @@ Layer:
       table: |-
         (SELECT
           way,
-          name,
-          layer,
           COALESCE(
            'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' END,
            'leisure_' || CASE WHEN leisure IN ('slipway', 'track') THEN leisure END,

--- a/style/aerialways.mss
+++ b/style/aerialways.mss
@@ -14,24 +14,6 @@
       dash/line-color: black;
       dash/line-dasharray: 0.4,13;
       dash/line-clip: false;
-      [zoom >= 17] {
-        text-name: "[name]";
-        text-fill: #666666;
-        text-size: 10;
-        text-dy: 4;
-        text-spacing: 900;
-        text-clip: false;
-        text-placement: line;
-        text-repeat-distance: 200;
-        text-margin: 18;
-        text-face-name: @book-fonts;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-      }
-      [zoom >= 19] {
-        text-size: 11;
-        text-dy: 5;
-      }
     }
   }
 
@@ -47,24 +29,6 @@
       dash/line-color: #707070;
       dash/line-dasharray: 6,25;
       dash/line-clip: false;
-      [zoom >= 17] {
-        text-name: "[name]";
-        text-fill: #666666;
-        text-size: 10;
-        text-dy: 4;
-        text-spacing: 900;
-        text-clip: false;
-        text-placement: line;
-        text-repeat-distance: 200;
-        text-margin: 18;
-        text-face-name: @book-fonts;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-      }
-      [zoom >= 19] {
-        text-size: 11;
-        text-dy: 5;
-      }
     }
   }
 
@@ -86,24 +50,6 @@
       dash/line-color: black;
       dash/line-dasharray: 1,30;
       dash/line-clip: false;
-      [zoom >= 17] {
-        text-name: "[name]";
-        text-fill: #666666;
-        text-size: 10;
-        text-dy: 4;
-        text-spacing: 900;
-        text-clip: false;
-        text-placement: line;
-        text-repeat-distance: 200;
-        text-margin: 18;
-        text-face-name: @book-fonts;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-      }
-      [zoom >= 19] {
-        text-size: 11;
-        text-dy: 5;
-      }
     }
   }
 
@@ -141,21 +87,8 @@
         [substance = 'water'] { center/line-color: @water-color; }
         [substance = 'gas'] { center/line-color: #c1c1c1; } // Lch(78,0,0)
         [substance = 'oil'] { center/line-color: #cfbfa5; } // Lch(78,15,83)
-        text-name: "[name]";
-        text-fill: #666666;
-        text-size: 10;
-        text-dy: 6;
-        text-spacing: 900;
-        text-clip: false;
-        text-placement: line;
-        text-repeat-distance: 200;
-        text-margin: 18;
-        text-face-name: @book-fonts;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
       }
       [zoom >= 18] {
-        text-dy: 7;
         line/line-width: 3;
         line/line-dasharray: 0,1,30,1;
         dash/line-width: 5;
@@ -164,14 +97,51 @@
         center/line-dasharray: 0,2,28,2;
       }
       [zoom >= 19] {
-        text-size: 11;
-        text-dy: 8;
         line/line-width: 4;
         line/line-dasharray: 0,1,36,1;
         dash/line-width: 6;
         dash/line-dasharray: 0,1,1,34,1,1;
         center/line-width: 3;
         center/line-dasharray: 0,2,34,2;
+      }
+    }
+  }
+}
+
+#text-line {
+  [feature = 'aerialway_cable_car'],
+  [feature = 'aerialway_gondola'],
+  [feature = 'aerialway_mixed_lift'],
+  [feature = 'aerialway_goods'],
+  [feature = 'aerialway_chair_lift'],
+  [feature = 'aerialway_drag_lift'],
+  [feature = 'aerialway_t-bar'],
+  [feature = 'aerialway_j-bar'],
+  [feature = 'aerialway_platter'],
+  [feature = 'aerialway_rope_tow'],
+  [feature = 'aerialway_zip_line'],
+  [feature = 'man_made_pipeline'] {
+    [zoom >= 17] {
+      text-name: "[name]";
+      text-fill: #666666;
+      text-size: 10;
+      text-dy: 4;
+      text-spacing: 900;
+      text-clip: false;
+      text-placement: line;
+      text-repeat-distance: 200;
+      text-margin: 18;
+      text-face-name: @book-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      [zoom >= 19] {
+        text-size: 11;
+        text-dy: 5;
+      }
+      [feature = 'man_made_pipeline'] {
+        text-dy: 6;
+        [zoom >= 18] { text-dy: 7; }
+        [zoom >= 19] { text-dy: 8; }
       }
     }
   }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2982,19 +2982,6 @@
       line-width: 1;
       [zoom >= 18] { line-width: 2; }
       [zoom >= 19] { line-width: 4; }
-
-      [zoom >= 19] {
-        text-name: "[name]";
-        text-size: 10;
-        text-face-name: @oblique-fonts;
-        text-fill: darken(@pitch, 40%);
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-        text-placement: line;
-        text-vertical-alignment: middle;
-        text-repeat-distance: @waterway-text-repeat-distance;
-        text-dy: 8;
-      }
     }
   }
 
@@ -3013,19 +3000,24 @@
       line-width: 1;
       [zoom >= 18] { line-width: 2; }
       [zoom >= 19] { line-width: 4; }
+    }
+  }
+}
 
-      [zoom >= 19] {
-        text-name: "[name]";
-        text-size: 10;
-        text-face-name: @oblique-fonts;
-        text-fill: darken(@pitch, 40%);
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-        text-placement: line;
-        text-vertical-alignment: middle;
-        text-repeat-distance: @waterway-text-repeat-distance;
-        text-dy: 8;
-      }
+#text-line {
+  [feature = 'leisure_track'],
+  [feature = 'attraction_water_slide'] {
+    [zoom >= 19] {
+      text-name: "[name]";
+      text-size: 10;
+      text-face-name: @oblique-fonts;
+      text-fill: darken(@pitch, 40%);
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-placement: line;
+      text-vertical-alignment: middle;
+      text-repeat-distance: @waterway-text-repeat-distance;
+      text-dy: 8;
     }
   }
 }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -3020,6 +3020,18 @@
       text-dy: 8;
     }
   }
+
+  [feature = 'leisure_slipway'][zoom >= 17] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: @transportation-text;
+    text-dy: 13;
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+  }
 }
 
 #trees [zoom >= 16] {


### PR DESCRIPTION
Fixes #4105 and part of #4104

### Changes proposed in this pull request:
- Move `aerialways`layer text labels to `text-line` layer
- Move leisure=track and attraction=water_slide name labels from `amenity-line` to `text-line`
- Add leisure=slipway name label on lines in `text-line`

Currently the `aerialway` and `man_made=pipeline` features in the `aerialways` layer have their name label text rendered in the same layer. This means that another pipeline, or aerialway, or a road bridge can render on top of the text, and the text is rendered at higher priority. 

The same problem occurs for `leisure=track` and `attraction=water_slide` features, which are rendered in the `amenity=line` layer as lines, along with their name labels. 

Also, I noticed that `leisure=slipway` only has a label when mapped as a node, not when mapped as a line, though we render the icon the same in both cases. 

This PR will fix these problems by rendering these features in the appropriate layer, `text-line`, which comes after road names and before text-point.

The layer amenity-line included `layer` and `name` columns in the sql select, but these are unused and have been removed.

### Test rendering:

Before
![pipeline-text-layer-before](https://user-images.githubusercontent.com/42757252/78329405-94dc7a00-75bc-11ea-8e8e-743573aa902a.png)

After
![pipeline-text-layer-after](https://user-images.githubusercontent.com/42757252/78329406-960da700-75bc-11ea-8748-084e7345319d.png)