### PR TITLE
Update pitch color to be less blue

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -63,7 +63,7 @@
 
 // --- Sports ---
 
-@pitch: #bfdfc3;           // Lch(86,18,146) also track
+@pitch: #88e0be;           // Lch(83,35,166) also track
 @track: @pitch;
 @stadium: @leisure; // also sports_centre
 @golf_course: @campsite;

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -63,7 +63,7 @@
 
 // --- Sports ---
 
-@pitch: #aae0cb;           // Lch(85,22,168) also track
+@pitch: #bfdfc3;           // Lch(86,18,146) also track
 @track: @pitch;
 @stadium: @leisure; // also sports_centre
 @golf_course: @campsite;


### PR DESCRIPTION
Fixes #4479 

Change proposed in this pull request:
- Update `@pitch` from `#aae0cb` to `#88e0be`

Test rendering with links to the example places:

Golf course with water hazards
https://www.openstreetmap.org/#map=15/41.5966/-93.6898

z15
![1-z15](https://user-images.githubusercontent.com/1396120/172261626-e6e92fad-8751-430f-b1f5-300b8e241049.png)
z16
![1-z16](https://user-images.githubusercontent.com/1396120/172261637-06252b63-dd99-4d7a-8087-0c14f6ab24c5.png)
z17
![1-z17](https://user-images.githubusercontent.com/1396120/172261644-f4b7f315-0a5c-44a5-8259-4d67400dc09a.png)


Park with pitches and pool
https://www.openstreetmap.org/#map=15/41.5731/-93.7213

z15
![2-z15](https://user-images.githubusercontent.com/1396120/172261678-8b71ea3d-ca1f-4fe4-80af-f708c7e0a1c7.png)
z16
![2-z16](https://user-images.githubusercontent.com/1396120/172261685-35a4cc41-f875-4056-9896-65deb5c39eb8.png)
z17
![2-z17](https://user-images.githubusercontent.com/1396120/172261691-8f829b60-80d5-4c5a-9677-97bb8e3cfeef.png)


School with pitches and sports center, nearby wooded area
https://www.openstreetmap.org/#map=15/41.5982/-93.7211

z15
![3-z15](https://user-images.githubusercontent.com/1396120/172261719-e338ec47-0e5c-4124-8ca3-dcd27326c3ef.png)
z16
![3-z16](https://user-images.githubusercontent.com/1396120/172261731-8dc0af3d-e22d-422e-adf8-b308daa0990e.png)
z17
![3-z17](https://user-images.githubusercontent.com/1396120/172261734-193e51e6-092f-45df-8d59-121b04871dae.png)


Comparison with the rest of the colors in this style
![comparison](https://user-images.githubusercontent.com/1396120/172261782-aee2e323-bdd5-4bfb-a2ce-c2e0c7539239.png)
