### PR TITLE
Render bus stations more prominantly

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -171,14 +171,11 @@
       // use colors from SVG to allow for white background
       marker-clip: false;
     }
-    [zoom < 16][zoom >= 12] {
+    [zoom < 16][zoom >=13] {
       marker-file: url('symbols/square.svg');
       marker-fill: @transportation-icon;
       marker-clip: false;
       marker-width: 4;
-      [zoom >= 13] {
-        marker-width: 6; 
-      }
       [zoom >= 15] {
         marker-width: 6;
       }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -165,10 +165,24 @@
     }
   }
 
-  [feature = 'amenity_bus_station'][zoom >= 16] {
-    marker-file: url('symbols/amenity/bus_station.svg');
-    // use colors from SVG to allow for white background
-    marker-clip: false;
+  [feature = 'amenity_bus_station'] {
+    [zoom >= 16] {
+      marker-file: url('symbols/amenity/bus_station.svg');
+      // use colors from SVG to allow for white background
+      marker-clip: false;
+    }
+    [zoom < 16][zoom >= 12] {
+      marker-file: url('symbols/square.svg');
+      marker-fill: @transportation-icon;
+      marker-clip: false;
+      marker-width: 4;
+      [zoom >= 13] {
+        marker-width: 6; 
+      }
+      [zoom >= 15] {
+        marker-width: 6;
+      }
+    }
   }
 
   [feature = 'amenity_taxi'][zoom >= 17] {


### PR DESCRIPTION
Fixes #4390

This PR attempts to increase rendering for `amenity=bus_station` without making the map too busy. Between zoom levels 13 and 16, `amenity=bus_station` will render as small blue squares, the width of each icon at each zoom level being identical to `railway=halt`.

This PR does not affect how bus stations render at zoom levels z>=16. Personally, however, I think it is worth noting how seamless the transition between the generic blue square and the bus station pictograph is when zooming in from z=15 to z=16.

### Changes proposed in this pull request:
- Change `style/amenity-points.mss` to render `amenity=bus_station` at z>=13
  - Use `symbols/square.svg` at z<16
    - Rendering is unaffected where z>=16
  - The marker width at each zoom level is the same as for `railway=halt`
### Test rendering with links to the example places:

- [Los Angeles, CA](https://www.openstreetmap.org/?mlat=34.1908&mlon=-118.5954#map=13/34.1908/-118.5954)
- [Pittsburgh, PA](https://www.openstreetmap.org/#map=12/40.4232/-80.0157)
- [Paris, France](https://www.openstreetmap.org/?mlat=48.8977&mlon=2.2813#map=13/48.8977/2.2813)





#### Los Angeles
###### Before
![image](https://user-images.githubusercontent.com/46303203/115960599-4f009580-a4e0-11eb-8f45-1cd4b2fa34d6.png)
###### After
![image](https://user-images.githubusercontent.com/46303203/115913366-828ae380-a43e-11eb-8dd0-d8a4867e84ce.png)

#### Pittsburgh

###### Before
![image](https://user-images.githubusercontent.com/46303203/115960607-5de74800-a4e0-11eb-943d-37a00a7b13f0.png)
###### After
![Screenshot_2021-04-23 OpenStreetMap Carto — Kosmtik(2)](https://user-images.githubusercontent.com/46303203/115912177-faf0a500-a43c-11eb-8d77-dc5d36912fc8.png)

#### Paris

###### Before:
![image](https://user-images.githubusercontent.com/46303203/115963327-dc49e700-a4ec-11eb-900b-f13ded20ed07.png)


###### Overpass Turbo query for `amenity=bus_station`:
![image](https://user-images.githubusercontent.com/46303203/115963357-eec42080-a4ec-11eb-8427-1d4be2050553.png)

###### At z=13
![Paris 2](https://user-images.githubusercontent.com/46303203/115963200-7f4e3100-a4ec-11eb-9e29-46610c9389bf.png)

###### At z=15
![Paris 3](https://user-images.githubusercontent.com/46303203/115963207-8117f480-a4ec-11eb-978f-89c5507a23fd.png)

###### At z=16 (unchanged)
![Paris 4](https://user-images.githubusercontent.com/46303203/115963213-837a4e80-a4ec-11eb-8c00-ec98acb10245.png)