### PR TITLE
Require feature check when checking for mall

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2202,8 +2202,8 @@
   [feature = 'leisure_pitch'] {
     [zoom >= 10][way_pixels > 3000][is_building = 'no'],
     [zoom >= 17][is_building = 'no'],
-    [zoom >= 10][way_pixels > 3000][shop = 'mall'],
-    [zoom >= 17][shop = 'mall'] {
+    [zoom >= 10][way_pixels > 3000][feature = 'shop'][shop = 'mall'],
+    [zoom >= 17][feature = 'shop'][shop = 'mall'] {
       text-name: "[name]";
       text-size: @landcover-font-size;
       text-wrap-width: @landcover-wrap-width-size;


### PR DESCRIPTION
#3759 + previous PRs changed the text-points feature=shop_mall into feature=shop shop=mall. This was done incorrectly in one place where the [feature='shop'] condition was not added, leading to having to check for shop=mall on everything else in the layer, even if it didn't have feature=shop.

This change brings compilation time from 9s to 6.5s and the text-point layer from 2.3s to 1.1s. The total XML decreases from 46670 to 45404 lines.

ref #1941 