### PR TITLE
Runway and taxiway rendering rework

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1032,6 +1032,7 @@ Layer:
         (SELECT
             way,
             aeroway,
+            tags->'runway' AS runway,
             bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct') AS bridge
           FROM planet_osm_line
           WHERE aeroway IN ('runway', 'taxiway')

--- a/project.mml
+++ b/project.mml
@@ -1728,8 +1728,11 @@ Layer:
             aeroway,
             ref
           FROM planet_osm_line
-          WHERE aeroway IN ('runway', 'taxiway')
-            AND ref IS NOT NULL
+          WHERE ref IS NOT NULL
+            AND (aeroway = 'taxiway'
+              OR (aeroway = 'runway'
+                AND NOT tags @> 'runway=>displaced_threshold'
+                AND NOT tags @> 'runway=>blast_pad'))
           ORDER BY CASE aeroway
             WHEN 'runway' THEN 2
             WHEN 'taxiway' THEN 1

--- a/project.mml
+++ b/project.mml
@@ -40,6 +40,7 @@ Stylesheet:
   - style/water-features.mss
   - style/road-colors-generated.mss
   - style/roads.mss
+  - style/aeroways.mss
   - style/power.mss
   - style/placenames.mss
   - style/buildings.mss
@@ -779,8 +780,7 @@ Layer:
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                               AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                               AND (covered NOT IN ('yes') OR covered IS NULL))
-                              THEN railway END)),
-              (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway END))
+                              THEN railway END))
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform', 'services')
@@ -788,7 +788,6 @@ Layer:
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
                 AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
                 AND (covered NOT IN ('yes') OR covered IS NULL))
-            OR aeroway IN ('runway', 'taxiway', 'helipad')
           ORDER BY COALESCE(layer,0), way_area desc
         ) AS highway_area_fill
     properties:
@@ -1010,6 +1009,20 @@ Layer:
         AS entrances
     properties:
       minzoom: 18
+  - id: aeroway-area-fill
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aeroway
+          FROM planet_osm_polygon
+          WHERE aeroway IN ('runway', 'taxiway', 'helipad')
+        ) AS aeroway_area_fill
+    properties:
+      minzoom: 11
   - id: aeroways
     geometry: linestring
     <<: *extents
@@ -1703,6 +1716,28 @@ Layer:
         ) AS power_towers
     properties:
       minzoom: 14
+  - id: aeroway-ref
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aeroway,
+            ref
+          FROM planet_osm_line
+          WHERE aeroway IN ('runway', 'taxiway')
+            AND ref IS NOT NULL
+          ORDER BY CASE aeroway
+            WHEN 'runway' THEN 2
+            WHEN 'taxiway' THEN 1
+            END DESC,
+            ref,
+            osm_id
+        ) AS aeroway_ref
+    properties:
+      minzoom: 15
   - id: roads-text-ref-low-zoom
     geometry: linestring
     <<: *extents
@@ -1773,13 +1808,10 @@ Layer:
                 SELECT
                     osm_id,
                     way,
-                    COALESCE(
-                      CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN highway END,
-                      CASE WHEN aeroway IN ('runway', 'taxiway') THEN aeroway END
-                    ) AS highway,
+                    highway,
                     string_to_array(ref, ';') AS refs
                   FROM planet_osm_line
-                  WHERE (highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') OR aeroway IN ('runway', 'taxiway'))
+                  WHERE highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary')
                     AND ref IS NOT NULL
               ) AS p) AS q
           WHERE height <= 4 AND width <= 11
@@ -1790,8 +1822,6 @@ Layer:
               WHEN highway = 'primary' THEN 36
               WHEN highway = 'secondary' THEN 35
               WHEN highway = 'tertiary' THEN 34
-              WHEN highway = 'runway' THEN 6
-              WHEN highway = 'taxiway' THEN 5
             END DESC NULLS LAST,
             height DESC,
             width DESC,

--- a/project.mml
+++ b/project.mml
@@ -1731,8 +1731,7 @@ Layer:
           WHERE ref IS NOT NULL
             AND (aeroway = 'taxiway'
               OR (aeroway = 'runway'
-                AND NOT tags @> 'runway=>displaced_threshold'
-                AND NOT tags @> 'runway=>blast_pad'))
+                AND NOT tags @> 'runway=>displaced_threshold'))
           ORDER BY CASE aeroway
             WHEN 'runway' THEN 2
             WHEN 'taxiway' THEN 1

