### PR TITLE
Make text for subway stations render at z>=15

### DIFF
--- a/style/stations.mss
+++ b/style/stations.mss
@@ -29,7 +29,8 @@
     [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
-    [zoom >= 14] {
+    [zoom >= 14][station !='subway'],
+    [zoom >=15] {
       text-name: "[name]";
       text-face-name: @bold-fonts;
       text-size: 10;

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -41,7 +41,8 @@
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.5; // -0.15 em
     }
-    [zoom >= 15] {
+    [zoom >= 15][station != 'subway'],
+    [zoom >= 16] {
       marker-width: 9;
       text-size: 11;
       text-wrap-width: 33; // 3 em

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -22,11 +22,12 @@
     marker-file: url('symbols/square.svg');
     marker-fill: @station-color;
     marker-clip: false;
-    [station != 'subway'] {
+    [station != 'subway'],
+    [zoom >= 14][station = 'subway'] {
       marker-width: 4;
     }
     [zoom >= 13][station != 'subway'],
-    [zoom >= 14][station = 'subway'] {
+    [zoom >= 15][station = 'subway'] {
       marker-width: 6;
     }
     [zoom >= 14][station !='subway'],

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -22,12 +22,11 @@
     marker-file: url('symbols/square.svg');
     marker-fill: @station-color;
     marker-clip: false;
-    [station != 'subway'],
-    [zoom >= 14][station = 'subway'] {
+    [station != 'subway'] {
       marker-width: 4;
     }
     [zoom >= 13][station != 'subway'],
-    [zoom >= 15][station = 'subway'] {
+    [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
     [zoom >= 14][station !='subway'],


### PR DESCRIPTION
Fixes #4389

### Changes proposed in this pull request:
- Begin rendering text for `railway=station` + `station=subway` at z>=15.

### Test rendering with links to the example places:
- [Chicago](https://www.openstreetmap.org/#map=14/41.8793/-87.6298)
- [Philadelphia](https://www.openstreetmap.org/#map=14/39.9482/-75.1672)
- [New York City](https://www.openstreetmap.org/#map=14/40.7178/-73.9888)

### Before

![image](https://user-images.githubusercontent.com/46303203/116095319-4b9f1280-a676-11eb-8254-ecd7ee91bfd8.png)
![image](https://user-images.githubusercontent.com/46303203/116097367-15fb2900-a678-11eb-8e82-36dbcbeb11eb.png)
![image](https://user-images.githubusercontent.com/46303203/116095227-39bd6f80-a676-11eb-9884-50e5ae02b01f.png)

### After

![Chicago](https://user-images.githubusercontent.com/46303203/116287344-487f5180-a75e-11eb-826d-4d6db7b2acf4.png)
![Philly](https://user-images.githubusercontent.com/46303203/116287353-4ae1ab80-a75e-11eb-8829-5df84285ed32.png)
![NYC](https://user-images.githubusercontent.com/46303203/116287358-4cab6f00-a75e-11eb-88af-8b05c55a28bf.png)

