### PR TITLE
Public transport shelter should not be labeled with elevation

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1466,7 +1466,7 @@ Layer:
                     WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                       AND ("natural" IN ('peak', 'volcano', 'saddle')
                         OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
-                        OR (amenity = 'shelter' AND tags->shelter_type NOT IN (public_transport, picnic_shelter))
+                        OR (amenity = 'shelter' AND tags->'shelter_type' NOT IN ('public_transport', 'picnic_shelter')))
                     THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,
                   CASE
                     WHEN (tags ? 'height') AND tags->'height' ~ '^\d{1,3}(\.\d+)?$'

--- a/project.mml
+++ b/project.mml
@@ -1466,7 +1466,7 @@ Layer:
                     WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                       AND ("natural" IN ('peak', 'volcano', 'saddle')
                         OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
-                        OR amenity = 'shelter') AND tags->shelter_type NOT IN (public_transport, picnic_shelter)
+                        OR amenity = 'shelter') 
                     THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,
                   CASE
                     WHEN (tags ? 'height') AND tags->'height' ~ '^\d{1,3}(\.\d+)?$'

--- a/project.mml
+++ b/project.mml
@@ -1466,7 +1466,7 @@ Layer:
                     WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                       AND ("natural" IN ('peak', 'volcano', 'saddle')
                         OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
-                        OR amenity = 'shelter')
+                        OR amenity = 'shelter') AND tags->shelter_type NOT IN (public_transport, picnic_shelter)
                     THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,
                   CASE
                     WHEN (tags ? 'height') AND tags->'height' ~ '^\d{1,3}(\.\d+)?$'

--- a/project.mml
+++ b/project.mml
@@ -1466,7 +1466,7 @@ Layer:
                     WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                       AND ("natural" IN ('peak', 'volcano', 'saddle')
                         OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
-                        OR amenity = 'shelter') 
+                        OR (amenity = 'shelter' AND tags->shelter_type NOT IN (public_transport, picnic_shelter))
                     THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,
                   CASE
                     WHEN (tags ? 'height') AND tags->'height' ~ '^\d{1,3}(\.\d+)?$'


### PR DESCRIPTION
Fixes #4270 

Changes proposed in this pull request:
-` OR (amenity = 'shelter' AND tags->shelter_type NOT IN (public_transport, picnic_shelter))`

