### PR TITLE
Switch to un-blessed (but still valid) osmdata

### DIFF
--- a/external-data.yml
+++ b/external-data.yml
@@ -9,7 +9,7 @@ sources:
     # The type of file this source is
     type: shp
     # Where to get it
-    url: https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip
+    url: https://osmdata.openstreetmap.de/new/simplified-water-polygons-split-3857.zip
     # The location within the archive
     file: simplified-water-polygons-split-3857/simplified_water_polygons.shp
     archive:
@@ -23,7 +23,7 @@ sources:
         - simplified-water-polygons-split-3857/simplified_water_polygons.shx
   water_polygons:
     type: shp
-    url: https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip
+    url: https://osmdata.openstreetmap.de/new/water-polygons-split-3857.zip
     file: water-polygons-split-3857/water_polygons.shp
     archive:
       format: zip


### PR DESCRIPTION
Due to a complicated and unfortunate mess, the blessed/marked good versions of the osmdata.openstreetmap.de output files have not been updated since Jan 9, 2020; and even though the original cause is (more or less) resolved, there have been enough changes in the past six months that the automatic script that blesses new versions still rejects them.

Happily, the un-blessed (but still valid, non-flooding-the-world) versions are still made available, just under slightly different URLs.

This is the minimal change needed to use those un-blessed files.

It is theoretically possible that joto, the maintainer of the osmdata box, may do a manual override (and I've requested that here: fossgis/osmdata#12 ) -- but as an alternative, and in the meantime, this enables the coastline data to be updated.

I previously proposed this by mistake in https://github.com/openstreetmap/chef/pull/326 ; TomH was kind enough to point me over here as the relevant place to ask the actual decision makers.