### PR TITLE
Add SRID to postgis datasources

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -29,6 +29,7 @@ _parts:
     dbname: "gis"
     key_field: ""
     geometry_field: "way"
+    srid: "3857"
     extent: "-20037508,-20037508,20037508,20037508"
 
 Stylesheet:

--- a/project.mml
+++ b/project.mml
@@ -22,7 +22,7 @@ _parts:
   # Extents are used for tilemill, and don't actually make it to the generated XML
   extents: &extents
     extent: *world
-    srs-name: "900913"
+    srs-name: "3857"
     srs: "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
   osm2pgsql: &osm2pgsql
     type: "postgis"


### PR DESCRIPTION
This way `mapnik` does not have to make expensive queries at XML loading time just to find the layer's projection. This helps a lot shortening feedback loops while modifying the style and viewing the result in f.i. `kosmtik`.
