### PR TITLE
Explicitly state that revealing a user's identifying information is unwelcome behavior

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,5 +2,4 @@
 
 ### Actual behavior
 
-### Links and screenshots illustrating the problem
-* ''Please provide links to example locations in the map when creating screen shots. If you wish to avoid revealing your location, do not use an example nearby.''
+### Screenshots with links illustrating the problem

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -3,3 +3,4 @@
 ### Actual behavior
 
 ### Links and screenshots illustrating the problem
+* ''Please provide links to example locations in the map when creating screen shots. If you wish to avoid revealing your location, do not use an example nearby.''

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ These actions are explicitly forbidden in OpenStreetMap Carto spaces:
 - Insulting, demeaning, hateful, or threatening remarks.
 - Discrimination based on age, disability, gender, nationality, ethnicity, religion, sexuality, or similar personal characteristic.
 - Bullying or systematic harassment.
-- Posting (or threatening to post) other people’s personally identifying information ("doxxing")
+- Revealing private information about other participants without explicit permission ("doxxing").
 - Unwelcome sexual advances.
 - Incitement to any of these.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,6 +49,7 @@ These actions are explicitly forbidden in OpenStreetMap Carto spaces:
 - Insulting, demeaning, hateful, or threatening remarks.
 - Discrimination based on age, disability, gender, nationality, ethnicity, religion, sexuality, or similar personal characteristic.
 - Bullying or systematic harassment.
+- Revealing private, identifying, or locating information about a user.
 - Unwelcome sexual advances.
 - Incitement to any of these.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ These actions are explicitly forbidden in OpenStreetMap Carto spaces:
 - Insulting, demeaning, hateful, or threatening remarks.
 - Discrimination based on age, disability, gender, nationality, ethnicity, religion, sexuality, or similar personal characteristic.
 - Bullying or systematic harassment.
-- Revealing private, identifying, or locating information about a user.
+- Posting (or threatening to post) other people’s personally identifying information ("doxxing")
 - Unwelcome sexual advances.
 - Incitement to any of these.
 


### PR DESCRIPTION
Fixes #4552

This proposes to explicitly state that revealing identifying information about a user against their wishes is unwelcome behavior on the project.