### PR TITLE
Render bus guideways less like bodies of water

### DIFF
--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2944,12 +2944,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #guideways {
   [zoom >= 11][zoom < 13] {
     line-width: 0.6;
-    line-color: #6699ff;
+    line-color: #7981b0;
     [zoom >= 12] { line-width: 1; }
   }
   [zoom >= 13] {
     line-width: 3;
-    line-color: #6699ff;
+    line-color: #7981b0;
     line-join: round;
     b/line-width: 1;
     b/line-color: white;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2944,12 +2944,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #guideways {
   [zoom >= 11][zoom < 13] {
     line-width: 0.6;
-    line-color: #7981b0;
+    line-color: #5f4cbf;
     [zoom >= 12] { line-width: 1; }
   }
   [zoom >= 13] {
     line-width: 3;
-    line-color: #7981b0;
+    line-color: #7f66ff;
     line-join: round;
     b/line-width: 1;
     b/line-color: white;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2944,12 +2944,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #guideways {
   [zoom >= 11][zoom < 13] {
     line-width: 0.6;
-    line-color: #5f4cbf;
+    line-color: #8461c4;
     [zoom >= 12] { line-width: 1; }
   }
   [zoom >= 13] {
     line-width: 3;
-    line-color: #7f66ff;
+    line-color: #8461c4;
     line-join: round;
     b/line-width: 1;
     b/line-color: white;

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -29,7 +29,8 @@
     [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
-    [zoom >= 14] {
+    [zoom >= 14][station !='subway'],
+    [zoom >=15] {
       text-name: "[name]";
       text-face-name: @bold-fonts;
       text-size: 10;

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -41,7 +41,8 @@
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.5; // -0.15 em
     }
-    [zoom >= 15] {
+    [zoom >= 15][station != 'subway'],
+    [zoom >= 16] {
       marker-width: 9;
       text-size: 11;
       text-wrap-width: 33; // 3 em

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -22,11 +22,12 @@
     marker-file: url('symbols/square.svg');
     marker-fill: @station-color;
     marker-clip: false;
-    [station != 'subway'] {
+    [station != 'subway'],
+    [zoom >= 14][station = 'subway'] {
       marker-width: 4;
     }
     [zoom >= 13][station != 'subway'],
-    [zoom >= 14][station = 'subway'] {
+    [zoom >= 15][station = 'subway'] {
       marker-width: 6;
     }
     [zoom >= 14][station !='subway'],

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -22,12 +22,11 @@
     marker-file: url('symbols/square.svg');
     marker-fill: @station-color;
     marker-clip: false;
-    [station != 'subway'],
-    [zoom >= 14][station = 'subway'] {
+    [station != 'subway'] {
       marker-width: 4;
     }
     [zoom >= 13][station != 'subway'],
-    [zoom >= 15][station = 'subway'] {
+    [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
     [zoom >= 14][station !='subway'],

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -41,8 +41,7 @@
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.5; // -0.15 em
     }
-    [zoom >= 15][station != 'subway'],
-    [zoom >= 16] {
+    [zoom >= 15] {
       marker-width: 9;
       text-size: 11;
       text-wrap-width: 33; // 3 em

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -29,8 +29,7 @@
     [zoom >= 14][station = 'subway'] {
       marker-width: 6;
     }
-    [zoom >= 14][station !='subway'],
-    [zoom >=15] {
+    [zoom >= 14] {
       text-name: "[name]";
       text-face-name: @bold-fonts;
       text-size: 10;


### PR DESCRIPTION
Fixes #3396

Changes proposed in this pull request:
- Apply station colors to `highway=bus_guideway`

Test rendering with links to the example places:
- [Cambridge, UK](https://www.openstreetmap.org/#map=13/52.2733/0.0559)

Before
![image](https://user-images.githubusercontent.com/46303203/116421514-e7628700-a80c-11eb-8e5a-c30d7301ce67.png)

After
![image](https://user-images.githubusercontent.com/46303203/116421345-bf732380-a80c-11eb-8def-9b9493979c28.png)