--- a/project.mml
+++ b/project.mml
@@ -1019,7 +1019,7 @@ Layer:
             way,
             aeroway
           FROM planet_osm_polygon
-          WHERE aeroway IN ('runway', 'taxiway', 'helipad')
+          WHERE aeroway IN ('helipad')
         ) AS aeroway_area_fill
     properties:
       minzoom: 11

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -1,16 +1,19 @@
-@aeroway-fill: #bbc;
-
+@aeroway-fill: #b1b9c7; // lch(75,8,270)
+@aeroway-center: #dfe3ea; // lch(90,4,270)
+@aeroway-text: #f2f4f7; // lch(96,2,270)
+@aeroway-text-halo: #6c788b; // lch(50,12,270)
 
 #aeroway-ref {
   [aeroway = 'runway'] {
     [zoom >= 15] {
       text-name: "[ref]";
       text-size: 12;
-      text-fill: #333;
-      text-spacing: 750;
+      text-fill: @aeroway-text;
+      text-halo-fill: @aeroway-text-halo;
+      text-spacing: 0;
       text-clip: false;
       text-placement: line;
-      text-face-name: @oblique-fonts;
+      text-face-name: @bold-fonts;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-repeat-distance: @minor-highway-text-repeat-distance;
@@ -24,13 +27,13 @@
     [zoom >= 16] {
       text-name: "[ref]";
       text-size: 10;
-      text-fill: #333;
-      text-spacing: 750;
+      text-fill: @aeroway-text;
+      text-spacing: 0;
       text-clip: false;
       text-placement: line;
-      text-face-name: @oblique-fonts;
+      text-face-name: @bold-fonts;
       text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
+      text-halo-fill: @aeroway-text-halo;
       text-repeat-distance: @minor-highway-text-repeat-distance;
     }
   }
@@ -68,7 +71,7 @@
         [zoom >= 19] { line-width: 68; }
       }
       ::center[runway != 'displaced_threshold'][runway != 'blast_pad'][zoom >= 15] {
-        line-color: #ddd;
+        line-color: @aeroway-center;
         line-width: 1.5;
         line-dasharray: 12,8;
         [zoom >= 16] {
@@ -93,25 +96,25 @@
   [aeroway = 'taxiway'] {
     [zoom >= 11] {
       ::casing[bridge = true][zoom >= 14] {
-        line-width: 4 + 2*@secondary-casing-width-z14;
+        line-width: 3 + 2*@secondary-casing-width-z14;
         line-color: @bridge-casing;
         line-join: round;
-        [zoom >= 15] { line-width: 6 + 2*@secondary-casing-width-z15; }
-        [zoom >= 16] { line-width: 8 + 2*@secondary-casing-width-z16; }
-        [zoom >= 17] { line-width: 11 + 2*@secondary-casing-width-z17; }
-        [zoom >= 18] { line-width: 16 + 2*@secondary-casing-width-z18; }
-        [zoom >= 19] { line-width: 22 + 2*@secondary-casing-width-z19; }
+        [zoom >= 15] { line-width: 4.5 + 2*@secondary-casing-width-z15; }
+        [zoom >= 16] { line-width: 6.8 + 2*@secondary-casing-width-z16; }
+        [zoom >= 17] { line-width: 10.1 + 2*@secondary-casing-width-z17; }
+        [zoom >= 18] { line-width: 15.2 + 2*@secondary-casing-width-z18; }
+        [zoom >= 19] { line-width: 23.8 + 2*@secondary-casing-width-z19; }
       }
       ::fill {
         line-color: @aeroway-fill ;
-        line-width: 1;
+        line-width: 1.3;
         [zoom >= 13] { line-width: 2; }
-        [zoom >= 14] { line-width: 4; }
-        [zoom >= 15] { line-width: 6; }
-        [zoom >= 16] { line-width: 8; }
-        [zoom >= 17] { line-width: 11; }
-        [zoom >= 18] { line-width: 16; }
-        [zoom >= 19] { line-width: 22; }
+        [zoom >= 14] { line-width: 3; }
+        [zoom >= 15] { line-width: 4.5; }
+        [zoom >= 16] { line-width: 6.8; }
+        [zoom >= 17] { line-width: 10.1; }
+        [zoom >= 18] { line-width: 15.2; }
+        [zoom >= 19] { line-width: 23.8; }
       }
     }
   }

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -1,7 +1,7 @@
-@aeroway-fill: #b1b9c7; // lch(75,8,270)
-@aeroway-center: #dfe3ea; // lch(90,4,270)
-@aeroway-text: #f2f4f7; // lch(96,2,270)
-@aeroway-text-halo: #6c788b; // lch(50,12,270)
+@aeroway-fill: #babacb; // lch(76,9,290)
+@aeroway-center: #e2e2e9; // lch(90,4,270)
+@aeroway-text: #f3f3f7; // lch(96,2,270)
+@aeroway-text-halo: #75758a; // lch(50,12,270)
 
 #aeroway-ref {
   [aeroway = 'runway'] {

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -2,9 +2,26 @@
 
 
 #aeroway-ref {
-  [aeroway = 'runway'],
-  [aeroway = 'taxiway'] {
+  [aeroway = 'runway'] {
     [zoom >= 15] {
+      text-name: "[ref]";
+      text-size: 12;
+      text-fill: #333;
+      text-spacing: 750;
+      text-clip: false;
+      text-placement: line;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @minor-highway-text-repeat-distance;
+      [zoom >= 16] { text-size: 18; }
+      [zoom >= 17] { text-size: 24; }
+      [zoom >= 18] { text-size: 32; }
+      [zoom >= 19] { text-size: 40; }
+    }
+  }
+  [aeroway = 'taxiway'] {
+    [zoom >= 16] {
       text-name: "[ref]";
       text-size: 10;
       text-fill: #333;
@@ -29,46 +46,46 @@
   [aeroway = 'runway'] {
     [zoom >= 11] {
       ::casing[bridge = true][zoom >= 14] {
-        line-width: 12 + 2*@major-casing-width-z14;
+        line-width: 9 + 2*@major-casing-width-z14;
         line-color: @bridge-casing;
         line-join: round;
-        [zoom >= 15] { line-width: 18 + 2*@major-casing-width-z15; }
-        [zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }
-        [zoom >= 17] { line-width: 40 + 2*@major-casing-width-z17; }
-        [zoom >= 18] { line-width: 56 + 2*@major-casing-width-z18; }
-        [zoom >= 19] { line-width: 72 + 2*@major-casing-width-z19; }
+        [zoom >= 15] { line-width: 13.5 + 2*@major-casing-width-z15; }
+        [zoom >= 16] { line-width: 20 + 2*@major-casing-width-z16; }
+        [zoom >= 17] { line-width: 30 + 2*@major-casing-width-z17; }
+        [zoom >= 18] { line-width: 46 + 2*@major-casing-width-z18; }
+        [zoom >= 19] { line-width: 68 + 2*@major-casing-width-z19; }
       }
       ::fill {
         line-color: @aeroway-fill;
         line-width: 2;
         [zoom >= 12] { line-width: 4; }
         [zoom >= 13] { line-width: 6; }
-        [zoom >= 14] { line-width: 12; }
-        [zoom >= 15] { line-width: 18; }
-        [zoom >= 16] { line-width: 24; }
-        [zoom >= 17] { line-width: 40; }
-        [zoom >= 18] { line-width: 56; }
-        [zoom >= 19] { line-width: 72; }
+        [zoom >= 14] { line-width: 9; }
+        [zoom >= 15] { line-width: 13.5; }
+        [zoom >= 16] { line-width: 20; }
+        [zoom >= 17] { line-width: 30; }
+        [zoom >= 18] { line-width: 46; }
+        [zoom >= 19] { line-width: 68; }
       }
       ::center[runway != 'displaced_threshold'][runway != 'blast_pad'][zoom >= 15] {
         line-color: #ddd;
         line-width: 1.5;
-        line-dasharray: 18,12;
+        line-dasharray: 12,8;
         [zoom >= 16] {
           line-width: 2;
-          line-dasharray: 24,16;
+          line-dasharray: 21,14;
         }
         [zoom >= 17] {
           line-width: 3.3;
-          line-dasharray: 40,27;
+          line-dasharray: 42,28;
         }
         [zoom >= 18] {
           line-width: 4.5;
-          line-dasharray: 56,37;
+          line-dasharray: 84,56;
         }
         [zoom >= 19] {
           line-width: 6;
-          line-dasharray: 72,48;
+          line-dasharray: 168,112;
         }
       }
     }

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -70,7 +70,7 @@
         [zoom >= 18] { line-width: 46; }
         [zoom >= 19] { line-width: 68; }
       }
-      ::center[runway != 'displaced_threshold'][runway != 'blast_pad'][zoom >= 15] {
+      ::center[runway != 'displaced_threshold'][zoom >= 15] {
         line-color: @aeroway-center;
         line-width: 1.5;
         line-dasharray: 12,8;

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -20,8 +20,6 @@
 }
 
 #aeroway-area-fill {
-  [aeroway = 'runway'][zoom >= 11],
-  [aeroway = 'taxiway'][zoom >= 13],
   [aeroway = 'helipad'][zoom >= 16] {
     polygon-fill: @aeroway-fill;
   }

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -1,0 +1,83 @@
+@aeroway-fill: #bbc;
+@runway-fill: @aeroway-fill;
+@taxiway-fill: @aeroway-fill;
+@helipad-fill: @aeroway-fill;
+
+
+#aeroway-ref {
+  [aeroway = 'runway'],
+  [aeroway = 'taxiway'] {
+    [zoom >= 15] {
+      text-name: "[ref]";
+      text-size: 10;
+      text-fill: #333;
+      text-spacing: 750;
+      text-clip: false;
+      text-placement: line;
+      text-face-name: @oblique-fonts;
+      text-halo-radius: @standard-halo-radius;
+      text-halo-fill: @standard-halo-fill;
+      text-repeat-distance: @minor-highway-text-repeat-distance;
+    }
+  }
+}
+
+#aeroway-area-fill {
+  [aeroway = 'runway'][zoom >= 11] {
+    polygon-fill: @runway-fill;
+  }
+
+  [aeroway = 'taxiway'][zoom >= 13] {
+    polygon-fill: @taxiway-fill;
+  }
+
+  [aeroway = 'helipad'][zoom >= 16] {
+    polygon-fill: @helipad-fill;
+  }
+}
+
+#aeroways {
+  [aeroway = 'runway'] {
+    [zoom >= 11] {
+      ::casing[bridge = true][zoom >= 14] {
+        line-width: 12 + 2*@major-casing-width-z14;
+        line-color: @bridge-casing;
+        line-join: round;
+        [zoom >= 15] { line-width: 18 + 2*@major-casing-width-z15; }
+        [zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }
+        [zoom >= 17] { line-width: 24 + 2*@major-casing-width-z17; }
+        [zoom >= 18] { line-width: 24 + 2*@major-casing-width-z18; }
+      }
+      ::fill {
+        line-color: @runway-fill;
+        line-width: 2;
+        [zoom >= 12] { line-width: 4; }
+        [zoom >= 13] { line-width: 6; }
+        [zoom >= 14] { line-width: 12; }
+        [zoom >= 15] { line-width: 18; }
+        [zoom >= 16] { line-width: 24; }
+      }
+    }
+  }
+  [aeroway = 'taxiway'] {
+    [zoom >= 11] {
+      ::casing[bridge = true][zoom >= 14] {
+        line-width: 4 + 2*@secondary-casing-width-z14;
+        line-color: @bridge-casing;
+        line-join: round;
+        [zoom >= 15] { line-width: 6 + 2*@secondary-casing-width-z15; }
+        [zoom >= 16] { line-width: 8 + 2*@secondary-casing-width-z16; }
+        [zoom >= 17] { line-width: 8 + 2*@secondary-casing-width-z17; }
+        [zoom >= 18] { line-width: 8 + 2*@secondary-casing-width-z18; }
+      }
+      ::fill {
+        line-color: @taxiway-fill ;
+        line-width: 1;
+        [zoom >= 13] { line-width: 2; }
+        [zoom >= 14] { line-width: 4; }
+        [zoom >= 15] { line-width: 6; }
+        [zoom >= 16] { line-width: 8; }
+      }
+    }
+  }
+}

--- a/style/aeroways.mss
+++ b/style/aeroways.mss
@@ -1,7 +1,4 @@
 @aeroway-fill: #bbc;
-@runway-fill: @aeroway-fill;
-@taxiway-fill: @aeroway-fill;
-@helipad-fill: @aeroway-fill;
 
 
 #aeroway-ref {
@@ -23,16 +20,10 @@
 }
 
 #aeroway-area-fill {
-  [aeroway = 'runway'][zoom >= 11] {
-    polygon-fill: @runway-fill;
-  }
-
-  [aeroway = 'taxiway'][zoom >= 13] {
-    polygon-fill: @taxiway-fill;
-  }
-
+  [aeroway = 'runway'][zoom >= 11],
+  [aeroway = 'taxiway'][zoom >= 13],
   [aeroway = 'helipad'][zoom >= 16] {
-    polygon-fill: @helipad-fill;
+    polygon-fill: @aeroway-fill;
   }
 }
 
@@ -45,17 +36,42 @@
         line-join: round;
         [zoom >= 15] { line-width: 18 + 2*@major-casing-width-z15; }
         [zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }
-        [zoom >= 17] { line-width: 24 + 2*@major-casing-width-z17; }
-        [zoom >= 18] { line-width: 24 + 2*@major-casing-width-z18; }
+        [zoom >= 17] { line-width: 40 + 2*@major-casing-width-z17; }
+        [zoom >= 18] { line-width: 56 + 2*@major-casing-width-z18; }
+        [zoom >= 19] { line-width: 72 + 2*@major-casing-width-z19; }
       }
       ::fill {
-        line-color: @runway-fill;
+        line-color: @aeroway-fill;
         line-width: 2;
         [zoom >= 12] { line-width: 4; }
         [zoom >= 13] { line-width: 6; }
         [zoom >= 14] { line-width: 12; }
         [zoom >= 15] { line-width: 18; }
         [zoom >= 16] { line-width: 24; }
+        [zoom >= 17] { line-width: 40; }
+        [zoom >= 18] { line-width: 56; }
+        [zoom >= 19] { line-width: 72; }
+      }
+      ::center[runway != 'displaced_threshold'][runway != 'blast_pad'][zoom >= 15] {
+        line-color: #ddd;
+        line-width: 1.5;
+        line-dasharray: 18,12;
+        [zoom >= 16] {
+          line-width: 2;
+          line-dasharray: 24,16;
+        }
+        [zoom >= 17] {
+          line-width: 3.3;
+          line-dasharray: 40,27;
+        }
+        [zoom >= 18] {
+          line-width: 4.5;
+          line-dasharray: 56,37;
+        }
+        [zoom >= 19] {
+          line-width: 6;
+          line-dasharray: 72,48;
+        }
       }
     }
   }
