### PR TITLE
Use indexes for turning circle queries

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -635,8 +635,9 @@ Layer:
           WHERE p.highway IN (
             'turning_circle',
             'turning_loop',
-            'mini_roundabout'
-          )
+            'mini_roundabout')
+            AND l.way && !bbox!
+            AND p.way && !bbox! -- Both conditions are necessary for good index usage, even with the DWithin above
           ORDER BY p.way, v.prio
         ) AS turning_circle_sql
     properties:


### PR DESCRIPTION
While testing I noticed that on zoom 15, the turning circle query is one of the slowest. This change reduces the duration from 20ms to to 1.2ms. The query times were several seconds with cold caches, but that is difficult to benchmark and reproduce.

No rendering changes.