### PR TITLE
Change protected-area line rendering style, width, color and opacity, text initial zoom

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1472,7 +1472,7 @@ Layer:
                 'shop' || CASE WHEN shop IN ('yes', 'no', 'vacant', 'closed', 'disused', 'empty') OR shop IS NULL THEN NULL ELSE '' END,
                 'leisure_' || CASE WHEN leisure IN ('amusement_arcade', 'beach_resort', 'bird_hide', 'bowling_alley', 'dog_park', 'firepit', 'fishing',
                                                     'fitness_centre', 'fitness_station', 'garden', 'golf_course', 'ice_rink', 'marina', 'miniature_golf',
-                                                    'nature_reserve', 'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
+                                                    'outdoor_seating', 'park', 'picnic_table', 'pitch', 'playground', 'recreation_ground',
                                                     'sauna', 'slipway', 'sports_centre', 'stadium', 'swimming_area', 'swimming_pool', 'track', 'water_park') THEN leisure END,
                 'power_' || CASE WHEN power IN ('plant', 'generator', 'substation') THEN power END,
                 'man_made_' || CASE WHEN (man_made IN ('chimney', 'communications_tower', 'crane', 'lighthouse', 'mast', 'obelisk', 'silo', 'storage_tank',
@@ -1496,6 +1496,7 @@ Layer:
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
                                           OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
+                'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
                 'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier END,

--- a/project.mml
+++ b/project.mml
@@ -1121,7 +1121,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
         ) AS protected_areas
@@ -1494,7 +1494,7 @@ Layer:
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway END,
                 'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                          OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
+                                          OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
                 'tourism_' || CASE WHEN tourism IN ('information') THEN tourism END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
@@ -1951,9 +1951,8 @@ Layer:
               'natural_' || CASE WHEN "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock',
                                                     'water', 'bay', 'strait') THEN "natural" END,
               'place_' || CASE WHEN place IN ('island') THEN place END,
-              'boundary_' || CASE WHEN (boundary = 'protected_area' AND tags->'protect_class' = '24') THEN 'aboriginal_lands'
-                                  WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','97','98','99'))
+              'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
+                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                        THEN boundary END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END
             ) AS feature,
@@ -1966,7 +1965,7 @@ Layer:
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
               OR "place" IN ('island')
               OR boundary IN ('aboriginal_lands', 'national_park')
-              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99'))
+              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
               OR leisure IN ('nature_reserve'))
             AND building IS NULL
             AND name IS NOT NULL
@@ -2155,7 +2154,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
             AND name IS NOT NULL
         ) AS protected_areas_text
     properties:

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -492,60 +492,91 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   text-dy: -10;
 }
 
+@protected-area-width-z8: 0.8;
+@protected-area-width-z9: 1;
+@protected-area-width-z10: 1.4;
+@protected-area-width-z11: 2.2;
+@protected-area-width-z12: 3.2;
+@protected-area-width-z14: 4;
+@protected-area-width-z16: 5;
+@protected-area-thin-width-z11: 0.8; // 2/5 of full width
+@protected-area-thin-width-z12: 1.2; // 2/5
+@protected-area-thin-width-z14: 1.4; // 2/5
+@protected-area-thin-width-z16: 1.8; // 2/5
+
 #protected-areas {
