### PR TITLE
Update DB dockerfile to use the postgis image

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM postgis/postgis:10-3.1-alpine
+FROM postgis/postgis:10-2.5-alpine
 
 COPY ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d/tune-postgis.sh

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM mdillon/postgis:10
+FROM postgis/postgis:10-3.1-alpine
 
-ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d
+COPY ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d/tune-postgis.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
       - PG_WORK_MEM
       - PG_MAINTENANCE_WORK_MEM
   import:

--- a/scripts/tune-postgis.sh
+++ b/scripts/tune-postgis.sh
@@ -3,5 +3,5 @@
 set -e
 export PGUSER="$POSTGRES_USER"
 
-"${psql[@]}" -c "ALTER SYSTEM SET work_mem='${PG_WORK_MEM:-16MB}';"
-"${psql[@]}" -c "ALTER SYSTEM SET maintenance_work_mem='${PG_MAINTENANCE_WORK_MEM:-256MB}';"
+psql -c "ALTER SYSTEM SET work_mem='${PG_WORK_MEM:-16MB}';"
+psql -c "ALTER SYSTEM SET maintenance_work_mem='${PG_MAINTENANCE_WORK_MEM:-256MB}';"


### PR DESCRIPTION
For local development, the Dockerfiles are used to set up a development environment. 

The database is created with the Dockerfile.db image, which is based on the image `mdillon/postgis` (https://hub.docker.com/r/mdillon/postgis/). This base image has not been updated for 2 years. Moreover, the Dockerhub link links to the official PostGIS image `postgis/postgis` (https://github.com/postgis/docker-postgis).

This PR updates the base image for the Dockerfile.db. The official image of PostgreSQL 10 with PostGIS 2.5 is used. The alpine version is used which results in a smaller image to download.

Using this base image will allow updating to more modern Postgres versions as well (see the full list in https://registry.hub.docker.com/r/postgis/postgis/tags).  In the future, newer PostgreSQL and PostGIS versions can be used. The upgrade is out of scope of this PR.

Finally, the Docker `COPY` command is used instead of the `ADD` command. The `ADD` command can also untar files, or fetch remote URLs which introduces complexity.

Tested by running the database, importing a dataset and viewing it in the Kosmtik previewer.