### PR TITLE
Update conditions of two indexes

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -44,7 +44,7 @@ CREATE INDEX planet_osm_roads_admin
   WHERE boundary = 'administrative';
 CREATE INDEX planet_osm_roads_admin_low
   ON planet_osm_roads USING GIST (way)
-  WHERE boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4');
+  WHERE boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4') AND osm_id < 0;
 CREATE INDEX planet_osm_roads_roads_ref
   ON planet_osm_roads USING GIST (way)
   WHERE highway IS NOT NULL AND ref IS NOT NULL;

--- a/indexes.sql
+++ b/indexes.sql
@@ -30,9 +30,12 @@ CREATE INDEX planet_osm_polygon_nobuilding
   WHERE building IS NULL;
 CREATE INDEX planet_osm_polygon_water
   ON planet_osm_polygon USING GIST (way)
-  WHERE waterway IN ('dock', 'riverbank', 'canal')
-    OR landuse IN ('reservoir', 'basin')
-    OR "natural" IN ('water', 'glacier');
+  WHERE (
+      waterway IN ('dock', 'riverbank', 'canal')
+      OR landuse IN ('reservoir', 'basin')
+      OR "natural" IN ('water', 'glacier')
+    ) AND
+      building IS NULL;
 CREATE INDEX planet_osm_polygon_way_area_z10
   ON planet_osm_polygon USING GIST (way)
   WHERE way_area > 23300;

--- a/indexes.yml
+++ b/indexes.yml
@@ -30,9 +30,10 @@ polygon:
   water:
     # The indentation here makes sense in the SQL output
     where: |-
-      waterway IN ('dock', 'riverbank', 'canal')
+      (waterway IN ('dock', 'riverbank', 'canal')
           OR landuse IN ('reservoir', 'basin')
-          OR "natural" IN ('water', 'glacier')
+          OR "natural" IN ('water', 'glacier'))
+      AND building IS NULL
   way_area_z6:
     where: way_area > 5980000
   way_area_z10:

--- a/indexes.yml
+++ b/indexes.yml
@@ -41,7 +41,7 @@ roads:
   # The roads table only has a subset of data, so it's just got some low-zoom
   # indexes and some fairly selective ones for high zoom
   admin_low:
-    where: boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4')
+    where: boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4') AND osm_id < 0
   admin:
     where: boundary = 'administrative'
   roads_ref:


### PR DESCRIPTION
This pull request updates the where conditions of indexes defined in `indexes.yml` and `indexes.sql`. The queries of the layers using the indexes have been changed in previous commits but the changes did not get reflected in the index creation scripts.

The performance gain is not expected to be large because the indexes are still useful for the layers they have been created for. However, it makes sense to me to make the index conditions match the conditions of their layers exactly if they have been created for them.

People who set up the style after this patch can benefit from slightly improved performance while people already running the style can decide whether they want to change the indexes or use the time for other purposes.

This pull request has no visual effects on rendering. It follows the spirit of my previous pull requests of this kind: #3909, #3682.

Note: The water areas index uses the condition `building IS NULL`. This condition was added long time ago in order to make use of the nobuilding index. In the meanwhile, someone added a special water index. Instead of adding `building IS NULL` to the water index's condition, I could remove `building IS NULL` from the condition of that layer as well but this can lead to mistagged water areas appear on the map if they are not rendered (and covered) by the buildings layer as well.