-  [way_pixels > 750] {
-    [zoom >= 8][zoom < 10] {
-      opacity: 0.25;
-      line-width: 1.2;
+  ::lowzoom {
+    [zoom >= 8][zoom < 10][way_pixels > 3000],
+    [zoom >= 10][zoom < 11][way_pixels > 750] {
       line-color: @protected-area;
-      [boundary = 'aboriginal_lands'] {
-        line-color: @aboriginal;
+      line-width: @protected-area-width-z8;
+      [zoom >= 9] { line-width: @protected-area-width-z9; }
+      [zoom >= 10] { line-width: @protected-area-width-z10; }
+      [boundary='aboriginal_lands'] { line-color: @aboriginal; }
+    }
+  }
+
+  ::wideline { // inner wide line
+    [zoom >= 11][way_pixels > 750] {
+      line-color: @protected-area;
+      line-join: round;
+      line-width: @protected-area-width-z11;
+      line-offset: (@protected-area-thin-width-z11/2 - @protected-area-width-z11/2);
+      [boundary='aboriginal_lands'] { line-color: @aboriginal; }
+      [zoom >= 12] {
+        line-width: @protected-area-width-z12;
+        line-offset: (@protected-area-thin-width-z12/2 - @protected-area-width-z12/2);
       }
-      [zoom >= 9] {
-        line-width: 1.5;
+      [zoom >= 14] {
+        line-width: @protected-area-width-z14;
+        line-offset: (@protected-area-thin-width-z14/2 - @protected-area-width-z14/2);
+      }
+      [zoom >= 16] {
+        line-width: @protected-area-width-z16;
+        line-offset: (@protected-area-thin-width-z16/2 - @protected-area-width-z16/2);
       }
     }
-    [zoom >= 10] {
-      // inner line
-      ::wideline {
-        opacity: 0.15;
-        line-width: 3.6;
-        // Unlike planet_osm_line, planet_osm_polygon does not preserves the
-        // original direction of the OSM way: Following OGS at
-        // https://www.opengeospatial.org/standards/sfa always at the left
-        // is the interior and at the right the exterior of the polygon.(This
-        // also applies to inner rings of multipolygons.) So a negative
-        // line-offset is always an offset to the inner side of the polygon.
-        line-offset: -0.9;
-        line-color: @protected-area;
-        [boundary = 'aboriginal_lands'] {
-          line-color: @aboriginal;
-        }
-        line-join: round;
-        line-cap: round;
-        [zoom >= 12] {
-          line-width: 4;
-          line-offset: -1;
-        }
-        [zoom >= 14] {
-          line-width: 6;
-          line-offset: -2;
-        }
+  }
+
+  ::narrowline { // outer thin line
+    [zoom >= 11][way_pixels > 750] {
+      background/line-color: white;
+      background/line-join: round;
+      background/line-width: @protected-area-thin-width-z11;
+      line-color: @protected-area;
+      line-join: round;
+      line-width: @protected-area-thin-width-z11;
+      line-dasharray: 3,0.5;
+      [boundary='aboriginal_lands'] { line-color: @aboriginal; }
+      [zoom >= 12] {
+        background/line-width: @protected-area-thin-width-z12;
+        line-width: @protected-area-thin-width-z12;
       }
-      // outer line
-      ::narrowline {
-        opacity: 0.15;
-        line-width: 1.8;
-        line-color: @protected-area;
-        [boundary = 'aboriginal_lands'] {
-          line-color: @aboriginal;
-        }
-        line-join: round;
-        line-cap: round;
-        [zoom >= 12] {
-            line-width: 2;
-        }
+      [zoom >= 14] {
+        background/line-width: @protected-area-thin-width-z14;
+        line-width: @protected-area-thin-width-z14;
+      }
+      [zoom >= 16] {
+        background/line-width: @protected-area-thin-width-z16;
+        line-width: @protected-area-thin-width-z16;
       }
     }
+  }
+  ::lowzoom { opacity: 0.4 }
+  ::wideline { opacity: 0.3 }
+  ::narrowline {
+    opacity: 0.4;
+    /*
+    The following code prevents protected area boundaries from being rendered on top of
+    each other. Comp-op works on the entire attachment, not on the individual
+    border. Therefore, this code generates an attachment containing a set of
+    colored dashed lines and white lines (of which only the top one is visible),
+    and with `comp-op: darken` the white part is ignored, while the
+    @admin-boundaries colored part is rendered (as long as the background is not
+    darker than @protected_area color).
+    The SQL has `ORDER BY admin_level`, so the boundary with the lowest
+    admin_level is rendered on top, and therefore the only visible boundary.
+    */
+    comp-op: darken;
   }
 }

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -496,8 +496,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       opacity: 0.25;
       line-width: 1.2;
       line-color: @protected-area;
-      [boundary='aboriginal_lands'],
-      [boundary='protected_area'][protect_class='24'] {
+      [boundary = 'aboriginal_lands'] {
         line-color: @aboriginal;
       }
       [zoom >= 9] {
@@ -517,8 +516,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
         // line-offset is always an offset to the inner side of the polygon.
         line-offset: -0.9;
         line-color: @protected-area;
-        [boundary='aboriginal_lands'],
-        [boundary='protected_area'][protect_class='24'] {
+        [boundary = 'aboriginal_lands'] {
           line-color: @aboriginal;
         }
         line-join: round;
@@ -537,8 +535,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
         opacity: 0.15;
         line-width: 1.8;
         line-color: @protected-area;
-        [boundary='aboriginal_lands'],
-        [boundary='protected_area'][protect_class='24'] {
+        [boundary = 'aboriginal_lands'] {
           line-color: @aboriginal;
         }
         line-join: round;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -476,10 +476,9 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
 #protected-areas-text[zoom >= 13][way_pixels > 192000] {
   text-name: "[name]";
   text-face-name: @book-fonts;
-  text-fill: @protected-area;
-  [boundary='aboriginal_lands'],
-  [boundary='protected_area'][protect_class='24'] {
-    text-fill: @aboriginal;
+  text-fill: darken(@protected-area, 3%);
+  [boundary='aboriginal_lands'] {
+    text-fill: darken(@aboriginal, 3%);
   }
   text-halo-radius: @standard-halo-radius;
   text-halo-fill: @standard-halo-fill;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -2,6 +2,9 @@
 @admin-boundaries-narrow: #845283; // Lch(42,35,327)
 @admin-boundaries-wide: #a37da1; // Lch(57,25,327)
 
+@protected-area: #65870f; // Lch(52,60,118)
+@aboriginal: #a76f56; // Lch(52,30,50)
+
 /* For performance reasons, the admin border layers are split into three groups
 for low, middle and high zoom levels.
 Three attachments are used, with minor borders before major ones, and the thin centerline last, to handle

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2027,11 +2027,7 @@
 
   [feature = 'landuse_military'],
   [feature = 'natural_wood'],
-  [feature = 'landuse_forest'],
-  [feature = 'boundary_national_park'],
-  [feature = 'leisure_nature_reserve'],
-  [feature = 'boundary_aboriginal_lands'],
-  [feature = 'boundary_protected_area'] {
+  [feature = 'landuse_forest'] {
     [zoom >= 8][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17] {
       text-name: "[name]";
@@ -2054,17 +2050,40 @@
       [feature = 'landuse_military'] {
         text-fill: darken(@military, 40%);
       }
-      [feature = 'boundary_aboriginal_lands'] {
-        text-fill: @aboriginal;
-      }
       [feature = 'natural_wood'],
       [feature = 'landuse_forest'] {
         text-fill: @forest-text;
       }
-      [feature = 'boundary_national_park'],
-      [feature = 'leisure_nature_reserve'],
-      [feature = 'boundary_protected_area'] {
-        text-fill: @protected-area;
+    }
+  }
+
+  [feature = 'boundary_aboriginal_lands'],
+  [feature = 'boundary_national_park'],
+  [feature = 'leisure_nature_reserve'],
+  [feature = 'boundary_protected_area'] {
+    [zoom >= 8][way_pixels > 12000][is_building = 'no']
+    [zoom >= 10][way_pixels > 3000][is_building = 'no'],
+    [zoom >= 17][way_pixels > 750] {
+      text-name: "[name]";
+      text-size: @landcover-font-size;
+      text-wrap-width: @landcover-wrap-width-size;
+      text-line-spacing: @landcover-line-spacing-size;
+      [way_pixels > 12000] {
+        text-size: @landcover-font-size-big;
+        text-wrap-width: @landcover-wrap-width-size-big;
+        text-line-spacing: @landcover-line-spacing-size-big;
+      }
+      [way_pixels > 48000] {
+        text-size: @landcover-font-size-bigger;
+        text-wrap-width: @landcover-wrap-width-size-bigger;
+        text-line-spacing: @landcover-line-spacing-size-bigger;
+      }
+      text-face-name: @landcover-face-name;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-fill: darken(@protected-area, 3%);
+      [feature = 'boundary_aboriginal_lands'] {
+        text-fill: darken(@aboriginal, 3%);
       }
     }
   }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2062,7 +2062,7 @@
   [feature = 'leisure_nature_reserve'],
   [feature = 'boundary_protected_area'] {
     [zoom >= 8][way_pixels > 12000][is_building = 'no']
-    [zoom >= 10][way_pixels > 3000][is_building = 'no'],
+    [zoom >= 9][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17][way_pixels > 750] {
       text-name: "[name]";
       text-size: @landcover-font-size;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -20,8 +20,6 @@
 @barrier-icon: #3f3f3f;
 @landform-color: #d08f55;
 @leisure-green: darken(@park, 60%);
-@protected-area: #008000;
-@aboriginal: #82643a;
 @religious-icon: #000000;
 
 @landcover-font-size: 10;


### PR DESCRIPTION
Follow-up of ideas in #3844
Requires #4113 to be merged first

## Changes proposed in this pull request:
- Increase opacity of protected-area lines
- Change `@protected-area` to`#65870f` - Lch(52,60,118) -  less saturated, yellow-green hue
- Change `@aboriginal` to `#a76f56` - Lch(52,30,50) - redder, less saturated
- Thinner outer line, with dash-array added, but higher opacity
- Change initial zoom level way_pixels requirement for protected area text lables to 12,000 way_pixels at z8 (still 3000 way_pixels at z9 and above as before)
- Slightly darken protected-areas-text along boundaries

### Explanation:
- These changes reduce the amount of opacity used for protected_area, national_park, nature_reserve and aboriginal_lands area boundary lines.
- This results in more consistent rendering over different types of backgrounds
- To prevent the new rendering from being too strong, the colors are adjusted to be less saturated
- The color hues are also shifted towards red, away from pure green and blue, so that there is more contrast with forests. This also makes it feasible to use green for admin-boundaries later
- The text is adjusted for the new colors
- The central text label is no longer shown for smaller features at z8, only when way_pixels are greater than 12000 - this shows many few labels at this zoom level.
- These changes will also make it possible to distinguish different types of protected area via protect_class or the main feature tag, in a future PR, by varying the dasharry pattern and line width. 

## Test renderings with links to the example places:

### Romania
https://www.openstreetmap.org/#map=8/45.066/24.472

**z8 Before**
![protected-area-before-8:45 066:24 472](https://user-images.githubusercontent.com/42757252/80289238-44a39400-86f2-11ea-9b95-025a5cca343c.png)

After
![protected-area-after-8:45 066:24 472](https://user-images.githubusercontent.com/42757252/80289245-4cfbcf00-86f2-11ea-9b82-790a9f17fc89.png)

**z9 Before**
https://www.openstreetmap.org/#map=9/47.6950/24.7879
![protected-area-before-romania-z9](https://user-images.githubusercontent.com/42757252/80289233-3b1a2c00-86f2-11ea-8c34-566ad86849e6.png)

After
![protected-area-after-romania-z9](https://user-images.githubusercontent.com/42757252/80289257-58e79100-86f2-11ea-8b5b-86464af82315.png)

**z10 Before**
![protected-area-before-romania-z10](https://user-images.githubusercontent.com/42757252/80289355-c3003600-86f2-11ea-8aeb-e87806102c4b.png)

After
![protected-area-after-romania-z10](https://user-images.githubusercontent.com/42757252/80289361-cdbacb00-86f2-11ea-8729-36bdf3a68b14.png)

**z11 Before**
![protected-area-before-romania-z11](https://user-images.githubusercontent.com/42757252/80289365-d0b5bb80-86f2-11ea-9ccb-2b2f2448ea46.png)

After
![protected-area-after-romania-z11](https://user-images.githubusercontent.com/42757252/80289368-d4e1d900-86f2-11ea-94c3-0766ca2c1748.png)

**z12Before**
![protected-area-before-romania-z12](https://user-images.githubusercontent.com/42757252/80289371-d90df680-86f2-11ea-88c2-ccc339f4a222.png)

After
![protected-area-after-romania-z12](https://user-images.githubusercontent.com/42757252/80289378-dd3a1400-86f2-11ea-972a-666aed64dd83.png)

**z13 Before**
![protected-area-before-romania-z13](https://user-images.githubusercontent.com/42757252/80289382-df03d780-86f2-11ea-8327-1b92c71ccebc.png)

After
![protected-area-after-romania-z13](https://user-images.githubusercontent.com/42757252/80289387-e3c88b80-86f2-11ea-9716-4b72bd16beb8.png)

**z14 Before**
![protected-area-before-romania-z14](https://user-images.githubusercontent.com/42757252/80289394-eb883000-86f2-11ea-984e-47dac0af4227.png)

After
![protected-area-after-romania-z14](https://user-images.githubusercontent.com/42757252/80289395-ee832080-86f2-11ea-97ef-5cdebc1b12b6.png)

**z16 Before**
https://www.openstreetmap.org/#map=16/47.8449/24.2806
![protected-area-before-16:47 8449:24 2806](https://user-images.githubusercontent.com/42757252/80289400-ff339680-86f2-11ea-94ae-f7288c579435.png)

After
![protected-area-after-16:47 8449:24 2806](https://user-images.githubusercontent.com/42757252/80289402-02c71d80-86f3-11ea-9fd6-0ebdae44c865.png)