### PR TITLE
Fix get-external-data.py ignoring populated table when --no-update is set

### DIFF
--- a/scripts/get-external-data.py
+++ b/scripts/get-external-data.py
@@ -177,7 +177,9 @@ class Downloader:
         # Variable used to tell if we downloaded something
         download_happened = False
 
-        if os.path.exists(filename) and os.path.exists(filename_lastmod) and opts.no_update:
+        if opts.no_update and (cached_data or table_last_modified):
+            # It is ok if this returns None, because for this to be None, 
+            # we need to have something in table and therefore need not import (since we are opts.no-update)
             result = cached_data
         else:
             if opts.force:


### PR DESCRIPTION
It has been brought to my attention in #4626 that I forgot to implement "table" part of `--no-update` help entry
> Don't download newer data than what is locally available (either in cache or table). Overridden by --force

