### PR TITLE
Reorder layers to get all the road layers together

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -829,35 +829,6 @@ Layer:
       table: *turning-circle_sql
     properties:
       minzoom: 15
-  - id: aerialways
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            aerialway,
-            man_made,
-            tags->'substance' AS substance
-          FROM planet_osm_line
-          WHERE aerialway IS NOT NULL
-            OR (man_made = 'pipeline'
-                AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
-                OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
-            OR (man_made = 'goods_conveyor'
-                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
-          ORDER BY
-            CASE
-              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
-              WHEN tags-> 'location' = 'overhead' THEN 2
-              WHEN bridge IS NOT NULL THEN 3
-              WHEN aerialway IS NOT NULL THEN 4
-            END
-        ) AS aerialways
-    properties:
-      minzoom: 12
   - id: roads-low-zoom
     geometry: linestring
     <<: *extents
@@ -1030,6 +1001,35 @@ Layer:
     properties:
       cache-features: true
       minzoom: 11
+  - id: aerialways
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aerialway,
+            man_made,
+            tags->'substance' AS substance
+          FROM planet_osm_line
+          WHERE aerialway IS NOT NULL
+            OR (man_made = 'pipeline'
+                AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
+                OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+            OR (man_made = 'goods_conveyor'
+                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
+          ORDER BY
+            CASE
+              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
+              WHEN tags-> 'location' = 'overhead' THEN 2
+              WHEN bridge IS NOT NULL THEN 3
+              WHEN aerialway IS NOT NULL THEN 4
+            END
+        ) AS aerialways
+    properties:
+      minzoom: 12
   - id: golf-line
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -321,6 +321,20 @@ Layer:
         ) AS icesheet_outlines
     properties:
       minzoom: 5
+  - id: cliffs
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way, "natural", man_made
+          FROM planet_osm_line
+          WHERE "natural" IN ('arete', 'cliff', 'ridge') OR man_made = 'embankment'
+        ) AS cliffs
+    properties:
+      cache-features: true
+      minzoom: 13
   - id: marinas-area
     geometry: polygon
     <<: *extents
@@ -508,20 +522,6 @@ Layer:
         ) AS line_barriers
     properties:
       minzoom: 15
-  - id: cliffs
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way, "natural", man_made
-          FROM planet_osm_line
-          WHERE "natural" IN ('arete', 'cliff', 'ridge') OR man_made = 'embankment'
-        ) AS cliffs
-    properties:
-      cache-features: true
-      minzoom: 13
   - id: ferry-routes
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -436,94 +436,6 @@ Layer:
         ) AS buildings
     properties:
       minzoom: 14
-  - id: tunnels
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      # This query is quite large, having to deal with both roads, railways. To
-      # allow for ways that are both railways and roads, a UNION ALL is present.
-      table: |-
-        (SELECT
-            way,
-            (CASE WHEN feature IN ('highway_motorway_link', 'highway_trunk_link', 'highway_primary_link', 'highway_secondary_link', 'highway_tertiary_link') THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,
-            horse,
-            foot,
-            bicycle,
-            tracktype,
-            int_surface,
-            access,
-            construction,
-            service,
-            link,
-            layernotnull
-          FROM ( -- subselect that contains both roads and rail
-            SELECT
-                way,
-                'highway_' || highway AS feature, --only motorway to tertiary links are accepted later on
-                horse,
-                foot,
-                bicycle,
-                tracktype,
-                CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
-                                      'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
-                  WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
-                                      'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
-                END AS int_surface,
-                CASE WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
-                construction,
-                CASE
-                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text
-                  ELSE 'INT-normal'::text
-                END AS service,
-                CASE
-                  WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes'
-                  ELSE 'no'
-                END AS link,
-                COALESCE(layer,0) AS layernotnull,
-                z_order
-              FROM planet_osm_line
-              WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
-                AND highway IS NOT NULL -- end of road select
-            UNION ALL
-            SELECT
-                way,
-                'railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
-                                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
-                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
-                                 ELSE railway END) AS feature,
-                horse,
-                foot,
-                bicycle,
-                tracktype,
-                'null',
-                CASE
-                  WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
-                construction,
-                CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,
-                'no' AS link,
-                COALESCE(layer,0) AS layernotnull,
-                z_order
-              FROM planet_osm_line
-              WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
-                AND (railway NOT IN ('platform') AND railway IS NOT NULL) -- end of rail select
-            ) AS features
-          ORDER BY
-            layernotnull,
-            z_order,
-            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
-            CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
-        ) AS tunnels
-    properties:
-      cache-features: true
-      group-by: layernotnull
-      minzoom: 10
   - id: landuse-overlay
     geometry: polygon
     <<: *extents
