### PR TITLE
Single tree and tree_row colors as forest

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -3064,9 +3064,9 @@
 
 #trees [zoom >= 16] {
   ::canopy {
-    opacity: 0.3;
+    opacity: 0.6;
     [natural = 'tree_row'] {
-      line-color: green;
+      line-color: darken(@forest,10%);
       line-cap: round;
       line-width: 2.5;
       [zoom >= 17] {
@@ -3083,11 +3083,17 @@
       }
     }
     [natural = 'tree'] {
+      marker-fill: darken(@forest,10%);
+      marker-allow-overlap: true;
+      marker-line-width: 0;
+      marker-ignore-placement: true;
+      marker-width: 2.5;
+      marker-height: 2.5;
+      [zoom >= 17] {
+        marker-width: 5;
+        marker-height: 5;
+      }
       [zoom >= 18] {
-        marker-fill: green;
-        marker-allow-overlap: true;
-        marker-line-width: 0;
-        marker-ignore-placement: true;
         marker-width: 10;
         marker-height: 10;
       }
@@ -3103,7 +3109,8 @@
   }
   [natural = 'tree']::trunk {
     [zoom >= 18] {
-      trunk/marker-fill: #b27f36;
+      trunk/opacity: 0.4;
+      trunk/marker-fill: #6b8d5e; // Same opacity and color as forest svg patterns
       trunk/marker-allow-overlap: true;
       trunk/marker-line-width: 0;
       trunk/marker-width: 2;


### PR DESCRIPTION
Fixes # (id of the issue to be closed)
 #2736
Concerns:
#1753
#2789

### Changes proposed in this pull request
- Change natural=tree and natural=tree_row color from 'green' to the same color as forest
- Change the trunk color of tree node to the same as the forest svg overlay
- Add back trees up to z16 given the lower visibility

### Rationale
 #2736 is closed as integrated in #1753, however no work as been done on the latest for 3 years. This pull request at least solve the outstanding tree colors, I doubt the original #00ff00 was of particular cartographic significance.

The transparency of the canopy has been kept, I guess in urban areas some will be attached to this transparency. #1753 is slightly improved, but not solved. Switching layer order could solve while keeping transparency.

I decided to add back the trees up to zoom 16, this was removed by @kocio-pl in #2789, this is probably subject to discussion. I think the less saturated green dots does not affect so much the map visibility any more. Also, proposing greener towns in august, I hope this will find some support ;-)

### Test rendering with links to the example places:

**Before / After - Urban area, over various backgrounds Z18**
![urban_area_z18](https://user-images.githubusercontent.com/506919/129489997-e1b54421-04a1-483e-866a-8cbdca171a16.png)

**Before / After - Transparency kept Z19**
![transparency_z19](https://user-images.githubusercontent.com/506919/129490031-91555284-9338-46ea-ba51-ca7e8782509f.png)

**Before / after image showing a tree_row, a hedge and single trees.**
![tree_row-hedge_intersects_crop](https://user-images.githubusercontent.com/506919/129489677-df271d47-9279-462d-9cff-8152279cac9f.png)

**Before / After -  In the countryside Z18**
![meadow_z18](https://user-images.githubusercontent.com/506919/129490487-c169cc85-8945-4cde-ae0d-2f7a79c8fa89.png)

**Lower zoom (Z17)**
This was change by #2789
**Carto now**
![warsaw_z17_now](https://user-images.githubusercontent.com/506919/129490064-2d1be06e-0762-4598-b0d1-58057d9b1a1c.png)

**Proposed**
![warsaw_z17_proposed](https://user-images.githubusercontent.com/506919/129490072-6918d713-794f-4e65-afba-38d7132175da.png)

**Carto 2017**
![warsaw_z17_2017](https://user-images.githubusercontent.com/506919/129490062-69f0737b-b172-476b-b093-92188d8dac78.png)

**Lower zoom (Z16)**
This was change by #2789
**Carto now**
![warsaw_z16_now](https://user-images.githubusercontent.com/506919/129490096-f20abd0d-42da-4e43-ab13-627111f3e322.png)

**Proposed**
![warsaw_z16_proposed](https://user-images.githubusercontent.com/506919/129490102-8ec5e2c3-9e0c-44c2-925a-70ba4f5499f5.png)

**Carto 2017**
![warsaw_z16_2017](https://user-images.githubusercontent.com/506919/129490091-7da287e0-8078-4fc1-839c-38e1c7d43efd.png)




