### PR TITLE
Make `amenity=bus_station` render more like `railway=halt`

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -171,14 +171,11 @@
       // use colors from SVG to allow for white background
       marker-clip: false;
     }
-    [zoom < 16][zoom >= 12] {
+    [zoom < 16][zoom >=13] {
       marker-file: url('symbols/square.svg');
       marker-fill: @transportation-icon;
       marker-clip: false;
       marker-width: 4;
-      [zoom >= 13] {
-        marker-width: 6; 
-      }
       [zoom >= 15] {
         marker-width: 6;
       }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -165,10 +165,24 @@
     }
   }
 
-  [feature = 'amenity_bus_station'][zoom >= 16] {
-    marker-file: url('symbols/amenity/bus_station.svg');
-    // use colors from SVG to allow for white background
-    marker-clip: false;
+  [feature = 'amenity_bus_station'] {
+    [zoom >= 16] {
+      marker-file: url('symbols/amenity/bus_station.svg');
+      // use colors from SVG to allow for white background
+      marker-clip: false;
+    }
+    [zoom < 16][zoom >= 12] {
+      marker-file: url('symbols/square.svg');
+      marker-fill: @transportation-icon;
+      marker-clip: false;
+      marker-width: 4;
+      [zoom >= 13] {
+        marker-width: 6; 
+      }
+      [zoom >= 15] {
+        marker-width: 6;
+      }
+    }
   }
 
   [feature = 'amenity_taxi'][zoom >= 17] {


### PR DESCRIPTION
 **_This comment is outdated!_**

See https://github.com/gravitystorm/openstreetmap-carto/pull/4383#issuecomment-826095714

---

### Changes proposed in this pull request:
- Change `style/amenity-points.mss` to render `amenity=bus_station` at z>=12
  - Use `symbols/square.svg` at z<16
    - Rendering is unaffected above z>=16
  - The marker width at each zoom level is the same as for `railway=station`
 

### Test rendering with links to the example places:

- [Pittsburgh, PA](https://www.openstreetmap.org/#map=12/40.4232/-80.0157)
- [Adelaide, NSW](https://www.openstreetmap.org/?mlat=-34.8707&mlon=138.6603#map=12/-34.8707/138.6603)

### Before
Pittsburgh at z=12:
![image](https://user-images.githubusercontent.com/46303203/115805706-7d348700-a3b3-11eb-9fcd-732f2c809de9.png)
Adelaide at z=12:
![image](https://user-images.githubusercontent.com/46303203/115805761-9e957300-a3b3-11eb-8a92-0a09616774b5.png)

#### After


Adelaide at z=12:
![z12 Adelaide](https://user-images.githubusercontent.com/46303203/115805208-8113d980-a3b2-11eb-9864-6aeffce3a513.png)
Adelaide at z=14:
![z14 adelaide](https://user-images.githubusercontent.com/46303203/115805186-75c0ae00-a3b2-11eb-97f2-05f1d1b163ab.png)
Pittsburgh at z=12
![z12 Pittsburgh without bus_guideway](https://user-images.githubusercontent.com/46303203/115805220-86712400-a3b2-11eb-8db5-dff9145d628e.png)
Pittsburgh at z=12, except the rendering for `highway=bus_guideway` is applied to `highway=busway`:
![z12 Pittsburgh with bus_guideway](https://user-images.githubusercontent.com/46303203/115805251-912bb900-a3b2-11eb-991a-2181433d5bcf.png)
