### PR TITLE
Cleanup of missed protect_class=24 selector

### DIFF
--- a/style/admin.mss
+++ b/style/admin.mss
@@ -477,8 +477,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   text-name: "[name]";
   text-face-name: @book-fonts;
   text-fill: @protected-area;
-  [boundary='aboriginal_lands'],
-  [boundary='protected_area'][protect_class='24'] {
+  [boundary='aboriginal_lands'] {
     text-fill: @aboriginal;
   }
   text-halo-radius: @standard-halo-radius;


### PR DESCRIPTION
Fixes #4113 

PR #4113 removed `protect_class` rendering for various values of that key, including `protect_class=24`.  However, it appears that one of the selectors was inadvertently missed.  This PR removes this code which is no longer needed.