### PR TITLE
Render boundary=protected_area+protect_class=22 (cultural protection)

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1166,7 +1166,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','22')))
             AND building IS NULL
             AND way_area > 1*!pixel_width!::real*!pixel_height!::real
         ) AS protected_areas
@@ -1537,8 +1537,9 @@ Layer:
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway END,
                 'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                          OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
+                'boundary_protected_area_' || CASE WHEN boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','22')
+                                          THEN tags->'protect_class' END,
                 'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END,
                 'tourism_' || CASE WHEN tourism IN ('information') AND tags->'information' IN ('audioguide', 'board', 'guidepost', 'office', 'map', 'tactile_map', 'terminal') THEN tourism END,
                 'office' || CASE WHEN tags->'office' IN ('no', 'vacant', 'closed', 'disused', 'empty') OR (tags->'office') IS NULL THEN NULL ELSE '' END,
@@ -1991,7 +1992,7 @@ Layer:
                                                     'water', 'bay', 'strait') THEN "natural" END,
               'place_' || CASE WHEN place IN ('island') THEN place END,
               'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
-                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
+                                       OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','22'))
                                        THEN boundary END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END
             ) AS feature,
@@ -2005,7 +2006,7 @@ Layer:
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
               OR "place" IN ('island')
               OR boundary IN ('aboriginal_lands', 'national_park')
-              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
+              OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','22'))
               OR leisure IN ('nature_reserve'))
             AND building IS NULL
             AND way_area > 100*POW(!scale_denominator!*0.001*0.28,2)
@@ -2202,7 +2203,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
-                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
+                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','22')))
             AND name IS NOT NULL
         ) AS protected_areas_text
     properties:

--- a/style/admin.mss
+++ b/style/admin.mss
@@ -477,7 +477,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
   text-name: "[name]";
   text-face-name: @book-fonts;
   text-fill: @protected-area;
-  [boundary='aboriginal_lands'] {
+  [boundary='aboriginal_lands'],
+  [boundary='protected_area'][protect_class='22'] {
     text-fill: @aboriginal;
   }
   text-halo-radius: @standard-halo-radius;
@@ -498,7 +499,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
       opacity: 0.25;
       line-width: 1.2;
       line-color: @protected-area;
-      [boundary = 'aboriginal_lands'] {
+      [boundary = 'aboriginal_lands'],
+      [boundary = 'protected_area'][protect_class = '22'] {
         line-color: @aboriginal;
       }
       [zoom >= 9] {
@@ -518,7 +520,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
         // line-offset is always an offset to the inner side of the polygon.
         line-offset: -0.9;
         line-color: @protected-area;
-        [boundary = 'aboriginal_lands'] {
+        [boundary = 'aboriginal_lands'],
+        [boundary = 'protected_area'][protect_class = '22'] {
           line-color: @aboriginal;
         }
         line-join: round;
@@ -537,7 +540,8 @@ Then all three layers are added to the rendering with comp-op: darken, so that t
         opacity: 0.15;
         line-width: 1.8;
         line-color: @protected-area;
-        [boundary = 'aboriginal_lands'] {
+        [boundary = 'aboriginal_lands'],
+        [boundary = 'protected_area'][protect_class = '22'] {
           line-color: @aboriginal;
         }
         line-join: round;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2050,7 +2050,15 @@
   [feature = 'boundary_national_park'],
   [feature = 'leisure_nature_reserve'],
   [feature = 'boundary_aboriginal_lands'],
-  [feature = 'boundary_protected_area'] {
+  [feature = 'boundary_protected_area_1'],
+  [feature = 'boundary_protected_area_1a'],
+  [feature = 'boundary_protected_area_1b'],
+  [feature = 'boundary_protected_area_2'],
+  [feature = 'boundary_protected_area_3'],
+  [feature = 'boundary_protected_area_4'],
+  [feature = 'boundary_protected_area_5'],
+  [feature = 'boundary_protected_area_6']
+  [feature = 'boundary_protected_area_22'] {
     [zoom >= 8][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17] {
       text-name: "[name]";
@@ -2073,7 +2081,8 @@
       [feature = 'landuse_military'] {
         text-fill: darken(@military, 40%);
       }
-      [feature = 'boundary_aboriginal_lands'] {
+      [feature = 'boundary_aboriginal_lands'],
+      [feature = 'boundary_protected_area_22'] {
         text-fill: @aboriginal;
       }
       [feature = 'natural_wood'],
@@ -2082,7 +2091,14 @@
       }
       [feature = 'boundary_national_park'],
       [feature = 'leisure_nature_reserve'],
-      [feature = 'boundary_protected_area'] {
+      [feature = 'boundary_protected_area_1'],
+      [feature = 'boundary_protected_area_1a'],
+      [feature = 'boundary_protected_area_1b'],
+      [feature = 'boundary_protected_area_2'],
+      [feature = 'boundary_protected_area_3'],
+      [feature = 'boundary_protected_area_4'],
+      [feature = 'boundary_protected_area_5'],
+      [feature = 'boundary_protected_area_6'] {
         text-fill: @protected-area;
       }
     }


### PR DESCRIPTION
This adds rendering for boundary=protected_area+protect_class=22, which is used for culturally-protected areas.

It reuses the existing rendering of boundary=aboriginal_lands. Both can be thematically categorised as socially-protected area, so it makes sense to render them identically. They are rendered the same as all variants of naturally-protected areas, but coloured in yellow instead of green.

In the past, this same rendering has also been used for protect_class=24 (politically-protected areas), before it was removed in #4113 to encourage use of clearer and more specific tags like boundary=aboriginal_lands. However, this issue does not apply to protect_class=22, as there are no better alternative tags available to indicate culturally-protected areas. Although the wiki suggests to add historic=* and/or heritage=* to the area, neither actually defines that the reason for its protection is cultural.

Code disclaimer: I have zero experience with this codebase and have no test setup to test the code. If you agree with the proposed rendering change, please check and test the code carefully.