### PR TITLE
Don't render boardwalk as bridge at z14 and z15

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -915,6 +915,7 @@ Layer:
             horse,
             foot,
             bicycle,
+            bridge,
             tracktype,
             int_surface,
             access,
@@ -929,6 +930,7 @@ Layer:
                 horse,
                 foot,
                 bicycle,
+                bridge,
                 tracktype,
                 CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
                                       'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
@@ -962,6 +964,7 @@ Layer:
                 horse,
                 foot,
                 bicycle,
+                bridge,
                 tracktype,
                 'null',
                 CASE

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -681,8 +681,9 @@
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
-        [zoom >= 15] {
+        [zoom >= 14][access != 'no'][bridge != 'boardwalk'],
+        [zoom >= 15][bridge != 'boardwalk'],
+        [zoom >= 16] {
           line-width: @footway-width-z14 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -886,8 +887,9 @@
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
-        [zoom >= 15] {
+        [zoom >= 14][access != 'no'][bridge != 'boardwalk'],
+        [zoom >= 15][bridge != 'boardwalk'],
+        [zoom >= 16] {
           line-width: @footway-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * @paths-background-width; }
           [zoom >= 16] { line-width: @footway-width-z16 + 2 * @paths-background-width; }
@@ -1850,7 +1852,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
       [zoom >= 14][access != 'no'],
       [zoom >= 15] {
-        #roads-fill[zoom >= 15] {
+        #roads-fill[zoom >= 15],
+        #bridges[zoom >= 14][zoom <= 15][bridge = 'boardwalk'] {
           background/line-color: @footway-casing;
           background/line-cap: round;
           background/line-join: round;


### PR DESCRIPTION
Changes proposed in this pull request:
- Don't render boardwalk as bridge at z14 and z15.

Currently a path with the tags `bridge=boardwalk` and `highway=path` stands out almost as prominently as secondary roads at zoom 14. At zoom 15 it still catches my eye a bit more than a tertiary road. This seems inappropriate for a footway.

I propose to render it as a `highway=path` at zoom 14 and 15, and as before like a bridge at zoom 16 and up.

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=14/52.0113/4.6852

Before
![oud](https://user-images.githubusercontent.com/6255050/92961028-e1cb5300-f46e-11ea-9f97-28fc7d7596d6.jpg)

After
![nieuw](https://user-images.githubusercontent.com/6255050/92961041-e4c64380-f46e-11ea-98f0-43f74bb8a921.jpg)