### PR TITLE
Fix URL for natural earth vector dataset.

### DIFF
--- a/external-data.yml
+++ b/external-data.yml
@@ -62,7 +62,7 @@ sources:
 
   ne_110m_admin_0_boundary_lines_land:
     type: shp
-    url: https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip
+    url: https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_0_boundary_lines_land.zip
     file: ne_110m_admin_0_boundary_lines_land.shp
     ogropts: &ne_opts
       - "--config"


### PR DESCRIPTION
Fixes #4461

Changes proposed in this pull request: The link to the `ne_110m_admin_0_boundary_lines_land.zip` dataset is down due to some issues with hosting. [According to the Natural Earth Vector maintainer](https://github.com/nvkelso/natural-earth-vector/issues/581#issuecomment-913988101), you should now use the URLs for S3. The URL and formating of the URL to the new dataset should look like this and appears to be the same file from before: https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_0_boundary_lines_land.zip
