### PR TITLE
Use masking instead of darken blending of admin boundaries and ferry routes

### DIFF
--- a/style/admin.mss
+++ b/style/admin.mss
@@ -8,10 +8,6 @@
 // The SQL has `ORDER BY admin_level DESC`, so the boundary with the lowest
 // admin_level is rendered on top.
 //
-// Three attachments are used, with minor borders before major ones, and the
-// thin centerline last, to handle overlapping borders correctly and allow each
-// type to have a different level of opacity.
-//
 // Where borders overlap, the overlapping border maskes the one below it. This
 // is done by drawing a background line behind each boundary line with
 // comp-op: dst-out.
@@ -19,24 +15,10 @@
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
-  ::firstline { opacity: 0.5; }
-  ::wideline { opacity: 0.5; }
-  ::narrowline { opacity: 0.6; }
+  ::fill { opacity: 0.5; }
+  ::centerline { opacity: 0.6; }
 
-  [admin_level = '2']::firstline {
-    [zoom >= 8] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 3;
-    }
-    [zoom >= 9] { background/line-width: 3.5; }
-    [zoom >= 10] { background/line-width: 4.5; }
-    [zoom >= 11] { background/line-width: 5.5; }
-    [zoom >= 12] { background/line-width: 6; }
-    [zoom >= 13] { background/line-width: 7; }
-    [zoom >= 14] { background/line-width: 8; }
-  }
-  [admin_level = '2']::wideline {
+  [admin_level = '2']::fill {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -87,7 +69,7 @@
       line-width: 8;
     }
   }
-  [admin_level = '2']::narrowline {
+  [admin_level = '2']::centerline {
     [zoom >= 8] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -125,20 +107,7 @@
     }
   }
 
-  [admin_level = '3']::firstline {
-    [zoom >= 8] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 1.8;
-    }
-    [zoom >= 9] { background/line-width: 2.5; }
-    [zoom >= 10] { background/line-width: 3.2; }
-    [zoom >= 11] { background/line-width: 4; }
-    [zoom >= 12] { background/line-width: 4.5; }
-    [zoom >= 13] { background/line-width: 5; }
-    [zoom >= 14] { background/line-width: 5.5; }
-  }
-  [admin_level = '3']::wideline {
+  [admin_level = '3']::fill {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-color: white;
@@ -189,7 +158,7 @@
       line-width: 5.5;
     }
   }
-  [admin_level = '3']::narrowline {
+  [admin_level = '3']::centerline {
     [zoom >= 10] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -219,20 +188,7 @@
     }
   }
 
-  [admin_level = '4']::firstline {
-    [zoom >= 8] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 1;
-    }
-    [zoom >= 9] { background/line-width: 1.5; }
-    [zoom >= 10] { background/line-width: 2; }
-    [zoom >= 11] { background/line-width: 2.5; }
-    [zoom >= 12] { background/line-width: 3; }
-    [zoom >= 13] { background/line-width: 3.5; }
-    [zoom >= 14] { background/line-width: 4; }
-  }
-  [admin_level = '4']::wideline {
+  [admin_level = '4']::fill {
     [zoom >= 4] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -284,7 +240,7 @@
       line-width: 4;
     }
   }
-  [admin_level = '4']::narrowline {
+  [admin_level = '4']::centerline {
     [zoom >= 10] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -313,7 +269,7 @@
     }
   }
 
-  [admin_level = '5'][zoom >= 8]::firstline {
+  [admin_level = '5'][zoom >= 8]::fill {
     background/line-join: bevel;
     background/line-comp-op: dst-out;
     background/line-width: 0.6;
@@ -347,7 +303,7 @@
       line-dasharray: 20,2,8,2;
     }
   }
-  [admin_level = '6'][zoom >= 10]::firstline {
+  [admin_level = '6'][zoom >= 10]::fill {
     background/line-join: bevel;
     background/line-comp-op: dst-out;
     background/line-width: 1;
@@ -371,7 +327,7 @@
       line-dasharray: 16,2,3,2;
     }
   }
-  [admin_level = '7']::firstline {
+  [admin_level = '7']::fill {
     [zoom >= 11] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -393,7 +349,7 @@
       line-dasharray: 12,2,3,2,3,2;
     }
   }
