### PR TITLE
Fix shop=car_repair label/icon colour mismatch (brown)

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -847,7 +847,7 @@
   }
 
   [feature = 'shop'] {
-    [shop != 'mall'][shop != 'massage'][zoom >= 17],
+    [shop != 'mall'][shop != 'massage'][shop != 'car_repair'][zoom >= 17],
     [shop = 'supermarket'][zoom >= 16],
     [shop = 'department_store'][zoom >= 16] {
       marker-clip: false;
@@ -1022,9 +1022,11 @@
       marker-file: url('symbols/shop/car_parts.svg');
     }
 
-    [shop = 'car_repair'][zoom >= 18] {
-      marker-file: url('symbols/shop/car_repair.svg');
+    [shop = 'car_repair'][zoom >= 17] {
       marker-fill: @amenity-brown;
+      [zoom >= 18] {
+        marker-file: url('symbols/shop/car_repair.svg');
+      }
     }
 
     [shop = 'dairy'][zoom >= 18] {


### PR DESCRIPTION
The colour of the icon (purple) and the label (brown) don't match.

This commit makes the icon brown in line with other service providing
amenities.

Fixes #2658

-----

_This is one of two ways to solve this. The other colour choice is shown in #4535. These two PR's are mutually exclusive._

_Either one is probably better than:_ ![nope](https://user-images.githubusercontent.com/683699/164528484-f6b6ff94-59d9-45a2-b479-b0a8c6370cf9.png)


-----

# Before

![17-now](https://user-images.githubusercontent.com/683699/164527921-539fc130-f1fe-412f-9721-0be4cbfb266d.png)

![18-now](https://user-images.githubusercontent.com/683699/164527945-ee4069ab-bcf0-4665-8a6b-776443739c79.png)

# After

![17-brown](https://user-images.githubusercontent.com/683699/164528151-3331b3ca-2fac-420a-a945-dbf9b2b494ad.png)

![18-brown](https://user-images.githubusercontent.com/683699/164528159-f0e69eaf-b23b-4656-a7d2-b2cbc4bb9e9b.png)