@@ -67,16 +83,20 @@
         line-join: round;
         [zoom >= 15] { line-width: 6 + 2*@secondary-casing-width-z15; }
         [zoom >= 16] { line-width: 8 + 2*@secondary-casing-width-z16; }
-        [zoom >= 17] { line-width: 8 + 2*@secondary-casing-width-z17; }
-        [zoom >= 18] { line-width: 8 + 2*@secondary-casing-width-z18; }
+        [zoom >= 17] { line-width: 11 + 2*@secondary-casing-width-z17; }
+        [zoom >= 18] { line-width: 16 + 2*@secondary-casing-width-z18; }
+        [zoom >= 19] { line-width: 22 + 2*@secondary-casing-width-z19; }
       }
       ::fill {
-        line-color: @taxiway-fill ;
+        line-color: @aeroway-fill ;
         line-width: 1;
         [zoom >= 13] { line-width: 2; }
         [zoom >= 14] { line-width: 4; }
         [zoom >= 15] { line-width: 6; }
         [zoom >= 16] { line-width: 8; }
+        [zoom >= 17] { line-width: 11; }
+        [zoom >= 18] { line-width: 16; }
+        [zoom >= 19] { line-width: 22; }
       }
     }
   }

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -17,10 +17,6 @@
 @bridleway-fill-noaccess: #aaddaa;
 @track-fill: #996600;
 @track-fill-noaccess: #e2c5bb;
