### PR TITLE
Updated to work with pyscopg2 version 2.9.1

### DIFF
--- a/scripts/get-external-data.py
+++ b/scripts/get-external-data.py
@@ -54,7 +54,7 @@ class Table:
         with self._conn.cursor() as cur:
             cur.execute('''DROP TABLE IF EXISTS "{temp_schema}"."{name}"'''
                         .format(name=self._name, temp_schema=self._temp_schema))
-        self._conn.commit()
+            self._conn.commit()
 
     # get the last modified date from the metadata table
     def last_modified(self):
@@ -64,6 +64,7 @@ class Table:
             results = cur.fetchone()
             if results is not None:
                 return results[0]
+            self._conn.commit()
 
     def grant_access(self, user):
         with self._conn.cursor() as cur:
@@ -98,7 +99,7 @@ class Table:
             # matter since it'll never need a vacuum.
             cur.execute('''ALTER TABLE "{temp_schema}"."{name}" RESET ( autovacuum_enabled );'''
                         .format(name=self._name, temp_schema=self._temp_schema))
-        self._conn.commit()
+            self._conn.commit()
 
         # VACUUM can't be run in transaction, so autocommit needs to be turned on
         old_autocommit = self._conn.autocommit
@@ -188,11 +189,12 @@ def main():
 
         renderuser = opts.renderuser or config["settings"].get("renderuser")
 
-        with requests.Session() as s, \
-            psycopg2.connect(database=database,
+        with requests.Session() as s:
+            conn = None
+            conn = psycopg2.connect(database=database,
                              host=host, port=port,
                              user=user,
-                             password=password) as conn:
+                             password=password)
 
             s.headers.update({'User-Agent': 'get-external-data.py/osm-carto'})
 
@@ -288,6 +290,8 @@ def main():
                 else:
                     logging.info(
                         "Table {} did not require updating".format(name))
+            if conn:
+                conn.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #4447

Tested against psycopg2 versions 2.8.6 and 2.9.1

The calls to `self._conn.commit()` should be superfluous in version 2.9.1 of psycopg2 but are still needed in older versions.