@@ -624,6 +536,94 @@ Layer:
         ) AS ferry_routes
     properties:
       minzoom: 8
+  - id: tunnels
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      # This query is quite large, having to deal with both roads, railways. To
+      # allow for ways that are both railways and roads, a UNION ALL is present.
+      table: |-
+        (SELECT
+            way,
+            (CASE WHEN feature IN ('highway_motorway_link', 'highway_trunk_link', 'highway_primary_link', 'highway_secondary_link', 'highway_tertiary_link') THEN substr(feature, 0, length(feature)-4) ELSE feature END) AS feature,
+            horse,
+            foot,
+            bicycle,
+            tracktype,
+            int_surface,
+            access,
+            construction,
+            service,
+            link,
+            layernotnull
+          FROM ( -- subselect that contains both roads and rail
+            SELECT
+                way,
+                'highway_' || highway AS feature, --only motorway to tertiary links are accepted later on
+                horse,
+                foot,
+                bicycle,
+                tracktype,
+                CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                      'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
+                  WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
+                                      'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
+                END AS int_surface,
+                CASE WHEN access IN ('destination') THEN 'destination'::text
+                  WHEN access IN ('no', 'private') THEN 'no'::text
+                END AS access,
+                construction,
+                CASE
+                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text
+                  ELSE 'INT-normal'::text
+                END AS service,
+                CASE
+                  WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes'
+                  ELSE 'no'
+                END AS link,
+                COALESCE(layer,0) AS layernotnull,
+                z_order
+              FROM planet_osm_line
+              WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
+                AND highway IS NOT NULL -- end of road select
+            UNION ALL
+            SELECT
+                way,
+                'railway_' || (CASE WHEN railway = 'preserved' AND service IN ('spur', 'siding', 'yard') THEN 'INT-preserved-ssy'::text
+                                 WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
+                                 WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
+                                 ELSE railway END) AS feature,
+                horse,
+                foot,
+                bicycle,
+                tracktype,
+                'null',
+                CASE
+                  WHEN access IN ('destination') THEN 'destination'::text
+                  WHEN access IN ('no', 'private') THEN 'no'::text
+                END AS access,
+                construction,
+                CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,
+                'no' AS link,
+                COALESCE(layer,0) AS layernotnull,
+                z_order
+              FROM planet_osm_line
+              WHERE (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes')
+                AND (railway NOT IN ('platform') AND railway IS NOT NULL) -- end of rail select
+            ) AS features
+          ORDER BY
+            layernotnull,
+            z_order,
+            CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
+            CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
+            CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 2 END
+        ) AS tunnels
+    properties:
+      cache-features: true
+      group-by: layernotnull
+      minzoom: 10
   - id: turning-circle-casing
     geometry: point
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -1012,23 +1012,6 @@ Layer:
         ) AS waterway_bridges
     properties:
       minzoom: 12
-  - id: entrances
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            tags->'entrance' AS entrance,
-            access
-          FROM planet_osm_point
-          WHERE (tags->'entrance') IS NOT NULL AND
-            (tags->'indoor' = 'no'
-            OR (tags->'indoor') IS NULL))
-        AS entrances
-    properties:
-      minzoom: 18
   - id: aeroways
     geometry: linestring
     <<: *extents
@@ -1465,6 +1448,23 @@ Layer:
         ) AS county_names
     properties:
       minzoom: 8
+  - id: entrances
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            tags->'entrance' AS entrance,
+            access
+          FROM planet_osm_point
+          WHERE (tags->'entrance') IS NOT NULL AND
+            (tags->'indoor' = 'no'
+            OR (tags->'indoor') IS NULL))
+        AS entrances
+    properties:
+      minzoom: 18
   - id: amenity-points
     geometry: point
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -890,29 +890,6 @@ Layer:
       cache-features: true
       minzoom: 6
       maxzoom: 9
-  - id: waterway-bridges
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            waterway,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') 
-              OR waterway = 'canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel,
-            'yes' AS bridge
-          FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
-            AND bridge IN ('yes', 'aqueduct')
-          ORDER BY COALESCE(layer,0)
-        ) AS waterway_bridges
-    properties:
-      minzoom: 12
   - id: bridges
     geometry: linestring
     <<: *extents
@@ -1012,6 +989,29 @@ Layer:
         ) AS guideways
     properties:
       minzoom: 11
+  - id: waterway-bridges
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            waterway,
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway = 'canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel,
+            'yes' AS bridge
+          FROM planet_osm_line
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+            AND bridge IN ('yes', 'aqueduct')
+          ORDER BY COALESCE(layer,0)
+        ) AS waterway_bridges
+    properties:
+      minzoom: 12
   - id: entrances
     geometry: point
     <<: *extents


