### PR TITLE
Render vaccination_centres.

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1535,6 +1535,7 @@ Layer:
                                         AND way_area IS NULL
                                    THEN amenity END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism END,
+                'healthcare_' || CASE WHEN tags->'healthcare' in ('vaccination_centre') then tags->'healthcare' END,
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place END
               ) AS feature,
               access,

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -593,6 +593,13 @@
     marker-clip: false;
   }
 
+  [feature = 'healthcare_vaccination_centre'][zoom >= 15] {
+    marker-file: url('symbols/amenity/hospital.svg');
+    marker-width: 10;
+    marker-fill: @health-color;
+    marker-clip: false;
+  }
+
   [feature = 'amenity_pharmacy'][zoom >= 17] {
     marker-file: url('symbols/amenity/pharmacy.svg');
     marker-fill: @health-color;


### PR DESCRIPTION
Fixes #4295.

Changes proposed in this pull request:
- add `healtcare=vaccination_centre`

Test rendering with links to the example places:

https://www.openstreetmap.org/#map=15/51.5566/-0.2794

Before
![Screenshot_20210127_153709](https://user-images.githubusercontent.com/167327/106006483-903a0280-60b5-11eb-8905-f35855196976.png)

After:
![Screenshot_20210127_153623](https://user-images.githubusercontent.com/167327/106006394-7698bb00-60b5-11eb-935f-86382cd57c77.png)

The `vaccination_centre` is just north of the Wembley Stadium.