### PR TITLE
Upgrade URLs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,6 +77,6 @@ Changes to the Code of Conduct should be proposed as pull requests.
 
 ## Acknowledgements
 
-This document is based on the [Go Code of Conduct](https://golang.org/conduct), which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
+This document is based on the [Go Community Code of Conduct](https://go.dev/conduct), which in turn has parts derived from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.
 
 This documented is licensed under the Creative Commons Attribution 3.0 License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ images might not be sufficient and a demo layer is necessary. pnorman has a serv
 
 ## Easy pickings
 
-Some [easy issues](labels/good%20first%20issue) have been selected
+Some [easy issues](https://github.com/gravitystorm/openstreetmap-carto/labels/good%20first%20issue) have been selected
 that are particularly suitable for new contributors to get familiar with the project's code base and the contribution process.
 
 ## Editing layers
 
 OpenStreetMap Carto uses a YAML file for defining layers, because it [works much
-better for big projects](issues/711).
+better for big projects](https://github.com/gravitystorm/openstreetmap-carto/issues/711).
 This requires CartoCSS 0.18.0 or later. If you need JSON MML, you can generate it
 with `python -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < project.mml > project.json`
 or the equivalent in a different language.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ images might not be sufficient and a demo layer is necessary. pnorman has a serv
 
 ## Easy pickings
 
-Some [easy issues](https://github.com/gravitystorm/openstreetmap-carto/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) have been selected
+Some [easy issues](labels/good%20first%20issue) have been selected
 that are particularly suitable for new contributors to get familiar with the project's code base and the contribution process.
 
 ## Editing layers
 
 OpenStreetMap Carto uses a YAML file for defining layers, because it [works much
-better for big projects](https://github.com/gravitystorm/openstreetmap-carto/issues/711).
+better for big projects](issues/711).
 This requires CartoCSS 0.18.0 or later. If you need JSON MML, you can generate it
 with `python -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < project.mml > project.json`
 or the equivalent in a different language.
@@ -148,8 +148,8 @@ Because SQL within JSON or YAML will not generally be syntax highlighted, indent
 ### External icon design resources
 The project's goals and design philsophy are different from other projects, but some external resources with general information about icon design are:
 
-* [Maki Icons Design Guidelines](https://www.mapbox.com/maki-icons/guidelines/)
-* [GNOME Icon Design Guildelines](https://developer.gnome.org/hig/stable/icons-and-artwork.html.en)
+* [Maki Icons Design Guidelines](https://labs.mapbox.com/maki-icons/guidelines/)
+* [GNOME Icon Design Guildelines](https://developer.gnome.org/hig/guidelines/ui-icons.html)
 
 ## Typography
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,13 +1,13 @@
 # Running OpenStreetMap Carto with Docker
 
-[Docker](https://docker.com) is a virtualized environment running a [_Docker demon_](https://docs.docker.com/engine/docker-overview), in which you can run software without altering your host system permanently. The software components run in _containers_ that are easy to setup and tear down individually. The Docker demon can use operating-system-level virtualization (Linux, Windows) or a virtual machine (macOS, Windows).
+[Docker](https://www.docker.com/) is a virtualized environment running a [_Docker demon_](https://docs.docker.com/get-started/overview/), in which you can run software without altering your host system permanently. The software components run in _containers_ that are easy to setup and tear down individually. The Docker demon can use operating-system-level virtualization (Linux, Windows) or a virtual machine (macOS, Windows).
 
 This allows to set up a development environment for OpenStreetMap Carto easily. Specifically, this environment consists of a
 PostgreSQL database to store the OpenStreetMap data and [Kosmtik](https://github.com/kosmtik/kosmtik) for previewing the style.
 
 ## Prerequisites
 
-Docker is available for Linux, macOS and Windows. [Install](https://www.docker.com/get-docker) the software packaged for your host system in order
+Docker is available for Linux, macOS and Windows. [Install](https://www.docker.com/products/docker-desktop/) the software packaged for your host system in order
 to be able to run Docker containers. You also need Docker Compose, which should be available once you installed
 Docker itself. Otherwise you need to [install Docker Compose manually](https://docs.docker.com/compose/install/).
 
@@ -29,7 +29,7 @@ Read on below to get the details.
 
 ## Repositories
 
-Instructions above will clone main OpenStreetMap Carto repository. To test your own changes you should [fork](https://help.github.com/articles/fork-a-repo/) gravitystorm/openstreetmap-carto repository and [clone your fork](https://help.github.com/articles/cloning-a-repository/).
+Instructions above will clone main OpenStreetMap Carto repository. To test your own changes you should [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) gravitystorm/openstreetmap-carto repository and [clone your fork](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 
 This OpenStreetMap Carto repository needs to be a directory that is shared between your host system and the Docker virtual machine. Home directories are shared by default; if your repository is in another place you need to add this to the Docker sharing list (e.g. macOS: Docker Preferences > File Sharing; Windows: Docker Settings > Shared Drives).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,9 @@
 # Installation
 
-This document describes how to manually configure your system for running OpenStreetMap Carto. If you prefer quick, platform independent setup for a development environment, without the need to install and configure tools by hand, follow a Docker installation guide in [DOCKER.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/DOCKER.md).
+This document describes how to manually configure your system for running OpenStreetMap Carto. If you prefer quick, platform independent setup for a development environment, without the need to install and configure tools by hand, follow a Docker installation guide in [DOCKER.md](DOCKER.md).
 
 ## OpenStreetMap data
-You need OpenStreetMap data loaded into a PostGIS database (see below for [dependencies](#dependencies)). These stylesheets expect a database generated with osm2pgsql using the pgsql backend (table names of `planet_osm_point`, etc), the default database name (`gis`), and the [lua transforms](https://github.com/openstreetmap/osm2pgsql/blob/master/docs/lua.md) documented in the instructions below.
+You need OpenStreetMap data loaded into a PostGIS database (see below for [dependencies](#dependencies)). These stylesheets expect a database generated with osm2pgsql using the pgsql backend (table names of `planet_osm_point`, etc), the default database name (`gis`), and the [lua transforms](https://osm2pgsql.org/doc/manual.html#lua-tag-transformations) documented in the instructions below.
 
 Start by creating a database
 
@@ -24,7 +24,7 @@ then grab some OSM data. It's probably easiest to grab an PBF of OSM data from [
 osm2pgsql -G --hstore --style openstreetmap-carto.style --tag-transform-script openstreetmap-carto.lua -d gis ~/path/to/data.osm.pbf
 ```
 
-You can find a more detailed guide to setting up a database and loading data with osm2pgsql at [switch2osm.org](https://switch2osm.org/manually-building-a-tile-server-16-04-2-lts/).
+You can find a more detailed guide to setting up a database and loading data with osm2pgsql at [switch2osm.org](https://switch2osm.org/serving-tiles/manually-building-a-tile-server-16-04-2-lts/).
 
 ### Custom indexes
 Custom indexes are required for rendering performance and are essential on full planet databases.
@@ -65,9 +65,9 @@ On Ubuntu 16.04 or Debian Testing you can download and install most of the requi
 sudo apt-get install fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted fonts-hanazono ttf-unifont
 ```
 
-Noto Emoji Regular (*not* Noto Color Emoji) can be downloaded [from the Noto Emoji repository](https://github.com/googlei18n/noto-emoji).
+Noto Emoji Regular (*not* Noto Color Emoji) can be downloaded [from the Noto Emoji repository](https://github.com/googlefonts/noto-emoji).
 
-It might be useful to have a more recent version of the fonts for [rare non-latin scripts](#non-latin-scripts). The current upstream font release has also some more scripts and style variants than in the Ubuntu package. It can be installed [from source](https://github.com/googlei18n/noto-fonts/blob/master/FAQ.md#where-are-the-fonts).
+It might be useful to have a more recent version of the fonts for [rare non-latin scripts](#non-latin-scripts). The current upstream font release has also some more scripts and style variants than in the Ubuntu package. It can be installed [from source](https://github.com/googlefonts/noto-fonts/blob/master/FAQ.md#where-are-the-fonts).
 
 DejaVu is packaged as `fonts-dejavu-core`.
 
@@ -75,8 +75,8 @@ DejaVu is packaged as `fonts-dejavu-core`.
 
 The fonts can be downloaded here:
 
-* [Noto homepage](https://www.google.com/get/noto/) and [Noto github repositories](https://github.com/googlei18n?utf8=%E2%9C%93&q=noto)
-* [DejaVu homepage](http://dejavu-fonts.org/)
+* [Noto homepage](https://www.google.com/get/noto/) and [Noto github repositories](https://github.com/googlefonts?utf8=%E2%9C%93&q=noto)
+* [DejaVu homepage](https://dejavu-fonts.org/)
 * [Hanazono homepage](http://fonts.jp/hanazono/)
 * [Unifont homepage](http://unifoundry.com/)
 
@@ -101,7 +101,7 @@ To display any map a database containing OpenStreetMap data and some utilities a
 
 * [PostgreSQL](https://www.postgresql.org/)
 * [PostGIS](https://postgis.net/)
-* [osm2pgsql](https://github.com/openstreetmap/osm2pgsql#installing) to [import your data](https://switch2osm.org/loading-osm-data/) into a PostGIS database
+* [osm2pgsql](https://github.com/openstreetmap/osm2pgsql#installing) to [import your data](https://switch2osm.org/serving-tiles/updating-as-people-edit/) into a PostGIS database
 * Python 3 with the psycopg2, yaml, and requests libraries (`python3-psycopg2` `python3-yaml` `python3-requests` packages on Debian-derived systems)
 * `ogr2ogr` for loading shapefiles into the database (`gdal-bin` on Debian-derived systems)
 
@@ -110,7 +110,7 @@ To display any map a database containing OpenStreetMap data and some utilities a
 Some colours, SVGs and other files are generated with helper scripts. Not all users will need these dependencies
 
 * Python and Ruby to run helper scripts
-* [Color Math](https://github.com/gtaylor/python-colormath) and [numpy](http://www.numpy.org/) if running generate_road_colors.py helper script (may be obtained with `pip install colormath numpy`)
+* [Color Math](https://github.com/gtaylor/python-colormath) and [numpy](https://numpy.org/) if running generate_road_colors.py helper script (may be obtained with `pip install colormath numpy`)
 
 ### Additional deployment dependencies
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ to reload their databases, v3.x compatibility is not maintained.
 The v5.x series updates Lua tag transforms, linestring and polygon decisions have changed.
 
 
-There are over [500 open requests](issues), some that have been open for years.
+There are over [500 open requests](https://github.com/gravitystorm/openstreetmap-carto/issues), some that have been open for years.
 These need reviewing and dividing into obvious fixes, or additional new features
 that need some cartographic judgement.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![screenshot](https://raw.github.com/gravitystorm/openstreetmap-carto/master/preview.png)
 
-These are the CartoCSS map stylesheets for the Standard map layer on [OpenStreetMap.org](https://www.openstreetmap.org).
+These are the CartoCSS map stylesheets for the Standard map layer on [OpenStreetMap.org](https://www.openstreetmap.org/).
 
 The general purpose, the cartographic design goals and guidelines for this style are outlined in [CARTOGRAPHY.md](CARTOGRAPHY.md).
 
@@ -10,7 +10,7 @@ These stylesheets can be used in your own cartography projects, and are designed
 to be easily customised. They work with [Kosmtik](https://github.com/kosmtik/kosmtik)
  and also with the command-line [CartoCSS](https://github.com/mapbox/carto) processor.
 
-Since August 2013 these stylesheets have been used on the OSMF tileservers (tile.openstreetmap.org), and
+Since August 2013 these stylesheets have been used on the [OSMF tileservers](https://operations.osmfoundation.org/policies/tiles/) (tile.openstreetmap.org), and
 are updated from each point release. They supersede the previous [XML-based stylesheets](https://github.com/openstreetmap/mapnik-stylesheets).
 
 # Installation
@@ -60,14 +60,11 @@ versions.
 
 Care has been taken to not get too clever with variables and expressions. While
 these often make it easier to customise, experience has shown that over-cleverness
-(e.g. [interpolated entities][cleverness]) can discourage contributions.
-
-[issues]: https://github.com/gravitystorm/openstreetmap-carto/issues
-[cleverness]: https://github.com/openstreetmap/mapnik-stylesheets/blob/master/inc/settings.xml.inc.template#L16
+(e.g. [interpolated entities](https://github.com/openstreetmap/mapnik-stylesheets/blob/master/inc/settings.xml.inc.template#L16)) can discourage contributions.
 
 ## Database schema change (v4.x)
 
-The v4.x series includes [osm2pgsql lua transforms](https://github.com/openstreetmap/osm2pgsql/blob/master/docs/lua.md)
+The v4.x series includes [osm2pgsql lua transforms](https://osm2pgsql.org/doc/manual.html#lua-tag-transformations)
 and a hstore column with all other tags, allowing use of more OpenStreetMap data. Users need
 to reload their databases, v3.x compatibility is not maintained.
 
@@ -76,7 +73,7 @@ to reload their databases, v3.x compatibility is not maintained.
 The v5.x series updates Lua tag transforms, linestring and polygon decisions have changed.
 
 
-There are over [500 open requests][issues], some that have been open for years.
+There are over [500 open requests](issues), some that have been open for years.
 These need reviewing and dividing into obvious fixes, or additional new features
 that need some cartographic judgement.
 
@@ -85,15 +82,15 @@ that need some cartographic judgement.
 There are many open-source stylesheets written for creating OpenStreetMap-based
 maps using Mapnik, many based on this project. Some alternatives are:
 
-* [OSM-Bright](https://github.com/mapbox/osm-bright)
-* [XML-based stylesheets](https://trac.openstreetmap.org/browser/subversion/applications/rendering/mapnik)
-* [osmfr-cartocss](https://github.com/cquest/osmfr-cartocss)
-* [openstreetmap-carto-german](https://github.com/giggls/openstreetmap-carto-de)
+* [OSM Bright](https://github.com/mapbox/osm-bright)
+* [XML-based stylesheets](https://github.com/openstreetmap/mapnik-stylesheets)
+* [OpenStreetMap "FR" Carto](https://github.com/cquest/osmfr-cartocss)
+* [OpenStreetMap Carto German](https://github.com/giggls/openstreetmap-carto-de)
 
 # Maintainers
 
-* Andy Allan [@gravitystorm](https://github.com/gravitystorm/)
-* Paul Norman [@pnorman](https://github.com/pnorman/)
+* Andy Allan [@gravitystorm](https://github.com/gravitystorm)
+* Paul Norman [@pnorman](https://github.com/pnorman)
 * Daniel Koć [@kocio-pl](https://github.com/kocio-pl)
 * Christoph Hormann [@imagico](https://github.com/imagico)
 * Lukas Sommer [@sommerluk](https://github.com/sommerluk)
@@ -102,5 +99,5 @@ maps using Mapnik, many based on this project. Some alternatives are:
 ## Previous maintainers
 
 * Michael Glanznig [@nebulon42](https://github.com/nebulon42)
-* Matthijs Melissen [@matthijsmelissen](https://github.com/matthijsmelissen/)
-* Mateusz Konieczny [@matkoniecz](https://github.com/matkoniecz/)
+* Matthijs Melissen [@matthijsmelissen](https://github.com/matthijsmelissen)
+* Mateusz Konieczny [@matkoniecz](https://github.com/matkoniecz)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ Throughout this document, replace $OLD_VERSION with the previous release and $NE
 
 1. Update your local master branch
 2. Review the changes in git since the last release with a command like `git log --graph $OLD_VERSION...master` or online at https://github.com/gravitystorm/openstreetmap-carto/compare/$OLD_VERSION...master
-3. Review [pull requests](https://github.com/gravitystorm/openstreetmap-carto/pulls) for anything that should be merged before release
+3. Review [pull requests](pulls) for anything that should be merged before release
 4. Check [`preview.png`](preview.png) and update it if needed. Preferred way is to import current Chicago data, export new image (for example from Kosmtik via [this link](http://127.0.0.1:6789/openstreetmap-carto/export/?showExtent=true&format=png&width=849&height=310&scale=1&zoom=15&bounds=-87.65145778656006%2C41.86914537674214%2C-87.61502265930177%2C41.8790515319021)) and upload as new version of this file
 
 Decide among the maintainers if a new release is due.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ Throughout this document, replace $OLD_VERSION with the previous release and $NE
 
 1. Update your local master branch
 2. Review the changes in git since the last release with a command like `git log --graph $OLD_VERSION...master` or online at https://github.com/gravitystorm/openstreetmap-carto/compare/$OLD_VERSION...master
-3. Review [pull requests](pulls) for anything that should be merged before release
+3. Review [pull requests](https://github.com/gravitystorm/openstreetmap-carto/pulls) for anything that should be merged before release
 4. Check [`preview.png`](preview.png) and update it if needed. Preferred way is to import current Chicago data, export new image (for example from Kosmtik via [this link](http://127.0.0.1:6789/openstreetmap-carto/export/?showExtent=true&format=png&width=849&height=310&scale=1&zoom=15&bounds=-87.65145778656006%2C41.86914537674214%2C-87.61502265930177%2C41.8790515319021)) and upload as new version of this file
 
 Decide among the maintainers if a new release is due.


### PR DESCRIPTION
Fixes minor issues with URLs. See commit descriptions for additional notes. furthermore, see #2341 ).

Fixes #4253, though this PR is not focused on changing links in comment lines; can be done seperately (usually unmaintained).

See also
- #2291 (review onboarding in general)
- #2341 (improve workflow link)
- #4323 (improve alternatives)
- /pull/4520 (for Debian update)