### PR TITLE
Render amenity=lounger

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2214,7 +2214,7 @@ Layer:
             name,
             COALESCE(
               'railway_' || CASE WHEN railway IN ('level_crossing', 'crossing') AND way_area IS NULL THEN railway END,
-              'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
+              'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal', 'lounger') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
@@ -2255,7 +2255,7 @@ Layer:
                 WHERE way && !bbox!
               ) _
             WHERE railway IN ('level_crossing', 'crossing')
-               OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
+               OR amenity IN ('bench', 'waste_basket', 'waste_disposal', 'lounger')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
                OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
@@ -2264,6 +2264,7 @@ Layer:
                 WHEN 'waste_basket' THEN 1
                 WHEN 'waste_disposal' THEN 1
                 WHEN 'bench' THEN 2
+                WHEN 'lounger' THEN 2
                 WHEN NULL THEN 3
               END DESC,
               way_pixels DESC NULLS LAST

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1584,6 +1584,14 @@
     }
   }
 
+  [feature = 'amenity_lounger'][zoom >= 19]::amenity {
+    marker-file: url('symbols/amenity/lounger.svg');
+    marker-fill: @man-made-icon;
+    [access != ''][access != 'permissive'][access != 'yes'] {
+      marker-opacity: 0.33;
+    }
+  }
+
   [feature = 'amenity_waste_basket'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/waste_basket.svg');
     marker-fill: @man-made-icon;

--- a/symbols/amenity/lounger.svg
+++ b/symbols/amenity/lounger.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14" height="14" version="1.1" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+ <path d="m1 7.5c-1 0-1 1.5 0 1.5h12c1 0 1-1.5 0-1.5zm1 2v1.5h1.5v-1.5zm8.5 0v1.5h1.5v-1.5zm-3.5-2c-0.70711 0.70711 0.29289 1.7071 1 1l5-5c0.70711-0.70711-0.29289-1.7071-1-1z"/>
+</svg>


### PR DESCRIPTION
Changes proposed in this pull request:
Render amenity=lounger, right now 3269 uses.
https://taginfo.openstreetmap.org/tags/amenity=lounger#overview
https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dlounger

Test rendering with links to the example places:
https://osm.org/#map=19/52.22657/20.93735
Before
![image](https://user-images.githubusercontent.com/2798728/184616032-fb07b963-2c6a-44b2-8009-1dd6992a9b9c.png)
After
![image](https://user-images.githubusercontent.com/2798728/184616065-d8e0f129-0d56-480b-8103-1732115feabc.png)

Current icon:
![image](https://user-images.githubusercontent.com/2798728/184616166-ce31491f-93cd-4dab-8275-61be12e2a6bb.png)

It is my first icon and I'd appreciate feedback. I modified bench.svg