### PR TITLE
Remove name rendering for information=board

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1882,15 +1882,18 @@
     text-halo-fill: @standard-halo-fill;
   }
 
-  [feature = 'tourism_information'][zoom >= 19],
-  [feature = 'tourism_information']["information"='office'][zoom >= 17] {
+  [feature = 'tourism_information'][information = 'audioguide'][zoom >= 19],
+  [feature = 'tourism_information'][information = 'guidepost'][zoom >= 19],
+  [feature = 'tourism_information'][information = 'map'][zoom >= 19],
+  [feature = 'tourism_information'][information = 'office'][zoom >= 17]
+  [feature = 'tourism_information'][information = 'tactile_map'][zoom >= 19],
+  [feature = 'tourism_information'][information = 'terminal'][zoom >= 19] {
       text-name: "[name]";
       text-size: @standard-font-size;
       text-wrap-width: @standard-wrap-width;
       text-line-spacing: @standard-line-spacing-size;
       text-fill: darken(black, 30%);
       [information = 'office'] { text-fill: @amenity-brown; }
-      [information = 'board'] { text-name: ''; }
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1890,6 +1890,7 @@
       text-line-spacing: @standard-line-spacing-size;
       text-fill: darken(black, 30%);
       [information = 'office'] { text-fill: @amenity-brown; }
+      [information = 'board'] { text-name: ''; }
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1882,18 +1882,18 @@
     text-halo-fill: @standard-halo-fill;
   }
 
-    [feature = 'tourism_information'][information != 'board'][zoom >= 19],
-    [feature = 'tourism_information'][information = 'office'][zoom >= 17] {
-      text-name: "[name]";
-      text-size: @standard-font-size;
-      text-wrap-width: @standard-wrap-width;
-      text-line-spacing: @standard-line-spacing-size;
-      text-fill: darken(black, 30%);
-      [information = 'office'] { text-fill: @amenity-brown; }
-      text-face-name: @standard-font;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @standard-halo-fill;
-      text-dy: 11;
+  [feature = 'tourism_information'][information != 'board'][zoom >= 19],
+  [feature = 'tourism_information'][information = 'office'][zoom >= 17] {
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    text-fill: darken(black, 30%);
+    [information = 'office'] { text-fill: @amenity-brown; }
+    text-face-name: @standard-font;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-dy: 11;
   }
 
   [feature = 'waterway_waterfall'] {

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1882,12 +1882,8 @@
     text-halo-fill: @standard-halo-fill;
   }
 
-  [feature = 'tourism_information'][information = 'audioguide'][zoom >= 19],
-  [feature = 'tourism_information'][information = 'guidepost'][zoom >= 19],
-  [feature = 'tourism_information'][information = 'map'][zoom >= 19],
-  [feature = 'tourism_information'][information = 'office'][zoom >= 17],
-  [feature = 'tourism_information'][information = 'tactile_map'][zoom >= 19],
-  [feature = 'tourism_information'][information = 'terminal'][zoom >= 19] {
+    [feature = 'tourism_information'][information != 'board'][zoom >= 19],
+    [feature = 'tourism_information'][information = 'office'][zoom >= 17] {
       text-name: "[name]";
       text-size: @standard-font-size;
       text-wrap-width: @standard-wrap-width;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1885,7 +1885,7 @@
   [feature = 'tourism_information'][information = 'audioguide'][zoom >= 19],
   [feature = 'tourism_information'][information = 'guidepost'][zoom >= 19],
   [feature = 'tourism_information'][information = 'map'][zoom >= 19],
-  [feature = 'tourism_information'][information = 'office'][zoom >= 17]
+  [feature = 'tourism_information'][information = 'office'][zoom >= 17],
   [feature = 'tourism_information'][information = 'tactile_map'][zoom >= 19],
   [feature = 'tourism_information'][information = 'terminal'][zoom >= 19] {
       text-name: "[name]";


### PR DESCRIPTION
Fixes #4619

Changes proposed in this pull request:
- Remove  name rendering of `information = board`

Test rendering with links to the example places:
https://www.openstreetmap.org/node/8423226477

**Before**
![download](https://user-images.githubusercontent.com/31376393/184567654-59607fe8-839a-4ce4-9b82-726ce4c0edc7.png)
**After**
![download (1)](https://user-images.githubusercontent.com/31376393/184567665-b733beed-4067-4587-8ee4-e9e9542ba45e.png)

This is my first pull request here, so please forgive me if my method of removing the name is not the preferred way :)