### PR TITLE
Fix shop=car_repair label/icon colour mismatch (purple)

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1024,7 +1024,6 @@
 
     [shop = 'car_repair'][zoom >= 18] {
       marker-file: url('symbols/shop/car_repair.svg');
-      marker-fill: @amenity-brown;
     }
 
     [shop = 'dairy'][zoom >= 18] {
@@ -2604,9 +2603,6 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: rgba(255, 255, 255, 0.6);
-      [shop = 'car_repair'] {
-        text-fill: @amenity-brown;
-      }
       [shop = 'massage'] {
         text-fill: @leisure-green;
       }


### PR DESCRIPTION
The colour of the icon (purple) and the label (brown) don't match.

This commit makes the label purple to match most other `shop=*` tags.

Fixes #2658

-----

_This is one of two ways to solve this. The other colour choice is shown in #4536. These two PR's are mutually exclusive._

_Either one is probably better than:_ ![nope](https://user-images.githubusercontent.com/683699/164528484-f6b6ff94-59d9-45a2-b479-b0a8c6370cf9.png)


-----

# Before

![17-now](https://user-images.githubusercontent.com/683699/164527921-539fc130-f1fe-412f-9721-0be4cbfb266d.png)

![18-now](https://user-images.githubusercontent.com/683699/164527945-ee4069ab-bcf0-4665-8a6b-776443739c79.png)

# After

![17-purple](https://user-images.githubusercontent.com/683699/164528001-72cdddf6-48af-48b1-8c8b-c6d2da4c0306.png)

![18-purple](https://user-images.githubusercontent.com/683699/164528009-078ef191-d0ff-44f3-aed6-7c829595b750.png)
