### PR TITLE
Potential fix for the issue of missing features in the 'planet_osm_transport_line' table

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -693,6 +693,9 @@ function osm2pgsql.process_way(object)
         if props ~= nil then
             tables.admin:add_row({admin_level = props.level, multiple_relations = (props.parents > 1), geom = { create = 'line' }})
         end
+        if z_order(object.tags) ~= nil then
+            add_transport_line(object.tags)
+        end       
     end
 end
 


### PR DESCRIPTION
Potential fix for the issue raised here https://github.com/gravitystorm/openstreetmap-carto/pull/4431#pullrequestreview-806339969.

This adds code for adding back-in the highway / boundary double tagged features that apparently get deleted from the 'planet_osm_transport_line' when the 'planet_osm_admin' table is filled in stage 2 processing of osm2pgsql.

Fixes # (id of the issue to be closed)

Changes proposed in this pull request:
- 

Test rendering with links to the example places:

Before
https://user-images.githubusercontent.com/7635726/141824056-010887af-ef75-45fd-af35-5e1369334168.png
After
![afbeelding](https://user-images.githubusercontent.com/7635726/142178883-7c0524e1-729a-4cef-b462-ad727b092c5b.png)
