### PR TITLE
get-external-data.py: store downloaded archives for further use

### DIFF
--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -12,7 +12,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     osm2pgsql gdal-bin python3-psycopg2 python3-yaml \
-    python3-requests python3-requests-file postgresql-client && rm -rf /var/lib/apt/lists/*
+    python3-requests postgresql-client && rm -rf /var/lib/apt/lists/*
 
 ADD openstreetmap-carto.style /
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,7 +102,7 @@ To display any map a database containing OpenStreetMap data and some utilities a
 * [PostgreSQL](https://www.postgresql.org/)
 * [PostGIS](https://postgis.net/)
 * [osm2pgsql](https://github.com/openstreetmap/osm2pgsql#installing) to [import your data](https://switch2osm.org/serving-tiles/updating-as-people-edit/) into a PostGIS database
-* Python 3 with the psycopg2, yaml, and requests libraries (`python3-psycopg2`, `python3-yaml`, `python3-requests`, `python3-requests-file` packages on Debian-derived systems)
+* Python 3 with the psycopg2, yaml, and requests libraries (`python3-psycopg2`, `python3-yaml`, `python3-requests` packages on Debian-derived systems)
 * `ogr2ogr` for loading shapefiles into the database (`gdal-bin` on Debian-derived systems)
 
 ### Optional development dependencies

--- a/scripts/get-external-data.py
+++ b/scripts/get-external-data.py
@@ -290,6 +290,7 @@ def main():
                         logging.critical("Command line was {}".format(
                             subprocess.list2cmdline(e.cmd)))
                         logging.critical("Output was\n{}".format(e.output))
+                        logging.critical("Error was\n{}".format(e.stderr))
                         raise RuntimeError(
                             "ogr2ogr error when loading table {}".format(name))
 


### PR DESCRIPTION
This allows to recreate the database objects without the need
to redownload all the (not so small) files.

Additionally it outputs stderr of `ogr2ogr` on error (which was collected but not displayed).

Motivation:
I got hit by https://github.com/OSGeo/gdal/issues/1692 and every time I re-ran the get-external-data.py script it tried to download ~600 MB of data (water-polygons-split-3857.zip).