### PR TITLE
Use barrier icon for gate fill

### DIFF
--- a/symbols/barrier/gate.svg
+++ b/symbols/barrier/gate.svg
@@ -1,3 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="6" height="5" viewBox="0 0 6 5">
-  <path d="m0,1 h6 v1 h-6 z m0,2 h6 v1 h-6 z m1,2 l3,-5 h1 l-3,5 z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="6"
+   height="5">
+	<path d="M 0,0 6,0 6,5 0,5 z" fill="#ffffff" />
+	<path d="M 0,1 6,1 6,2 0,2 z" fill="#3f3f3f" />
+	<path d="M 0,3 6,3 6,4 0,4 z" fill="#3f3f3f" />
+	<path d="M 4,0 1,5 2,5 5,0 z" fill="#3f3f3f" />
 </svg>


### PR DESCRIPTION
Fixes #4599

#4457 removed the fill from symbols/barrier/gate.svg, which was correct, but there wasn't a marker-fill for this icon in the MSS. This PR adds that.

With PR:
![image](https://user-images.githubusercontent.com/1190866/178666707-1d9c7ead-295b-4a94-9f06-e52d48623ca5.png)

master:
![image](https://user-images.githubusercontent.com/1190866/178666811-88a90d23-4cd5-42c6-afc2-148e0f6f41e9.png)

cc @pitdicker