### PR TITLE
Change icon for shelter_type=public_transport

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1592,6 +1592,7 @@ Layer:
                                 ELSE 'other' END AS shop,
               CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building,
               tags->'operator' AS operator,
+              tags->'shelter_type' AS shelter_type,
               ref,
               way_area,
               COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -54,6 +54,10 @@
     [feature = 'amenity_shelter'] {
       marker-fill: @man-made-icon;
     }
+    [shelter_type = 'public_transport'] {
+      marker-file: url('symbols/amenity/shelter_public_transport.svg');
+      marker-fill: @transportation-icon;
+    }
     marker-fill: @accommodation-icon;
     marker-clip: false;
     [access != ''][access != 'permissive'][access != 'yes'] {

--- a/symbols/amenity/shelter_public_transport.svg
+++ b/symbols/amenity/shelter_public_transport.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+  <path d="M11.227.004L2.693 2.922v11.103H4.18V9.021h.578l.166.616.734-.198-.476-1.78-.737.196.159.592H4.18V4.535l7.047-3.514V.004z"/>
+</svg>
+


### PR DESCRIPTION
The default shelter icon looks a bit strange for shelters tagged with `shelter_type=public_transport`; the minimal shelter type you would find at a bus or tram stop.

This commit introduces a distinct icon for this shelter type, and changes the colour of it to `@transportation-icon` to match the public transport stop itself.

This type of icon was suggested by @polarbearing in #4270.

## Rendering

![Screenshot from 2021-02-02 19-23-08](https://user-images.githubusercontent.com/683699/106645546-ccc19e80-658c-11eb-9956-87558ef61577.png)

Seems to work okay with shelters mapped as buildings too:

![Screenshot from 2021-02-02 19-29-16](https://user-images.githubusercontent.com/683699/106645702-01355a80-658d-11eb-87e0-efb4950be1d9.png)

At the very least no worse than the generic shelter icon.

## Current icon and colour

![Screenshot from 2021-02-02 19-30-14](https://user-images.githubusercontent.com/683699/106645792-1e6a2900-658d-11eb-8d10-10b504e18a14.png)

![Screenshot from 2021-02-02 19-31-19](https://user-images.githubusercontent.com/683699/106645885-448fc900-658d-11eb-840e-c91aeb08f79c.png)
