### PR TITLE
Render landuse=flowerbed

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -167,6 +167,20 @@
     }
   }
 
+  [feature = 'landuse_flowerbed'] {
+    [zoom >= 11] {
+      polygon-fill: @orchard;
+      [way_pixels >= 4]  { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.3;  }
+    }
+    [zoom >= 13] {
+      polygon-pattern-file: url('symbols/orchard.png');
+      polygon-pattern-alignment: global;
+      [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
+    }
+  }
+
   [feature = 'landuse_plant_nursery'] {
     [zoom >= 10] {
       polygon-fill: @orchard;


### PR DESCRIPTION
landuse=flowerbed is a gap in the rendering of urban vegetation. 13k occurrences according to Taginfo. I propose using the same rendering as landuse=orchard, as orchard and flowerbed are unlikely to be adjacent. I propose starting at zoom 11 because leisure=garden starts at zoom 10 and flowerbeds are smaller detail.