### PR TITLE
fix python script not running

### DIFF
--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -52,7 +52,7 @@ EOF
   $OSM2PGSQL_DATAFILE
 
   # Downloading needed shapefiles
-  scripts/get-external-data.py
+  python3 scripts/get-external-data.py
   ;;
 
 kosmtik)


### PR DESCRIPTION
The Python script that downloads the shapefiles needs to be run with python3

Please let me know if I did this correctly, this is my first pull request. I'm interested in contributing here, this line in docker-startup.sh was preventing the import from completing successfully.