### PR TITLE
Restore broken rendering of big water areas on low zoom levels

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -233,7 +233,7 @@ Layer:
         ) AS water_areas
     properties:
       cache-features: true
-      minzoom: 5
+      minzoom: 0
   - id: ocean-lz
     geometry: polygon
     <<: *extents


### PR DESCRIPTION
Fixes #4638

Changes proposed in this pull request:
- The PR #3750 has changed the rendering of _labels_ for big water areas. I didn’t read all the PR comments, but I suppose removing the rendering of the _areas themselves_ was not intentional?? If so, this PR restores the rendering of water bodies on low zoom levels.