### PR TITLE
Restore admin-text rendering for admin_level 3 to 5

### DIFF
--- a/style/admin.mss
+++ b/style/admin.mss
@@ -448,6 +448,9 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
 #admin-text[zoom >= 11][way_pixels >= 196000] {
   [admin_level = '1'][way_pixels >= 360000],
   [admin_level = '2'][way_pixels >= 360000],
+  [zoom >= 11][admin_level = '3'],
+  [zoom >= 11][admin_level = '4'],
+  [zoom >= 11][admin_level = '5'],
   [zoom >= 12][admin_level = '6'],
   [zoom >= 13][admin_level = '7'],
   [zoom >= 14][admin_level = '8'],


### PR DESCRIPTION
Fixes a mistake in PR #4100
Changes proposed in this pull request:
- Add back admin_level=3, =4, =5 admin-text rendering along border lines from z11

The rendering of `admin-text` labels for these zoom levels was accidentally removed in PR#4100

Test rendering with links to the example places:
- Boundary of admin_level=3 and admin_level=4 areas in Papua New Guinea
- https://www.openstreetmap.org/#map=11/-4.9966/143.9676

Before
![admin-text-fix-before](https://user-images.githubusercontent.com/42757252/80287213-15d2f100-86e5-11ea-80df-e84a595cf3bd.png)

After
![admin-text-fix-after](https://user-images.githubusercontent.com/42757252/80287207-0e134c80-86e5-11ea-9b91-60d4d6a03cc9.png)
