### PR TITLE
Make water-lines-casing an attachment of water-lines

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -164,26 +164,6 @@ Layer:
         ) AS icesheet_polygons
     properties:
       minzoom: 5
-  - id: water-lines-casing
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            waterway,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') 
-              OR waterway='canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel
-          FROM planet_osm_line
-          WHERE waterway IN ('stream', 'drain', 'ditch')
-        ) AS water_lines_casing
-    properties:
-      minzoom: 13
   - id: water-lines-low-zoom
     geometry: linestring
     <<: *extents

--- a/style/water.mss
+++ b/style/water.mss
@@ -35,7 +35,22 @@
   }
 }
 
-#water-lines-casing {
+#water-lines-low-zoom {
+  [waterway = 'river'][zoom >= 8][zoom < 12] {
+    [int_intermittent = 'yes'] {
+      line-dasharray: 8,4;
+      line-cap: butt;
+      line-join: round;
+      line-clip: false;
+    }
+    line-color: @water-color;
+    line-width: 0.7;
+    [zoom >= 9] { line-width: 1.2; }
+    [zoom >= 10] { line-width: 1.6; }
+  }
+}
+
+#water-lines::casing {
   [waterway = 'stream'],
   [waterway = 'ditch'],
   [waterway = 'drain'] {
@@ -55,21 +70,6 @@
         }
       }
     }
-  }
-}
-
-#water-lines-low-zoom {
-  [waterway = 'river'][zoom >= 8][zoom < 12] {
-    [int_intermittent = 'yes'] {
-      line-dasharray: 8,4;
-      line-cap: butt;
-      line-join: round;
-      line-clip: false;
-    }
-    line-color: @water-color;
-    line-width: 0.7;
-    [zoom >= 9] { line-width: 1.2; }
-    [zoom >= 10] { line-width: 1.6; }
   }
 }
 


### PR DESCRIPTION
The SQL query of `water-lines-casing` was a subset of the one for `water-lines`, so it is easy to turn it into an attachment to that layer. This removes one small query.

I have checked the generated Mapnik XML, the styles are in the right order now part of `water-lines`. No visual changes.