### PR TITLE
Render landuse=education

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -101,7 +101,7 @@ Layer:
               ('landuse_' || (CASE WHEN landuse IN ('quarry', 'vineyard', 'orchard', 'cemetery', 'residential', 'garages', 'meadow', 'grass',
                                                     'allotments', 'forest', 'farmyard', 'farmland', 'greenhouse_horticulture',
                                                     'recreation_ground', 'village_green', 'retail', 'industrial', 'railway', 'commercial',
-                                                    'brownfield', 'landfill', 'salt_pond', 'construction', 'plant_nursery', 'religious') THEN landuse END)) AS landuse,
+                                                    'brownfield', 'landfill', 'salt_pond', 'construction', 'plant_nursery', 'religious', 'education') THEN landuse END)) AS landuse,
               ('shop_' || (CASE WHEN shop IN ('mall') AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL) THEN shop END)) AS shop,
               ('leisure_' || (CASE WHEN leisure IN ('swimming_pool', 'playground', 'park', 'recreation_ground', 'garden',
                                                     'golf_course', 'miniature_golf', 'sports_centre', 'stadium', 'pitch', 'ice_rink',
@@ -1524,7 +1524,7 @@ Layer:
                 'landuse_' || CASE WHEN landuse IN ('reservoir', 'basin', 'recreation_ground', 'village_green', 'quarry', 'vineyard', 'orchard', 'cemetery',
                                                     'residential', 'garages', 'meadow', 'grass', 'allotments', 'forest', 'farmyard', 'farmland',
                                                     'greenhouse_horticulture', 'retail', 'industrial', 'railway', 'commercial', 'brownfield', 'landfill',
-                                                    'construction', 'salt_pond', 'military', 'plant_nursery') THEN landuse END,
+                                                    'construction', 'salt_pond', 'military', 'plant_nursery', 'education') THEN landuse END,
                 'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" END,
                 'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
                                                       'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2175,6 +2175,7 @@
   [feature = 'amenity_school'],
   [feature = 'amenity_college'],
   [feature = 'amenity_university'],
+  [feature = 'landuse_education'],
   [feature = 'landuse_religious'],
   [feature = 'natural_heath'],
   [feature = 'natural_scrub'],
@@ -2286,7 +2287,8 @@
       [feature = 'amenity_kindergarten'],
       [feature = 'amenity_school'],
       [feature = 'amenity_college'],
-      [feature = 'amenity_university'] {
+      [feature = 'amenity_university'],
+      [feature = 'landuse_education'] {
         text-fill: darken(@societal_amenities, 80%);
       }
       [feature = 'landuse_religious'] {

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -582,7 +582,8 @@
   [feature = 'amenity_kindergarten'],
   [feature = 'amenity_community_centre'],
   [feature = 'amenity_social_facility'],
-  [feature = 'amenity_arts_centre'] {
+  [feature = 'amenity_arts_centre'],
+  [feature = 'landuse_education'] {
     [zoom >= 10] {
       polygon-fill: @built-up-lowzoom;
       [way_pixels >= 4]  { polygon-gamma: 0.75; }


### PR DESCRIPTION
Render `landuse=education` the same way as `amenity=school` etc.; this is in line with the stated goals of this tag, and actively stimulates mappers to stop abusing `amenity-school` to force rendering of shared grounds.

Fixes #774

# Before

## 19

![Screenshot from 2022-03-15 19-27-45](https://user-images.githubusercontent.com/683699/158446826-4c0b0403-fc36-4cf7-84b5-9dc295edf6c8.png)


## 17

![Screenshot from 2022-03-15 19-27-39](https://user-images.githubusercontent.com/683699/158446798-fe809d52-965d-4f4d-817f-14a608d36f5d.png)


# After

## 19

![Screenshot from 2022-03-15 19-21-30](https://user-images.githubusercontent.com/683699/158446265-0b579d09-dd67-44de-a91a-377ef68d460b.png)


## 17

![Screenshot from 2022-03-15 19-21-39](https://user-images.githubusercontent.com/683699/158446205-8b166435-7869-410d-ba98-25ceff39b7da.png)

