### PR TITLE
De-emphasize parking=street_side

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1446,10 +1446,14 @@
   [feature = 'amenity_bicycle_parking'],
   [feature = 'amenity_motorcycle_parking'],
   [feature = 'amenity_parking_entrance'] {
-    [zoom >= 14][way_pixels > 750],
-    [zoom >= 17][feature = 'amenity_parking'],
+    [zoom >= 14][way_pixels > 750]["parking" != 'street_side']["parking" != 'lane'],
+    [zoom >= 17][feature = 'amenity_parking']["parking" != 'street_side']["parking" != 'lane'],
     [zoom >= 18] {
       [feature = 'amenity_parking'] { marker-file: url('symbols/amenity/parking.svg'); }
+      [feature = 'amenity_parking']["parking" = 'street_side'],
+      [feature = 'amenity_parking']["parking" = 'lane'] { 
+        marker-file: url('symbols/amenity/parking_subtle.svg'); 
+      }
       [feature = 'amenity_bicycle_parking'] { marker-file: url('symbols/amenity/bicycle_parking.svg'); }
       [feature = 'amenity_motorcycle_parking'] { marker-file: url('symbols/amenity/motorcycle_parking.svg'); }
       [feature = 'amenity_parking_entrance']["parking"='underground'] { marker-file: url('symbols/amenity/parking_entrance_underground.svg'); }

--- a/symbols/amenity/parking_subtle.svg
+++ b/symbols/amenity/parking_subtle.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9" height="9" width="9">
+  <path fill-rule="evenodd" d="M2.005 1v7.003h1.002V5H5.41c2.27 0 2.27-4 0-4zm1.002 1v2h2.12c1.195 0 1.195-2 0-2z"/>
+</svg>


### PR DESCRIPTION
For `amenity=parking` of the type `parking=street_side` (street-side parking in bays and other demarcated parking areas) and `parking=lane` (parking on a lane alongside a street), the amenity icon is replaced with a smaller one that is shown from `z18` onwards.

With the introduction and formal acceptance of `parking=street_side`, mappers now have a way of indicating that a mapped parking amenity is a parking bay/area on the side of a street. This tag gives renderers a chance to solve the problem of these parts of the street layout from cluttering the map with large blue **P**'s that are better suited for larger parking lots.

This commit introduces a smaller **P** icon that is pixel aligned to match the crispness of the existing generic parking **P**.

Fixes #4262.

-----

### Current rendering at `z17`

![orig-z17](https://user-images.githubusercontent.com/683699/106192459-80511a00-61ac-11eb-9f7f-f303a48d10a9.png)

### Proposed at `z17`

No **P** for `parking=street_side` yet; the other `amenity=parking` are unchanged.

![p-z17](https://user-images.githubusercontent.com/683699/106192539-9b238e80-61ac-11eb-90a5-5bbb5fa1bd68.png)

### Current rendering at `z18`

![orig-p18](https://user-images.githubusercontent.com/683699/106193486-dc686e00-61ad-11eb-8a83-9e6062c80174.png)

### Proposed at `z18`

Subtler small **P**.

![p-z18](https://user-images.githubusercontent.com/683699/106192626-bbebe400-61ac-11eb-8379-5b85925bfebe.png)

### Proposed at `z19`

![p-z19](https://user-images.githubusercontent.com/683699/106192659-c8703c80-61ac-11eb-8d5b-8db2ff5503c9.png)

### Proposed in comparison with `parking=surface`

![comparison-with-generic-p](https://user-images.githubusercontent.com/683699/106193665-1cc7ec00-61ae-11eb-8b2f-1166e3f6354f.png)

-----

This PR is limited to the introduction of the smaller **P** for `parking=street_side` and `parking=lane`. During testing of this feature I've noticed that the grey background of `amenity=parking` makes larger parking lots and areas lose their association with the icon and the meaning of the area.

I have found that a slight blue tint pulls the icon and the background together, creating a more coherent rendering:

![blue-2](https://user-images.githubusercontent.com/683699/106193975-821bdd00-61ae-11eb-93b9-43c7e038d0bf.png)

![blue-1](https://user-images.githubusercontent.com/683699/106193969-7fb98300-61ae-11eb-9277-a1fbaa2abab0.png)

Here I've used `@parking: #ededef;`.

This is not for this PR, but worth considering as a follow up development, and it may solve what @jeisenbe mentioned in #4262:

> Another issue is that the current parking background color is not very distinctive, so if we don’t show the icon it might not be clear what we are looking at. 

Here the icon remains at `z >= 18` (but de-emphasized), but the same concern is present here too.

