### PR TITLE
Solve overlapping of amenity=prison over natural features

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -92,7 +92,7 @@ Layer:
               way, COALESCE(name, '') AS name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway END)) AS aeroway,
               ('amenity_' || (CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
-                                                    'hospital', 'kindergarten', 'grave_yard', 'prison', 'place_of_worship', 'clinic', 'ferry_terminal',
+                                                    'hospital', 'kindergarten', 'grave_yard', 'place_of_worship', 'clinic', 'ferry_terminal',
                                                     'marketplace', 'community_centre', 'social_facility', 'arts_centre', 'parking_space', 'bus_station',
                                                     'fire_station', 'police')
                               OR amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity END)) AS amenity,
@@ -120,7 +120,7 @@ Layer:
               OR leisure IS NOT NULL
               OR aeroway IN ('apron', 'aerodrome')
               OR amenity IN ('parking', 'bicycle_parking', 'motorcycle_parking', 'taxi', 'university', 'college', 'school', 'hospital', 'kindergarten',
-                             'grave_yard', 'place_of_worship', 'prison', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
+                             'grave_yard', 'place_of_worship', 'clinic', 'ferry_terminal', 'marketplace', 'community_centre', 'social_facility',
                              'arts_centre', 'parking_space', 'bus_station', 'fire_station', 'police')
               OR man_made IN ('works', 'wastewater_plant','water_works')
               OR "natural" IN ('beach', 'shoal', 'heath', 'mud', 'wetland', 'grassland', 'wood', 'sand', 'scree', 'shingle', 'bare_rock', 'scrub')

--- a/project.mml
+++ b/project.mml
@@ -531,10 +531,14 @@ Layer:
             way,
             landuse,
             military,
+            amenity,
+            "natural",
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE (landuse = 'military'
             OR military = 'danger_area')
+            OR ("natural" = 'scrub'
+            OR amenity = 'prison')
             AND building IS NULL
         ) AS landuse_overlay
     properties:

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -214,14 +214,6 @@
     }
   }
 
-  [feature = 'amenity_prison'][zoom >= 10][way_pixels > 75] {
-    polygon-pattern-file: url('symbols/grey_vertical_hatch.png');
-    polygon-pattern-alignment: global;
-    line-color: #888;
-    line-width: 3;
-    line-opacity: 0.329;
-  }
-
   [feature = 'landuse_residential'][zoom >= 8] {
     polygon-fill: @built-up-lowzoom;
     [zoom >= 12] { polygon-fill: @built-up-z12; }

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -821,6 +821,19 @@
       line-offset: -1.0;
     }
   }
+  [natural = 'scrub'][zoom >= 8][way_pixels > 900],
+  [natural = 'scrub'][zoom >= 13],
+  [amenity = 'prison'][zoom >= 10] {
+    [zoom >= 15] {
+      [amenity = 'prison'][zoom >= 10][way_pixels > 75] {
+        polygon-pattern-file: url('symbols/grey_vertical_hatch.png');
+        polygon-pattern-alignment: global;
+        line-color: #888;
+        line-width: 3;
+        line-opacity: 0.329;
+      }
+    }
+  }
 }
 
 #cliffs {


### PR DESCRIPTION
Fixes #3841

Changes proposed in this pull request:
- correct rendering of amenity=prison over natural elements

Test rendering with links to the example places:

Before
![immagine](https://user-images.githubusercontent.com/29042221/86470589-0357e200-bd3c-11ea-8ae1-9ff4a2b6535f.png)

After
![solved_issue](https://user-images.githubusercontent.com/29042221/86470648-1ff41a00-bd3c-11ea-8567-8b89bbcd2f67.png)

The original data that cause the problem have been delated, the test could be done with these data. 
[prison.zip](https://github.com/gravitystorm/openstreetmap-carto/files/4869761/prison.zip)

