### PR TITLE
Limit dual insertion in Line and Polygon table to "boundary=administrative"

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -704,7 +704,7 @@ function osm2pgsql.process_relation(object)
     if clean_tags(object.tags) then
         return
     end
-    if type == "boundary" or (type == "multipolygon" and object.tags["boundary"]) then
+    if (type == "boundary" or (type == "multipolygon" and object.tags["boundary"])) and object.tags.boundary == 'administrative' then
         add_line(object.tags)
 
         if roads(object.tags) then


### PR DESCRIPTION
Hi Paul, this is a proposal for a minor change to the relation function. 

Currently, if a relation is tagged as either "type=boundary" or "type=multipolygon" with a boundary tag, then the feature will end up as both a geometry in the Line as well as Polygon table. 

While this is the desired behavior for administrative boundary relations to allow sophisticated Line symbology and de-duplication of administrative boundary lines of different "admin_level", other "boundary" relation types like "type=boundary and boundary=protected_area", should likely only end up in the Polygon table, not the Line table, as they usually do not represent contiguous topological connected structures, but are usually "stand-alone".

This change now limits dual insertion in Line and Polygon table to "boundary=administrative" tagged features only.

Fixes # (id of the issue to be closed)

Changes proposed in this pull request:
- 

Test rendering with links to the example places:

Before

After
