### PR TITLE
Allow building on ARM64 machines by setting platform: linux/amd64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   kosmtik:
     image: kosmtik:v1
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Set platform:linux/amd64 in docker-compose.yml to allow running with docker on new Apple machines with ARM64 processors.

Without explicitly setting this all docker compose commands including `docker compose up` and `docker compose build kosmtik` fail due to a lack of prebuilt binaries for arm64.

A native image would be more performant but this workaround allows at least allows development on new Apple machines.

Fixes #4538

Changes proposed in this pull request:
- Explicitly set platform: linux/amd64 in docker-compose.yml

Test rendering with links to the example places:

Before

After