-@aeroway-fill: #bbc;
-@runway-fill: @aeroway-fill;
-@taxiway-fill: @aeroway-fill;
-@helipad-fill: @aeroway-fill;
 @access-marking: #eaeaea;
 @access-marking-living-street: #cccccc;
 
@@ -2728,18 +2724,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       polygon-gamma: 0.65;
     }
   }
-
-  [feature = 'aeroway_runway'][zoom >= 11] {
-    polygon-fill: @runway-fill;
-  }
-
-  [feature = 'aeroway_taxiway'][zoom >= 13] {
-    polygon-fill: @taxiway-fill;
-  }
-
-  [feature = 'aeroway_helipad'][zoom >= 16] {
-    polygon-fill: @helipad-fill;
-  }
 }
 
 #junctions {
@@ -2961,51 +2945,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
   }
 }
 
-#aeroways {
-  [aeroway = 'runway'] {
-    [zoom >= 11] {
-      ::casing[bridge = true][zoom >= 14] {
-        line-width: 12 + 2*@major-casing-width-z14;
-        line-color: @bridge-casing;
-        line-join: round;
-        [zoom >= 15] { line-width: 18 + 2*@major-casing-width-z15; }
-        [zoom >= 16] { line-width: 24 + 2*@major-casing-width-z16; }
-        [zoom >= 17] { line-width: 24 + 2*@major-casing-width-z17; }
-        [zoom >= 18] { line-width: 24 + 2*@major-casing-width-z18; }
-      }
-      ::fill {
-        line-color: @runway-fill;
-        line-width: 2;
-        [zoom >= 12] { line-width: 4; }
-        [zoom >= 13] { line-width: 6; }
-        [zoom >= 14] { line-width: 12; }
-        [zoom >= 15] { line-width: 18; }
-        [zoom >= 16] { line-width: 24; }
-      }
-    }
-  }
-  [aeroway = 'taxiway'] {
-    [zoom >= 11] {
-      ::casing[bridge = true][zoom >= 14] {
-        line-width: 4 + 2*@secondary-casing-width-z14;
-        line-color: @bridge-casing;
-        line-join: round;
-        [zoom >= 15] { line-width: 6 + 2*@secondary-casing-width-z15; }
-        [zoom >= 16] { line-width: 8 + 2*@secondary-casing-width-z16; }
-        [zoom >= 17] { line-width: 8 + 2*@secondary-casing-width-z17; }
-        [zoom >= 18] { line-width: 8 + 2*@secondary-casing-width-z18; }
-      }
-      ::fill {
-        line-color: @taxiway-fill ;
-        line-width: 1;
-        [zoom >= 13] { line-width: 2; }
-        [zoom >= 14] { line-width: 4; }
-        [zoom >= 15] { line-width: 6; }
-        [zoom >= 16] { line-width: 8; }
-      }
-    }
-  }
-}
 
 #roads-text-ref-low-zoom[zoom < 13] {
   [highway = 'motorway'][zoom >= 10],
