### PR TITLE
Travis: Build with NodeJS 10 & 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 sudo: false
 node_js:
   - "10"
+  - "14"
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 dist: bionic
 sudo: false
 node_js:
-  - "10"
   - "14"
 services:
   - postgresql


### PR DESCRIPTION
At the moment there is only version 10 which has been released back in 2018. This project should also be able to build with a modern version of NodeJS.

Changes proposed in this pull request:
- Build against NodeJS 14 as well as NodeJS 10

Older versions can be removed in the future.
