### PR TITLE
Fix advertising column shape

### DIFF
--- a/symbols/advertising_column.svg
+++ b/symbols/advertising_column.svg
@@ -6,6 +6,5 @@
 	 viewBox="0 0 14 14" enable-background="new 0 0 14 14" xml:space="preserve">
 <rect id="posters" x="4.5" y="4.108" style="fill-opacity:0.3;stroke-width:0.01526906;opacity:0.9;fill:#000000" width="5" height="8"/>
 <rect id="bottom" x="4" y="13" width="6" height="1"/>
-<rect id="top" x="4" y="2" width="6" height="1"/>
-<polygon id="tip" points="4,2 7,0 10,2 "/>
+<path id="top" d="M 4,3 L 4,2 7,0 10,2 10,3 Z"/>
 </svg>


### PR DESCRIPTION
Side-to-side shape connections can lead to artifacts on some zoom levels.

I didn't create an issue since the fix is pretty small.

Changes proposed in this pull request:
- Fix `advertising_column.svg` shape.

Before (you can see pale white line between `tip` and `top` shapes)

![Screen Shot 2021-06-19 at 23 29 46](https://user-images.githubusercontent.com/2399987/122654851-cbb59600-d156-11eb-8519-b56368d2c3be.png)
![Screen Shot 2021-06-19 at 23 30 21](https://user-images.githubusercontent.com/2399987/122654853-d07a4a00-d156-11eb-9124-c684658d96cc.png)

After

![Screen Shot 2021-06-19 at 23 31 15](https://user-images.githubusercontent.com/2399987/122654856-d96b1b80-d156-11eb-8668-a621b7dfd4af.png)
![Screen Shot 2021-06-19 at 23 31 29](https://user-images.githubusercontent.com/2399987/122654860-dc660c00-d156-11eb-800c-0c05608f4633.png)