### PR DESCRIPTION
The intention of this PR is to get all road layers together. This is a first step of working on the road styling complexity. Next steps for other PRs would be to unify the road layers.

I would like to ask for review on this first step. Whether it is possible to reorder the layers like this impacts the ability to simplify the road styling.

### Layers before this pr
- `bridge` (polygon instead of way)
- buildings
- `tunnels`
  - `::casing` [zoom >= 12]
  - `::bridges_and_tunnels_background` [zoom >= 12]
  - `::halo` [zoom < 12]
  - `::fill`
- landuse-overlay (military area hatch)
- tourism-boundary (zoo, theme-park)
- barriers
- cliffs (cliff, ridge, arete, embankment)
- ferry-routes
- `turning-circle-casings`
- `highway-area-casing`
- `roads-casing`
  - `::casing`
- `highway-area-fill`
- `roads-fill`
  - `::halo` [zoom < 12]
  - `::fill`
- `turning-circle-fill`
- aerialways
- `roads-low-zoom`
  - `::halo`
  - `::fill`
- waterway-bridges (aqueducts)
- `bridges`
  - `::casing` [zoom >= 12]
  - `::bridges_and_tunnels_background` [zoom >= 12]
  - `::halo` [zoom < 12]
  - `::fill`
- `guideways`
- entrances
- aeroway (runway & taxiway)

The layers landuse-overlay, tourism-boundary, barriers, cliffs and ferry-routes should move before tunnels.
To be moved after the road layers are aerialways, waterway-bridges and entrances.
Is it acceptable for all these layers to be moved out of the way?

### Moving some layers before tunnels
While tunnels are physically underneath under basically all objects, they should often be rendered on top. As said in https://github.com/gravitystorm/openstreetmap-carto/issues/3025#issuecomment-358648415: "rendering underground roads under features on the ground would make them invisible."

Something to consider is that underground roads are currently even rendered on top of buildings. Is for each of the following layers that feature really important enough to be rendered on top? 

#### landuse-overlay
This is only used for the military area hatch. Plenty of layers are already drawn on top of this one. I see no problem in moving it up a bit, to just on top of buildings. That would put in on top of only landcovers and buildings, which seems about right to me. A tunnel underneath a military area (is that an existing combination?) would be rendered on top of the hatch.

#### tourism-boundary
Used for zoos and theme-parks. The boundary is already covered by roads. This makes sense for entrances, and is a bit unfortune when there are park roads running close along the boundary. I don't think moving tunnels to be on top of it really changes rendering for the worse. And again, probably a rare combination.

#### barriers
Whether to render barriers above or below roads is an issue: https://github.com/gravitystorm/openstreetmap-carto/issues/528, https://github.com/gravitystorm/openstreetmap-carto/pull/2394, https://github.com/gravitystorm/openstreetmap-carto/pull/3872. highway-area-fill should render on top of roads-casing, roads-casing on top of barriers, and barriers on top of highway-area-fill.

Without touching that issue... A barrier on this layer doesn't obstruct the tunnel. It can be equally reasonable to draw the road on top, as it is to draw the barrier on top. Rendering roads is currently considered more important than rendering barriers, and I would like to extend that to tunnels.

#### cliffs
Cliff, ridge, arete and embankment are terrain features, defined in the landcover MSS. In my opinion, it makes sense to move this layer to right after landcover-area-symbols and icesheet-outlines.

Compared to now, that would cause a couple of water-related features such as a dam, weir or pier to be drawn on top of them (should be rare, maybe those can exist near a cliff?). Buildings and barriers would also be drawn on top. I consider this an improvement.

Tunnels, which are the issue here, would also be drawn on top. I can't really call this better or worse.

#### ferry-routes
At low zoom ferry routes are rendered underneath roads. At higher zoom tunnels would move underneath the ferry route.I don't think it matters much.

### Layers to move after roads

#### waterway-bridges
The layer waterway-bridges with aquaducts should remain on top of roads. Is there a problem when it is also on top of bridges? Conceptually I can imagine bridges should be drawn on top of aquaducts. I can't help but imagine a bridge over an aquaduct to be rare, and not worth the simplifications it would stand in the way.
*Edit:* Moved to be after guideways.

#### aerialways
Moving aerialways with cable_cars etc. on top of all road-related features and after ~waterway-bridges~ aeroways (*edit*) seems like nothing but an improvement.

#### entrances
Having the layer with building entrances on top of buildings and roads is logical. I see no problem in moving it a bit further. ~For now I have put it after aerialways, but can imagine it would even be good to put it around aminity-points.~ *Edit:* This layer doesn't have to move, as aeroway doesn't have to be merged into the road layers after all. But I put it to just before amenities, as that seems to just be better.