-  [admin_level = '8']::firstline {
+  [admin_level = '8']::fill {
     [zoom >= 12] {
       background/line-join: bevel;
       background/line-comp-op: dst-out;
@@ -411,7 +367,7 @@
     }
   }
 
-  [admin_level = '9'][zoom >= 13]::firstline {
+  [admin_level = '9'][zoom >= 13]::fill {
     background/line-join: bevel;
     background/line-comp-op: dst-out;
     background/line-width: 1.2;
@@ -426,7 +382,7 @@
       line-dasharray: 0,4,2,2,3,2,2,4;
     }
   }
-  [admin_level = '10'][zoom >= 14]::firstline {
+  [admin_level = '10'][zoom >= 14]::fill {
     background/line-join: bevel;
     background/line-comp-op: dst-out;
     background/line-width: 1.2;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -11,7 +11,8 @@
 // Where borders overlap the simple case is that a border is just drawn on top.
 // If the overlapping border is a dashed line, it first draws a continuous
 // background line with comp-op: dst-out to mask out the line below, and then
-// draws the dashed line on top.
+// draws the dashed line on top. The mask line uses `gamma: 0` to prevent
+// aliasing issues.
 
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
@@ -43,6 +44,7 @@
     [zoom >= 8] {
       mask/line-join: bevel;
       mask/line-comp-op: dst-out;
+      mask/line-gamma: 0;
       mask/line-width: 0.6;
       line-join: bevel;
       line-color: @admin-boundaries-narrow;
@@ -101,6 +103,7 @@
     [zoom >= 10] {
       mask/line-join: bevel;
       mask/line-comp-op: dst-out;
+      mask/line-gamma: 0;
       mask/line-width: 0.8;
       line-join: bevel;
       line-color: @admin-boundaries-narrow;
@@ -152,6 +155,7 @@
     [zoom >= 10] {
       mask/line-join: bevel;
       mask/line-comp-op: dst-out;
+      mask/line-gamma: 0;
       mask/line-width: 0.6;
       line-color: @admin-boundaries-narrow;
       line-width: 0.6;
@@ -180,6 +184,7 @@
   [admin_level = '5'][zoom >= 8]::fill {
     mask/line-join: bevel;
     mask/line-comp-op: dst-out;
+    mask/line-gamma: 0;
     mask/line-width: 0.6;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -214,6 +219,7 @@
   [admin_level = '6'][zoom >= 10]::fill {
     mask/line-join: bevel;
     mask/line-comp-op: dst-out;
+    mask/line-gamma: 0;
     mask/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -239,6 +245,7 @@
     [zoom >= 11] {
       mask/line-join: bevel;
       mask/line-comp-op: dst-out;
+      mask/line-gamma: 0;
       mask/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
@@ -261,6 +268,7 @@
     [zoom >= 12] {
       mask/line-join: bevel;
       mask/line-comp-op: dst-out;
+      mask/line-gamma: 0;
       mask/line-width: 1.4;
       line-join: bevel;
       line-color: @admin-boundaries;
@@ -278,6 +286,7 @@
   [admin_level = '9'][zoom >= 13]::fill {
     mask/line-join: bevel;
     mask/line-comp-op: dst-out;
+    mask/line-gamma: 0;
     mask/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -293,6 +302,7 @@
   [admin_level = '10'][zoom >= 14]::fill {
     mask/line-join: bevel;
     mask/line-comp-op: dst-out;
+    mask/line-gamma: 0;
     mask/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -8,9 +8,10 @@
 // The SQL has `ORDER BY admin_level DESC`, so the boundary with the lowest
 // admin_level is rendered on top.
 //
-// Where borders overlap, the overlapping border maskes the one below it. This
-// is done by drawing a background line behind each boundary line with
-// comp-op: dst-out.
+// Where borders overlap the simple case is that a border is just drawn on top.
+// If the overlapping border is a dashed line, it first draws a continuous
+// background line with comp-op: dst-out to mask out the line below, and then
+// draws the dashed line on top.
 
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
@@ -20,54 +21,23 @@
 
   [admin_level = '2']::fill {
     [zoom >= 4] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1.2;
     }
-    [zoom >= 5] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-    }
-    [zoom >= 6] {
-      background/line-width: 1.8;
-      line-width: 1.8;
-    }
-    [zoom >= 7] {
-      background/line-width: 2.2;
-      line-width: 2.2;
-    }
-    [zoom >= 8] {
-      background/line-width: 3;
-      line-width: 3;
-    }
-    [zoom >= 9] {
-      background/line-width: 3.5;
-      line-width: 3.5;
-    }
+    [zoom >= 5] { line-width: 1.5; }
+    [zoom >= 6] { line-width: 1.8; }
+    [zoom >= 7] { line-width: 2.2; }
+    [zoom >= 8] { line-width: 3; }
+    [zoom >= 9] { line-width: 3.5; }
     [zoom >= 10] {
-      background/line-width: 4.5;
       line-color: @admin-boundaries-wide;
       line-width: 4.5;
     }
-    [zoom >= 11] {
-      background/line-width: 5.5;
-      line-width: 5;
-    }
-    [zoom >= 12] {
-      background/line-width: 6;
-      line-width: 6;
-    }
-    [zoom >= 13] {
-      background/line-width: 7;
-      line-width: 7;
-    }
-    [zoom >= 14] {
-      background/line-width: 8;
-      line-width: 8;
-    }
+    [zoom >= 11] { line-width: 5; }
+    [zoom >= 12] { line-width: 6; }
+    [zoom >= 13] { line-width: 7; }
+    [zoom >= 14] { line-width: 8; }
   }
   [admin_level = '2']::centerline {
     [zoom >= 8] {
@@ -109,54 +79,23 @@
 
   [admin_level = '3']::fill {
     [zoom >= 4] {
-      background/line-join: bevel;
-      background/line-color: white;
-      background/line-width: 0.6;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 0.6;
     }
-    [zoom >= 5] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-    }
-    [zoom >= 6] {
-      background/line-width: 1;
-      line-width: 1;
-    }
-    [zoom >= 7] {
-      background/line-width: 1.2;
-      line-width: 1.2;
-    }
-    [zoom >= 8] {
-      background/line-width: 1.8;
-      line-width: 1.8;
-    }
-    [zoom >= 9] {
-      background/line-width: 2.5;
-      line-width: 2.5;
-    }
+    [zoom >= 5] { line-width: 0.8; }
+    [zoom >= 6] { line-width: 1; }
+    [zoom >= 7] { line-width: 1.2; }
+    [zoom >= 8] { line-width: 1.8; }
+    [zoom >= 9] { line-width: 2.5; }
     [zoom >= 10] {
-      background/line-width: 3.2;
       line-color: @admin-boundaries-wide;
       line-width: 3.2;
     }
-    [zoom >= 11] {
-      background/line-width: 4;
-      line-width: 4;
-    }
-    [zoom >= 12] {
-      background/line-width: 4.5;
-      line-width: 4.5;
-    }
-    [zoom >= 13] {
-      background/line-width: 5;
-      line-width: 5;
-    }
-    [zoom >= 14] {
-      background/line-width: 5.5;
-      line-width: 5.5;
-    }
+    [zoom >= 11] { line-width: 4; }
+    [zoom >= 12] { line-width: 4.5; }
+    [zoom >= 13] { line-width: 5; }
+    [zoom >= 14] { line-width: 5.5; }
   }
   [admin_level = '3']::centerline {
     [zoom >= 10] {
@@ -190,55 +129,24 @@
 
   [admin_level = '4']::fill {
     [zoom >= 4] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 0.4;
       line-color: @admin-boundaries;
       line-join: bevel;
       line-width: 0.4;
       line-clip: false;
     }
-    [zoom >= 5] {
-      background/line-width: 0.5;
-      line-width: 0.5;
-    }
-    [zoom >= 6] {
-      background/line-width: 0.6;
-      line-width: 0.6;
-    }
-    [zoom >= 7] {
-      background/line-width: 0.8;
-      line-width: 0.8;
-    }
-    [zoom >= 8] {
-      background/line-width: 1;
-      line-width: 1;
-    }
-    [zoom >= 9] {
-      background/line-width: 1.5;
-      line-width: 1.5;
-    }
+    [zoom >= 5] { line-width: 0.5; }
+    [zoom >= 6] { line-width: 0.6; }
+    [zoom >= 7] { line-width: 0.8; }
+    [zoom >= 8] { line-width: 1; }
+    [zoom >= 9] { line-width: 1.5; }
     [zoom >= 10] {
-      background/line-width: 2;
       line-color: @admin-boundaries-wide;
       line-width: 2;
     }
-    [zoom >= 11] {
-      background/line-width: 2.5;
-      line-width: 2.8;
-    }
-    [zoom >= 12] {
-      background/line-width: 3;
-      line-width: 3;
-    }
-    [zoom >= 13] {
-      background/line-width: 3.5;
-      line-width: 3.5;
-    }
-    [zoom >= 14] {
-      background/line-width: 4;
-      line-width: 4;
-    }
+    [zoom >= 11] { line-width: 2.8; }
+    [zoom >= 12] { line-width: 3; }
+    [zoom >= 13] { line-width: 3.5; }
+    [zoom >= 14] { line-width: 4; }
   }
   [admin_level = '4']::centerline {
     [zoom >= 10] {

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -41,39 +41,39 @@
   }
   [admin_level = '2']::centerline {
     [zoom >= 8] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 0.6;
-      thin/line-join: bevel;
-      thin/line-color: @admin-boundaries-narrow;
-      thin/line-width: 0.6;
+      mask/line-join: bevel;
+      mask/line-comp-op: dst-out;
+      mask/line-width: 0.6;
+      line-join: bevel;
+      line-color: @admin-boundaries-narrow;
+      line-width: 0.6;
     }
     [zoom >= 9] {
-      background/line-width: 0.8;
-      thin/line-width: 0.8;
+      mask/line-width: 0.8;
+      line-width: 0.8;
     }
     [zoom >= 10] {
-      background/line-width: 1;
-      thin/line-width: 1;
-      thin/line-dasharray: 18,1,4,1;
+      mask/line-width: 1;
+      line-width: 1;
+      line-dasharray: 18,1,4,1;
     }
     [zoom >= 11] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
+      mask/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 12] {
-      background/line-width: 1.4;
-      thin/line-width: 1.4;
-      thin/line-dasharray: 27,1.5,6,1.5;
+      mask/line-width: 1.4;
+      line-width: 1.4;
+      line-dasharray: 27,1.5,6,1.5;
     }
     [zoom >= 13] {
-      background/line-width: 1.6;
-      thin/line-width: 1.6;
+      mask/line-width: 1.6;
+      line-width: 1.6;
     }
     [zoom >= 14] {
-      background/line-width: 1.8;
-      thin/line-width: 1.8;
-      thin/line-dasharray: 36,2,8,2;
+      mask/line-width: 1.8;
+      line-width: 1.8;
+      line-dasharray: 36,2,8,2;
     }
   }
 
@@ -99,31 +99,31 @@
   }
   [admin_level = '3']::centerline {
     [zoom >= 10] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 0.8;
-      thin/line-join: bevel;
-      thin/line-color: @admin-boundaries-narrow;
-      thin/line-width: 0.8;
-      thin/line-dasharray: 12,2,1.5,2;
+      mask/line-join: bevel;
+      mask/line-comp-op: dst-out;
+      mask/line-width: 0.8;
+      line-join: bevel;
+      line-color: @admin-boundaries-narrow;
+      line-width: 0.8;
+      line-dasharray: 12,2,1.5,2;
     }
     [zoom >= 11] {
-      background/line-width: 1;
-      thin/line-width: 1;
+      mask/line-width: 1;
+      line-width: 1;
     }
     [zoom >= 12] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
-      thin/line-dasharray: 17,3,2,3;
+      mask/line-width: 1.2;
+      line-width: 1.2;
+      line-dasharray: 17,3,2,3;
     }
     [zoom >= 13] {
-      background/line-width: 1.4;
-      thin/line-width: 1.4;
+      mask/line-width: 1.4;
+      line-width: 1.4;
     }
     [zoom >= 14] {
-      background/line-width: 1.6;
-      thin/line-width: 1.6;
-      thin/line-dasharray: 23,4,3,4;
+      mask/line-width: 1.6;
+      line-width: 1.6;
+      line-dasharray: 23,4,3,4;
     }
   }
 
@@ -150,96 +150,96 @@
   }
   [admin_level = '4']::centerline {
     [zoom >= 10] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 0.6;
-      thin/line-color: @admin-boundaries-narrow;
-      thin/line-width: 0.6;
-      thin/line-dasharray: 8,2,1.5,2,1.5,2;
+      mask/line-join: bevel;
+      mask/line-comp-op: dst-out;
+      mask/line-width: 0.6;
+      line-color: @admin-boundaries-narrow;
+      line-width: 0.6;
+      line-dasharray: 8,2,1.5,2,1.5,2;
     }
     [zoom >= 11] {
-      background/line-width: 0.8;
-      thin/line-width: 0.8;
+      mask/line-width: 0.8;
+      line-width: 0.8;
     }
     [zoom >= 12] {
-      background/line-width: 1;
-      thin/line-width: 1;
-      thin/line-dasharray: 12,3,2,3,2,3;
+      mask/line-width: 1;
+      line-width: 1;
+      line-dasharray: 12,3,2,3,2,3;
     }
     [zoom >= 13] {
-      background/line-width: 1.2;
-      thin/line-width: 1.2;
+      mask/line-width: 1.2;
+      line-width: 1.2;
     }
     [zoom >= 14] {
-      background/line-width: 1.4;
-      thin/line-width: 1.4;
-      thin/line-dasharray: 16,4,3,4,3,4;
+      mask/line-width: 1.4;
+      line-width: 1.4;
+      line-dasharray: 16,4,3,4,3,4;
     }
   }
 
   [admin_level = '5'][zoom >= 8]::fill {
-    background/line-join: bevel;
-    background/line-comp-op: dst-out;
-    background/line-width: 0.6;
+    mask/line-join: bevel;
+    mask/line-comp-op: dst-out;
+    mask/line-width: 0.6;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 0.6;
     line-dasharray: 4,0.6,2,0.6;
     line-clip: false;
     [zoom >= 9] {
-      background/line-width: 0.8;
+      mask/line-width: 0.8;
       line-width: 0.8;
       line-dasharray: 6,1,3,1;
     }
     [zoom >= 10] {
-      background/line-width: 1.2;
+      mask/line-width: 1.2;
       line-width: 1.2;
       line-dasharray: 10,1.5,4.5,1.5;
     }
     [zoom >= 11] {
-      background/line-width: 1.7;
+      mask/line-width: 1.7;
       line-width: 1.7;
     }
     [zoom >= 12] {
-      background/line-width: 2.1;
+      mask/line-width: 2.1;
       line-width: 2.1;
       line-dasharray: 16,2,6,2;
     }
     [zoom >= 14] {
-      background/line-width: 2.4;
+      mask/line-width: 2.4;
       line-width: 2.4;
       line-dasharray: 20,2,8,2;
     }
   }
   [admin_level = '6'][zoom >= 10]::fill {
-    background/line-join: bevel;
-    background/line-comp-op: dst-out;
-    background/line-width: 1;
+    mask/line-join: bevel;
+    mask/line-comp-op: dst-out;
+    mask/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1;
     line-dasharray: 8,1.5,1.5,1.5;
     line-clip: false;
     [zoom >= 11] {
-      background/line-width: 1.4;
+      mask/line-width: 1.4;
       line-width: 1.4;
     }
     [zoom >= 12] {
-      background/line-width: 1.8;
+      mask/line-width: 1.8;
       line-width: 1.8;
     line-dasharray: 12,1.5,2,1.5;
     }
     [zoom >= 14] {
-      background/line-width: 2.1;
+      mask/line-width: 2.1;
       line-width: 2.1;
       line-dasharray: 16,2,3,2;
     }
   }
   [admin_level = '7']::fill {
     [zoom >= 11] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 1.2;
+      mask/line-join: bevel;
+      mask/line-comp-op: dst-out;
+      mask/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1.2;
@@ -247,21 +247,21 @@
       line-clip: false;
     }
     [zoom >= 12] {
-      background/line-width: 1.5;
+      mask/line-width: 1.5;
       line-width: 1.5;
       line-dasharray: 9,2,2,2,2,2;
     }
     [zoom >= 14] {
-      background/line-width: 1.8;
+      mask/line-width: 1.8;
       line-width: 1.8;
       line-dasharray: 12,2,3,2,3,2;
     }
   }
   [admin_level = '8']::fill {
     [zoom >= 12] {
-      background/line-join: bevel;
-      background/line-comp-op: dst-out;
-      background/line-width: 1.4;
+      mask/line-join: bevel;
+      mask/line-comp-op: dst-out;
+      mask/line-width: 1.4;
       line-join: bevel;
       line-color: @admin-boundaries;
       line-width: 1.4;
@@ -269,31 +269,31 @@
       line-clip: false;
     }
     [zoom >= 14] {
-      background/line-width: 1.6;
+      mask/line-width: 1.6;
       line-width: 1.6;
       line-dasharray: 10,2,2,2,3,2,2,2;
     }
   }
 
   [admin_level = '9'][zoom >= 13]::fill {
-    background/line-join: bevel;
-    background/line-comp-op: dst-out;
-    background/line-width: 1.2;
+    mask/line-join: bevel;
+    mask/line-comp-op: dst-out;
+    mask/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.2;
     line-dasharray: 0,3,2,2,2,2,2,3;
     line-clip: false;
     [zoom >= 14] {
-      background/line-width: 1.4;
+      mask/line-width: 1.4;
       line-width: 1.4;
       line-dasharray: 0,4,2,2,3,2,2,4;
     }
   }
   [admin_level = '10'][zoom >= 14]::fill {
-    background/line-join: bevel;
-    background/line-comp-op: dst-out;
-    background/line-width: 1.2;
+    mask/line-join: bevel;
+    mask/line-comp-op: dst-out;
+    mask/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
     line-width: 1.2;

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -2,21 +2,31 @@
 @admin-boundaries-narrow: #845283; // Lch(42,35,327)
 @admin-boundaries-wide: #a37da1; // Lch(57,25,327)
 
-/* For performance reasons, the admin border layers are split into three groups
-for low, middle and high zoom levels.
-Three attachments are used, with minor borders before major ones, and the thin centerline last, to handle
-overlapping borders correctly and allow each type to have a different level of opacity.
-Overlapping borders are hidden by a white background line, rendered before each line.
-Then all three layers are added to the rendering with comp-op: darken, so that the white lines will not show
-*/
+// For performance reasons the admin border layers are split into three groups
+// for low, middle and high zoom levels.
+//
+// The SQL has `ORDER BY admin_level DESC`, so the boundary with the lowest
+// admin_level is rendered on top.
+//
+// Three attachments are used, with minor borders before major ones, and the
+// thin centerline last, to handle overlapping borders correctly and allow each
+// type to have a different level of opacity.
+//
+// Where borders overlap, the overlapping border maskes the one below it. This
+// is done by drawing a background line behind each boundary line with
+// comp-op: dst-out.
 
 #admin-low-zoom[zoom < 8],
 #admin-mid-zoom[zoom >= 8][zoom < 13],
 #admin-high-zoom[zoom >= 13] {
+  ::firstline { opacity: 0.5; }
+  ::wideline { opacity: 0.5; }
+  ::narrowline { opacity: 0.6; }
+
   [admin_level = '2']::firstline {
     [zoom >= 8] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 3;
     }
     [zoom >= 9] { background/line-width: 3.5; }
@@ -29,7 +39,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '2']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
@@ -80,7 +90,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '2']::narrowline {
     [zoom >= 8] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 0.6;
       thin/line-join: bevel;
       thin/line-color: @admin-boundaries-narrow;
@@ -118,7 +128,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '3']::firstline {
     [zoom >= 8] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 1.8;
     }
     [zoom >= 9] { background/line-width: 2.5; }
@@ -182,7 +192,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '3']::narrowline {
     [zoom >= 10] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 0.8;
       thin/line-join: bevel;
       thin/line-color: @admin-boundaries-narrow;
@@ -212,7 +222,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '4']::firstline {
     [zoom >= 8] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 1;
     }
     [zoom >= 9] { background/line-width: 1.5; }
@@ -225,7 +235,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '4']::wideline {
     [zoom >= 4] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 0.4;
       line-color: @admin-boundaries;
       line-join: bevel;
@@ -277,7 +287,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '4']::narrowline {
     [zoom >= 10] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 0.6;
       thin/line-color: @admin-boundaries-narrow;
       thin/line-width: 0.6;
@@ -302,27 +312,10 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       thin/line-dasharray: 16,4,3,4,3,4;
     }
   }
-  ::firstline { opacity: 0.5; }
-  ::wideline { opacity: 0.5; }
-  ::narrowline { opacity: 0.6; }
-  /*
-  The following code prevents admin boundaries from being rendered on top of
-  each other. Comp-op works on the entire attachment, not on the individual
-  border. Therefore, this code generates an attachment containing a set of
-  @admin-boundaries/white dashed lines (of which only the top one is visible),
-  and with `comp-op: darken` the white part is ignored, while the
-  @admin-boundaries colored part is rendered (as long as the background is not
-  darker than @admin-boundaries).
-  The SQL has `ORDER BY admin_level`, so the boundary with the lowest
-  admin_level is rendered on top, and therefore the only visible boundary.
-  */
-  ::firstline,
-  ::wideline,
-  ::narrowline { comp-op: darken; }
 
   [admin_level = '5'][zoom >= 8]::firstline {
     background/line-join: bevel;
-    background/line-color: white;
+    background/line-comp-op: dst-out;
     background/line-width: 0.6;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -356,7 +349,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   }
   [admin_level = '6'][zoom >= 10]::firstline {
     background/line-join: bevel;
-    background/line-color: white;
+    background/line-comp-op: dst-out;
     background/line-width: 1;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -381,7 +374,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '7']::firstline {
     [zoom >= 11] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 1.2;
       line-join: bevel;
       line-color: @admin-boundaries;
@@ -403,7 +396,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   [admin_level = '8']::firstline {
     [zoom >= 12] {
       background/line-join: bevel;
-      background/line-color: white;
+      background/line-comp-op: dst-out;
       background/line-width: 1.4;
       line-join: bevel;
       line-color: @admin-boundaries;
@@ -420,7 +413,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
 
   [admin_level = '9'][zoom >= 13]::firstline {
     background/line-join: bevel;
-    background/line-color: white;
+    background/line-comp-op: dst-out;
     background/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;
@@ -435,7 +428,7 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   }
   [admin_level = '10'][zoom >= 14]::firstline {
     background/line-join: bevel;
-    background/line-color: white;
+    background/line-comp-op: dst-out;
     background/line-width: 1.2;
     line-join: bevel;
     line-color: @admin-boundaries;

--- a/style/ferry-routes.mss
+++ b/style/ferry-routes.mss
@@ -1,16 +1,27 @@
 @ferry-route: #66f;
 @ferry-route-text: @ferry-route;
 
+// Overlapping dashed lines of ferry routes can look like a continues line
+// (see #457). To avoid this we draw a masking line behind the ferry routes.
+// That line is drawn with comp-op: dst-out, and with `gamma: 0` to prevent
+// aliasing issues.
+//
+// To limit the masking operation to just this layer, opacity or comp-op needs
+// to be set at the layer level. Sadly setting default values like `opacity: 1`
+// or `comp-op: scr-over` don't work. As a hack we set opacity to 0.99999.
+
 #ferry-routes {
+  opacity: 0.99999;
+
   [zoom >= 8] {
-    /* background prevents problems with overlapping ferry-routes, see #457 */
-    background/line-color: @water-color;
-    background/line-width: 1; /* Needs to be a bit wider than the route itself because of antialiasing */
+    mask/line-width: 0.4;
+    mask/line-comp-op: dst-out;
+    mask/line-gamma: 0;
     line-color: @ferry-route;
     line-width: 0.4;
     line-dasharray: 4,4;
     [zoom >= 11] {
-      background/line-width: 1;
+      mask/line-width: 0.8;
       line-width: 0.8;
       line-dasharray: 6,6;
     }


### PR DESCRIPTION
### Current
The admin boundaries are currently drawn with some complicated tricks to avoid strange renderings where boundaries overlap. It is build around `comp-op: darken`, applied at the attachment level. Within an attachment layer, for every boundary there is first drawn a white line to cover any previous boundaries. Then the new boundary is drawn on top. The entire attachment layer is blended on top of the map so far, where only the pixels that are darker than the map are blended. Because the white lines that cover up overlapping boundaries are lighter, they fall away when blending. This has the tricky assumption that boundary lines are always darker than what is already drawn on the map.

The admin boundaries have different styles for every admin level. The most importand ones, `admin_level <= 4`, are a wide line with a thin center line. The others admin levels are drawn with thin lines. This is currently drawn with three attachment layers:
- `:firstline`. All lines of `admin_level > 4`. To keep blending with `comp-op: darken` working as intended, lines from `admin_level <= 4` are drawn as white background lines.
- `:wideline`. Wide lines of `admin_level <= 4`.
- `:narrowline`. The center lines of `admin_level <= 4`.

The only reason not to combine `:firstline` and `:wideline` is so that their opacity can be seperately controlled. Until now they both have been the same, 0.5. The cost is ca. 100 lines of mss, and having to draw the background lines of `admin_level <= 4` one more time than necessary.

White background lines are always drawn, even when not needed in the cases where a boundary line is solid.

### New
- Use `comp-op: dst-out` at the line level instead of `comp-op: darken` at the layer level. The result is the same, but works it independent of lightness.
- Merge `:firstline` and `:wideline`.
- Don't draw background lines behind solid lines.

### Aliasing artifacts
`comp-op: darken` doesn't take the opacity of a pixel into account, only the lightness. I don't know the lightness formula for aliased pixels, but it worked out. With the current foreground and background colors the covered aliasing pixels along a border line were lighter than the background color. With the darken blending filter they became invisible.

Masking doesn't have such a luxury. Any aliased pixel with not be fully masked out. A solution is to adjust the gamma AGG uses for anti-aliasing. Setting it to 0 for the mask lines makes them fully mask out the aliased pixels. But it does lead to small artifacts at three-way intersections. In my opinion this is not a problem, and maybe even looks good. At these points there would always be small aliasing artifacts anyway, and because a three-way point rarely look perfect because the dashes would have to align just right. Now it looks like one of the dashes ends just before the intersection.

Aliasing issue:
![aliasing](https://user-images.githubusercontent.com/6255050/133574608-9d0f6519-d41d-4224-be14-31b7a178eeaf.png)
With `gamma: 0`:
![aliasing_gamma0](https://user-images.githubusercontent.com/6255050/133568531-a7427fc5-3924-4487-9b74-69d1a617b2fb.png)

### Ferry routes
Ferry routes work around the same problem as admin boundaries: multiple dashed lines that can overlap, but then the dashes may not overlap and cause the line to look solid. The current solution is to draw a background line with the water color. This doesn't look optimal where a ferry route crosses a tunnel. Also it doesn't work with https://github.com/gravitystorm/openstreetmap-carto/pull/4128. I changed them to use the same solution as admin boundaries.

### Advantages
- I am quite happy with how these changes shaved off a quarter of the mss lines related to admin borders.
- Instead of two background lines and a border line for boundaries at `admin_level <= 4`, now only the border line is drawn.
- Basically all hidden complexity around drawing admin boundaries is now gone, such as why `:firstline` was used to draw invisible lines for `admin_level <= 4` and only starting at `zoom >= 8`.
- Masking is a simpler operation than `comp-op: darken`. This helps with my usecase: SVG files generated with Mapnik, which get some further processing before turning them into pdf. Any files with `comp-op` generated by Mapnik are non-standard (='broken'), and have to be fixed by a script. But an SVG with a `comp-op` that does masking is much easier to fix than one that does blending, because masking is a well-supported feature by viewers while blending is not even supported well enough by browsers. This is the first time since https://github.com/gravitystorm/openstreetmap-carto/pull/1107 that I have fully working SVG exports again 🎉.

### Previews
No visible changes to admin boundaries. After:
![1](https://user-images.githubusercontent.com/6255050/133559584-388a755c-1f7a-4668-814c-360c08bf0bbc.png)
![2](https://user-images.githubusercontent.com/6255050/133559575-51c535b0-0d3c-40b2-b626-66312344ed83.png)
![3](https://user-images.githubusercontent.com/6255050/133575608-a1027121-7736-4f2f-91db-82c073e2af4a.png)
![4](https://user-images.githubusercontent.com/6255050/133582696-27db502d-2b38-477e-8b75-8dc8bbd00238.png)

Ferry routes crossing a tunnel before:
![ferry_before](https://user-images.githubusercontent.com/6255050/133576792-d8b118ec-ed80-4da3-b1a9-8e8104d71965.png)
Ferry routes crossing a tunnel after:
![ferry_after](https://user-images.githubusercontent.com/6255050/133576838-1886084a-5f5e-4b0d-969e-e28e70f1a264.png)