### PR TITLE
Remove rendering of protect_class = 7, 24, 97, 98, 99 boundary=protected_area features

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1118,7 +1118,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
         ) AS protected_areas
@@ -1465,7 +1465,7 @@ Layer:
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway END,
                 'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                          OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
+                                          OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
@@ -1922,9 +1922,8 @@ Layer:
               'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
                                                     'water', 'bay', 'strait') THEN "natural" END,
               'place_' || CASE WHEN place IN ('island') THEN place END,
-              'boundary_' || CASE WHEN (boundary = 'protected_area' AND tags->'protect_class' = '24') THEN 'aboriginal_lands'
-                                  WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','97','98','99'))
+              'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
+                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                        THEN boundary END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END
             ) AS feature,
@@ -1937,7 +1936,7 @@ Layer:
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
               OR "place" IN ('island')
               OR boundary IN ('aboriginal_lands', 'national_park')
-              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
+              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
               OR leisure IN ('nature_reserve'))
             AND building IS NULL
             AND name IS NOT NULL
@@ -2125,7 +2124,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
             AND name IS NOT NULL
         ) AS protected_areas_text
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1443,7 +1443,7 @@ Layer:
                 'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
-                                                    'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
+                                                    'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
                                                     'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure END,
                 'power_' || CASE WHEN power IN ('plant', 'generator', 'substation') THEN power END,
                 'man_made_' || CASE WHEN (man_made IN ('chimney', 'communications_tower', 'crane', 'lighthouse', 'mast', 'obelisk', 'silo', 'storage_tank',
@@ -1467,6 +1467,7 @@ Layer:
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
                                           OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
+                'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
                 'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier END,

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -256,8 +256,7 @@ overlapping borders correctly.
       opacity: 0.25;
       line-width: 1.2;
       line-color: @protected-area;
-      [boundary='aboriginal_lands'],
-      [boundary='protected_area'][protect_class='24'] {
+      [boundary = 'aboriginal_lands'] {
         line-color: @aboriginal;
       }
       [zoom >= 9] {
@@ -277,8 +276,7 @@ overlapping borders correctly.
         // line-offset is always an offset to the inner side of the polygon.
         line-offset: -0.9;
         line-color: @protected-area;
-        [boundary='aboriginal_lands'],
-        [boundary='protected_area'][protect_class='24'] {
+        [boundary = 'aboriginal_lands'] {
           line-color: @aboriginal;
         }
         line-join: round;
@@ -297,8 +295,7 @@ overlapping borders correctly.
         opacity: 0.15;
         line-width: 1.8;
         line-color: @protected-area;
-        [boundary='aboriginal_lands'],
-        [boundary='protected_area'][protect_class='24'] {
+        [boundary = 'aboriginal_lands'] {
           line-color: @aboriginal;
         }
         line-join: round;


### PR DESCRIPTION
Needed prior to #3656

### Changes proposed in this pull request:
- Stop rendering boundary=protected_area with protect_class = 7,  protect_class = 24, and  protect_class = 97, 98, or 99
- Move leisure=nature_reserve selection after boundary=aboriginal_lands in `amenity-points`, to match `text-point-low-zoom` layer. 

### Explanation
- The tag `boundary=protected_area` is mostly tagged with protect_class = 1a, 1b, 2, 3, 4, 5, 6 which match the IUCN categories for "Strict Nature Reserve (IUCN Category 1a)", "Wilderness" (IUCN 1b), "National Park" (2), "Natural Monument or Natural Feature" (3), " " (4), "Protected Landscape or Seascape" (5), "Area with sustainable use of natural resources (6). 
- Sometimes these IUCN categories, from the Internation Union of Conservation Naturalists, are used with boundary=national_park or leisure=nature_reserve as well
- The proposal for boundary=protected_area also created new values of protect_class which do not match any IUCN category. The tag `protect_class=7` was for local areas which do not have an IUCN level, and 97 to 99 were for international areas. However, these tags are not well defined, and the IUCN categories actually include international parks, so these values seem to break the system.
- There is also protect_class=24 for "political protection" which has been used mainly for Indigenous Lands in Brazil and some other countries. However, the approved tag boundary=aboriginal_lands is more common and more clearly defined.
- I also noticed that boundary=aboriginal_lands is selected prior to leisure=nature_reserve in text-poly-low-zoom but afterwards in amenity-points (used for text-point), so the color of labels for areas double-tagged as aboriginal_lands + nature_reserve will change between z9 and z11. This should be fixed to keep the aboriginal_lands color at all zoom levels, since the leisure=nature_reserve tag was often added for rendering in the past.

Also see discussion in https://github.com/gravitystorm/openstreetmap-carto/issues/3656#issuecomment-609041048 and https://github.com/gravitystorm/openstreetmap-carto/issues/3656#issuecomment-609373726

See https://wiki.openstreetmap.org/wiki/Proposal:_Named_protection_class_for_protected_areas

Additional changes to the protected areas rendering should be made, but this PR is a pre-requisites to designing a sensible system to fix #3656, since protect_class 7, 97, 98, and 99 don't fit into a logical structure. 

It was also considered to remove rendering of protect_class=5 or 6, since these areas have limited protection, but in some countries National Parks are these classes and would still be rendered if tagged boundary=national_park, so they are kept for now.

There was also discussion about removing protect_class=2 since this is the usually category for boundary=national_park, but again, some protect_class=2 features are called "National Monuments" or "State Parks" or "Provincial Parks" etc, and some "National Park" (or related term) features do not have the same level of protection.