### PR TITLE
Update project.mml for railway:preserved=yes parity with railway=preserved

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -487,7 +487,7 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                'railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                'railway_' || (CASE WHEN (tags->'railway:preserved' IN ('yes') OR (railway = 'preserved' AND service IN ('spur', 'siding', 'yard'))) THEN 'INT-preserved-ssy'::text
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                  ELSE railway END) AS feature,
@@ -743,7 +743,7 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                ('railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                ('railway_' || (CASE WHEN (tags->'railway:preserved' IN ('yes') OR (railway = 'preserved' AND service IN ('spur', 'siding', 'yard'))) THEN 'INT-preserved-ssy'::text
                                      WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                      WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                      ELSE railway END)) AS feature,
@@ -962,7 +962,7 @@ Layer:
             UNION ALL
             SELECT
                 way,
-                'railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                'railway_' || (CASE WHEN (tags->'railway:preserved' IN ('yes') OR (railway = 'preserved' AND service IN ('spur', 'siding', 'yard'))) THEN 'INT-preserved-ssy'::text
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                  ELSE railway END) AS feature,
@@ -1891,7 +1891,7 @@ Layer:
       table: |-
         (SELECT
             way,
-            CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+            CASE WHEN (tags->'railway:preserved' IN ('yes') OR (railway = 'preserved' AND service IN ('spur', 'siding', 'yard'))) THEN 'INT-preserved-ssy'::text
                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service' ELSE railway END AS railway,
             CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,


### PR DESCRIPTION
Fixes #2615

# Changes proposed in this pull request #
`railway:preserved=yes` should become the preferred option over `railway=preserved`. A [proposal is underway](https://wiki.openstreetmap.org/wiki/Proposed_features/Discourage_railway%3Dpreserved) to discourage the use of the latter.

Very active railway mappers were concerned, that `railway:preserved` isn't rendered as of yet, this is the first try to fix these concerns. 

# Test rendering with links to the example places #
https://www.openstreetmap.org/#map=18/52.66410/8.64290&layers=N

## Before ##
![grafik](https://user-images.githubusercontent.com/24451207/113774282-588bae80-9727-11eb-838c-ee9fcc6fa920.png)

## After ##
![grafik](https://user-images.githubusercontent.com/24451207/113774330-68a38e00-9727-11eb-81fa-c2489c06f9d2.png)

# Unresolved issue #

I wasn't able to display the `name=*` next to the line, just like it does next to `railway=preserved` lines. I would need help in fixing this.

Thanks everyone for your support!

^Kai