@@ -3126,21 +3065,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           shield-file: url("symbols/shields/tertiary_[width]x[height]_z18.svg");
         }
       }
-    }
-  }
-  [highway = 'runway'],
-  [highway = 'taxiway'] {
-    [zoom >= 15] {
-      text-name: "[refs]";
-      text-size: 10;
-      text-fill: #333;
-      text-spacing: 750;
-      text-clip: false;
-      text-placement: line;
-      text-face-name: @oblique-fonts;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-repeat-distance: @minor-highway-text-repeat-distance;
     }
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor aeroways to their own layers. Fixes #2169
- Add a dashed centerline to runways
- Scale runway and taxiways past zoom 16
- Stop rendering runway and taxiway areas. Fixes #4340

[zoom 15 YVR](https://www.openstreetmap.org/#map=#15/49.1940/-123.1950)
![image](https://user-images.githubusercontent.com/1190866/179371510-34b4b6aa-964b-44f2-8497-18d791ca3d80.png)

[zoom 17 YNJ](https://www.openstreetmap.org/#map=17/49.10051/-122.62892)
![image](https://user-images.githubusercontent.com/1190866/179371497-74a8d84f-643f-43d3-bb4f-58717fee1db6.png)

[zoom 19 WA07](https://www.openstreetmap.org/#map=19/48.37482/-122.33878)
![image](https://user-images.githubusercontent.com/1190866/179371444-a9df0a87-e817-47d0-9cb3-d0cf58e010c2.png)

[zoom 16 FRA](https://www.openstreetmap.org/#map=16/50.0444/8.5342)
![image](https://user-images.githubusercontent.com/1190866/179371469-c1f02ce7-6517-461c-bad4-2e31404bc174.png)

[zoom 15 SIN](https://www.openstreetmap.org/#map=15/1.3602/103.9856)
![image](https://user-images.githubusercontent.com/1190866/179371624-04d44739-f91c-4fc2-bef9-994bd38576de.png)

cc @jdhoek