### PR TITLE
Remove hsla-filter that has no effect

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -70,8 +70,10 @@
 
 #landcover-low-zoom[zoom < 10],
 #landcover[zoom >= 10] {
-  ::low-zoom[zoom < 12] { image-filters: scale-hsla(0,1,0,1,0.2,1,0,1); }
-  ::high-zoom[zoom >= 12]                 { image-filters: scale-hsla(0,1,0,1,0,  1,   0,1); }
+  ::low-zoom[zoom < 12] {
+    // Increase the lightness of the map by scaling color lightness to be in the 20%-100% range
+    image-filters: scale-hsla(0,1, 0,1, 0.2,1, 0,1);
+  }
 
   ::low-zoom[zoom < 12],
   ::high-zoom[zoom >= 12] {


### PR DESCRIPTION
This is very minor.
`landcover.mss` defines an image filter for high zoom levels that has no effect.
For a moment I thought it could be a cause of color artifacts with SVG images (which was not the case).

This commit just removes the filter.