### PR TITLE
Improve country label placement by splitting

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1178,13 +1178,20 @@ Layer:
     <<: *extents
     Datasource:
       <<: *osm2pgsql
+      # By splitting MPs into polygons, finding the largest in real area, and
+      # finding a label point in 4326 we get better labeling points. 4326 does
+      # distort the placement, but it does so in a way that results in better
+      # results for most countries.
       table: |-
         (SELECT
-            ST_PointOnSurface(way) AS way,
+            (SELECT ST_Transform(ST_PointOnSurface(geom),3857)
+              FROM ST_Dump(ST_Transform(way,4326))
+              ORDER BY ST_Area(geom::geography) DESC
+              LIMIT 1) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             name
           FROM planet_osm_polygon
-          WHERE ST_PointOnSurface(way) && !bbox!
+          WHERE way && !bbox!
             AND name IS NOT NULL
             AND boundary = 'administrative'
             AND admin_level = '2'


### PR DESCRIPTION
By splitting MPs into polygons, taking the largest, and finding a point in 4326 we get better points for placing labels. 4326 does distort the placement, but it does so in a way that results in better results for most countries.

When monitoring for slow queries, this query does not take significant time compared to other layers. I have some upcoming work that will improve the other queries, as some of them are quite slow on low zoom.

I am making this change for countries only because
- splitting and calculating true area is only different from what st_pointonsurface does if there is a significant north/south difference in the different polygons that make up a MP. In practice, this means only countries are impacted.
- The difference for ST_PointOnSurface between 4326 and 3857 is only significant for large objects. This could in theory impact large bays, but people tend to not have strong opinions on bays, label placement isn't as crucial when the entire area is water, and we're considering removing them from the very low zooms.

Fixes #4241

For the images, left is the tile.osm.org deployment, right is this PR
![image](https://user-images.githubusercontent.com/1190866/180344576-1d0900f0-8c0b-43b4-a43f-971baefddbcb.png)
![image](https://user-images.githubusercontent.com/1190866/180345720-de72a50e-d6af-44c1-b54a-4655745be9c1.png)
![image](https://user-images.githubusercontent.com/1190866/180346025-2ef52e8f-ab96-4b52-b97d-8c4ddf7f9060.png)
![image](https://user-images.githubusercontent.com/1190866/180346453-aa0df8fb-a9d1-494a-a336-6e939ce3a2bb.png)
![image](https://user-images.githubusercontent.com/1190866/180346631-b537fac6-30dd-4bee-beb9-6ff37cd76a78.png)

From my tests, I have a geojson with all the country labels computed this way, because this PR is easiest to test with a full planet import.

[point_4326.zip](https://github.com/gravitystorm/openstreetmap-carto/files/9163902/point_4326.zip)
