### PR TITLE
Update of the flex version of openstreetmap-carto

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -334,15 +334,15 @@ col_definitions.polygon[1].projection = srid
 
 -- Add 'z-order' and 'way_area' columns
 if add_z_order_col then
-    table.insert(col_definition["line"], { column = 'z_order', type = 'int4' })
+    table.insert(col_definitions["line"], { column = 'z_order', type = 'int4' })
     if add_roads_table then
-        table.insert(col_definition["roads"], { column = 'z_order', type = 'int4' })
+        table.insert(col_definitions["roads"], { column = 'z_order', type = 'int4' })
     end
-    table.insert(col_definition["polygon"], { column = 'z_order', type = 'int4' })
+    table.insert(col_definitions["polygon"], { column = 'z_order', type = 'int4' })
 end
 
 if add_way_area_col then
-    table.insert(col_definition["polygon"], { column = 'way_area', type = 'area' })
+    table.insert(col_definitions["polygon"], { column = 'way_area', type = 'area' })
 end
             
 -- Combine the two sets of columns and create a map with column names.

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -1,6 +1,6 @@
 -- IMPORTANT NOTICE:
 -- This is an osm2pgsql 'flex output' Lua file, and requires a minimum version of 
--- osm2pgsql of >=1.3.0 to work, but >=1.4.1 is highly recommended. This Lua file will not
+-- osm2pgsql of >=1.4.0 to work, but >=1.4.1 is highly recommended. This Lua file will not
 -- work with older versions of osm2pgsql, nor will it work with 'pgsql output' options on
 -- the command line.
 
@@ -89,6 +89,7 @@ end
 
 local tables = {}
 local pg_cols
+local col_definitions
 
 -- A list of columns per table, replacing the osm2pgsql .style file
 -- These need to be ordered, so that means a list

--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -527,7 +527,7 @@ local polygon_values = {
     boundary = {aboriginal_lands = true, national_park = true, protected_area = true},
     highway = {services = true, rest_area = true},
     junction = {yes = true},
-    railway = {station = true, traverser = true, turntable = true, wash = true}
+    railway = {station = true}
 }
 
 -- The following keys will be deleted
@@ -904,7 +904,6 @@ function osm2pgsql.process_way(object)
 
     local area_tags = isarea(object.tags)
     if object.is_closed and area_tags then
---    if object.is_closed and object.tags["area"] ~= "no" then
         add_polygon(object)
     else
         add_line(object)


### PR DESCRIPTION
This an adjusted osm2pgsql flex 'openstreetmap-carto.lua' script / style that builds upon the good work of Paul Norman and adds in some nice options of the 'compatible.lua' file, part of a the osm2pgsql repository, that has been created by Jochen Topf.

Most notably, from Jochen's work, it adds:
- The ability to specify the table prefix (e.g. 'planet_osm')
- The ability to set the projection of the resulting geometries in the style file
- The option to choose between having Multipolygons or only Polygons created. Note: this also fixes the use of an outdated 'multi' option of the osm2pgsql flex output that was deprecated and finally removed in the latest flex based osm2pgsql versions. This issue caused a failure to run the existing 'flex-master'  version of the Lua script using the latest osm2pgsql versions (>= 1.4.x).

On top of this, it adds a few other new configuration options, and extends code documentation:
- Ability to optionally suppress the creation of z-order or way_area columns
- Ability to optionally create the 'roads'  and new 'route' table
- Ability to explicitly define columns to add, or alternatively create a minimum schema with all tags in the hstore column only.
- Fix for the outdated and broken link to osm2pgsql's 'pgsql' output, this has now been replaced by a reference to the new 'osm2pgsql.org' website.

Fixes # (id of the issue to be closed)

Changes proposed in this pull request:
- 

Test rendering with links to the example places:

Before

After
