### PR TITLE
Add an index for names at low zoom

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -25,6 +25,9 @@ CREATE INDEX planet_osm_polygon_military
 CREATE INDEX planet_osm_polygon_name
   ON planet_osm_polygon USING GIST (ST_PointOnSurface(way))
   WHERE name IS NOT NULL;
+CREATE INDEX planet_osm_polygon_name_z6
+  ON planet_osm_polygon USING GIST (ST_PointOnSurface(way))
+  WHERE name IS NOT NULL AND way_area > 5980000;
 CREATE INDEX planet_osm_polygon_nobuilding
   ON planet_osm_polygon USING GIST (way)
   WHERE building IS NULL;

--- a/indexes.yml
+++ b/indexes.yml
@@ -20,6 +20,9 @@ polygon:
   name:
     function: ST_PointOnSurface(way)
     where: name IS NOT NULL
+  name_z6:
+    function: ST_PointOnSurface(way)
+    where: name IS NOT NULL AND way_area > 5980000
   admin:
     function: ST_PointOnSurface(way)
     where: name IS NOT NULL AND boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4')


### PR DESCRIPTION
One of the slowest queries at zoom 5 is for the text-poly-low-zoom
layer. This index speeds it up, and similar queries up substantially.

No rendering changes.

This index brings a text_poly_low_zoom query down from 120s-31s warm and 6.5s hot to 825ms hot, and improves the experience when developing low zooms.

Index build time on my system is 6:35, and index size is 31MB.