### PR TITLE
Add rendering for `highway=busway`

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -165,10 +165,24 @@
     }
   }
 
-  [feature = 'amenity_bus_station'][zoom >= 16] {
-    marker-file: url('symbols/amenity/bus_station.svg');
-    // use colors from SVG to allow for white background
-    marker-clip: false;
+  [feature = 'amenity_bus_station'] {
+    [zoom >= 16] {
+      marker-file: url('symbols/amenity/bus_station.svg');
+      // use colors from SVG to allow for white background
+      marker-clip: false;
+    }
+    [zoom < 16][zoom >= 12] {
+      marker-file: url('symbols/square.svg');
+      marker-fill: @transportation-icon;
+      marker-clip: false;
+      marker-width: 4;
+      [zoom >= 13] {
+        marker-width: 6; 
+      }
+      [zoom >= 15] {
+        marker-width: 6;
+      }
+    }
   }
 
   [feature = 'amenity_taxi'][zoom >= 17] {


### PR DESCRIPTION
### Fixes # (id of the issue to be closed)
- #4226

### Changes proposed in this pull request:
The rendering for `higway=bus_guideway` would be applied to instances of `highway=busway`.

### Test rendering with links to the example places:
- https://www.openstreetmap.org/relation/4051402#map=15/40.4294/-80.0636

#### Before
![image](https://user-images.githubusercontent.com/46303203/115767526-43458f80-a377-11eb-831b-99395b138b71.png)

### After
![image](https://user-images.githubusercontent.com/46303203/115767409-1db88600-a377-11eb-9440-ac68c599115a.png)
