### PR TITLE
Add phantom labels for all bridges

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1418,8 +1418,6 @@ Layer:
           WHERE ST_PointOnSurface(way) && !bbox!
             AND name IS NOT NULL
             AND man_made = 'bridge'
-            AND way_area > 125*POW(!scale_denominator!*0.001*0.28,2)
-            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           ORDER BY way_area DESC
         ) AS bridge_text
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1822,6 +1822,32 @@ Layer:
         ) AS roads_area_text_name
     properties:
       minzoom: 15
+  - id: roads-text-name-phantom
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
+            construction,
+            length(name)*!scale_denominator!*0.001*0.28/st_length(way) as char_per_pixel
+          FROM planet_osm_line l
+          WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
+                            'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction')
+            AND name IS NOT NULL
+            AND bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct')
+          ORDER BY
+            z_order DESC, -- put important roads first
+            COALESCE(layer, 0), -- put top layered roads first
+            length(name) DESC, -- Try to fit big labels in first
+            name DESC, -- Force a consistent ordering between differently named streets
+            l.osm_id DESC -- Force an ordering for streets of the same name, e.g. dualized roads
+        ) AS roads_text_name_phantom
+    properties:
+      cache-features: true
+      minzoom: 13
   - id: roads-text-name
     geometry: linestring
     <<: *extents

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2796,13 +2796,17 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #bridge-text  {
   [man_made = 'bridge'] {
+    text-name: "B";
+    text-face-name: @book-fonts;
+    text-opacity: 0;
+
     [zoom >= 12][way_pixels > 125][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: 10;
       text-wrap-width: 30; // 3 em
       text-line-spacing: -1.2; // -0.15 em
       text-fill: black;
-      text-face-name: @book-fonts;
+      text-opacity: 1;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-margin: 3; // 0.3 em

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -324,6 +324,8 @@
 
 @railway-text-repeat-distance: 200;
 
+@phantom-line-text-threshold: 2.1;
+
 #roads-casing, #bridges, #tunnels {
   ::casing {
     [zoom >= 12] {
@@ -3199,6 +3201,88 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-spacing: 760;
       text-repeat-distance: @major-highway-text-repeat-distance;
       text-vertical-alignment: middle;
+    }
+  }
+}
+
+
+#roads-text-name-phantom {
+  [highway = 'motorway'],
+  [highway = 'trunk'],
+  [highway = 'primary'],
+  [highway = 'construction'][construction = 'motorway'],
+  [highway = 'construction'][construction = 'trunk'],
+  [highway = 'construction'][construction = 'primary'],
+
+  [highway = 'secondary'],
+  [highway = 'construction'][construction = 'secondary']  {
+    [zoom = 13][char_per_pixel > @phantom-line-text-threshold/8],
+    [zoom = 14][char_per_pixel > @phantom-line-text-threshold/9],
+    [zoom >= 15][zoom < 17][char_per_pixel > @phantom-line-text-threshold/10],
+    [zoom >= 17][zoom < 19][char_per_pixel > @phantom-line-text-threshold/11],
+    [zoom >= 19][char_per_pixel > @phantom-line-text-threshold/12] {
+      text-name: "B";
+      text-size: 1;
+      text-opacity: 0;
+      text-face-name: @book-fonts;
+    }
+  }
+
+  [highway = 'tertiary'],
+  [highway = 'construction'][construction = 'tertiary'] {
+    [zoom >= 14][zoom < 17][char_per_pixel > @phantom-line-text-threshold/9],
+    [zoom >= 17][zoom >= 17][zoom < 19][char_per_pixel > @phantom-line-text-threshold/11],
+    [zoom >= 19][char_per_pixel > @phantom-line-text-threshold/12] {
+      text-name: "B";
+      text-size: 1;
+      text-opacity: 0;
+      text-face-name: @book-fonts;
+    }
+  }
+
+  [highway = 'construction'][construction = null][zoom >= 16] {
+    [zoom = 16][char_per_pixel > @phantom-line-text-threshold/9],
+    [zoom >= 17][zoom >= 17][zoom < 19][char_per_pixel > @phantom-line-text-threshold/11],
+    [zoom >= 19][char_per_pixel > @phantom-line-text-threshold/12] {
+      text-name: "B";
+      text-size: 1;
+      text-opacity: 0;
+      text-face-name: @book-fonts;
+    }
+  }
+
+  [highway = 'residential'],
+  [highway = 'unclassified'],
+  [highway = 'road'],
+  [highway = 'construction'][construction = null],
+  [highway = 'construction'][construction = 'residential'],
+  [highway = 'construction'][construction = 'unclassified'],
+  [highway = 'construction'][construction = 'road'],
+  [highway = 'living_street'],
+  [highway = 'pedestrian'],
+  [highway = 'construction'][construction = 'living_street'][zoom >= 16],
+  [highway = 'construction'][construction = 'pedestrian'][zoom >= 16] {
+    [zoom = 15][char_per_pixel > @phantom-line-text-threshold/8],
+    [zoom = 16][char_per_pixel > @phantom-line-text-threshold/9],
+    [zoom >= 17][zoom < 19][char_per_pixel > @phantom-line-text-threshold/11],
+    [zoom >= 19][char_per_pixel > @phantom-line-text-threshold/12] {
+      text-name: "B";
+      text-size: 1;
+      text-opacity: 0;
+      text-face-name: @book-fonts;
+    }
+  }
+
+  [highway = 'raceway'],
+  [highway = 'service'],
+  [highway = 'construction'][construction = 'raceway'],
+  [highway = 'construction'][construction = 'service'][zoom >= 17] {
+    [zoom = 16][char_per_pixel > @phantom-line-text-threshold/9],
+    [zoom >= 17][char_per_pixel > @phantom-line-text-threshold/11] {
+      text-name: "B";
+      text-size: 1;
+      text-opacity: 0;
+      text-face-name: @book-fonts;
     }
   }
 }


### PR DESCRIPTION
**Partially fixes #478** 

**Changes proposed in this pull request:**
- Add a phantom label to all bridges in order to displace water labels for not to be on top of bridges

**Test rendering with links to the example places:**

Before:
![Selección_006](https://user-images.githubusercontent.com/25908318/122748812-e853ea00-d28c-11eb-8665-8f051fb91df8.png)

After:
![Selección_007](https://user-images.githubusercontent.com/25908318/122748834-eee26180-d28c-11eb-8df6-e06b805039d3.png)