### PR TITLE
Add elevation rendering to tourism=wilderness_hut

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1475,6 +1475,7 @@ Layer:
                       WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                         AND ("natural" IN ('peak', 'volcano', 'saddle')
                           OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
+                          OR tourism = 'wilderness_hut'
                           OR (amenity = 'shelter' AND tags->'shelter_type' NOT IN ('public_transport', 'picnic_shelter'))
                           OR tags->'mountain_pass' = 'yes')
                       THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,

--- a/project.mml
+++ b/project.mml
@@ -1474,8 +1474,8 @@ Layer:
                     CASE
                       WHEN (tags ? 'ele') AND tags->'ele' ~ '^-?\d{1,4}(\.\d+)?$'
                         AND ("natural" IN ('peak', 'volcano', 'saddle')
-                          OR tourism = 'alpine_hut' OR (tourism = 'information' AND tags->'information' = 'guidepost')
-                          OR tourism = 'wilderness_hut'
+                          OR (tourism = 'information' AND tags->'information' = 'guidepost')
+                          OR tourism IN ('alpine_hut', 'wilderness_hut')
                           OR (amenity = 'shelter' AND tags->'shelter_type' NOT IN ('public_transport', 'picnic_shelter'))
                           OR tags->'mountain_pass' = 'yes')
                       THEN CONCAT(REPLACE(ROUND((tags->'ele')::NUMERIC)::TEXT, '-', U&'\2212'), U&'\00A0', 'm') END,


### PR DESCRIPTION
Fixes #4566 

Changes proposed in this pull request:
- Adds elevation rendering for `tourism = wilderness_hut`

Test rendering with links to the example places:
https://www.openstreetmap.org/way/985409968#map=19/48.49545/-121.20517

**Before**
![download (4)](https://user-images.githubusercontent.com/31376393/184662864-fd11e1cb-29e7-44d6-a206-c2dc9ee85446.png)

**After**
![download (3)](https://user-images.githubusercontent.com/31376393/184662877-54644c40-8a19-4d62-849a-36a6a6b56b0e.png)

