### PR TITLE
YAML highlighting on GitHub webpage for CartoCSS MML files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 *.py text eol=lf
 
 # YAML highlighting on GitHub webpage for CartoCSS MML files.
-*.mml linguist-language=YAML
+*.mml linguist-language=YAML linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 *.py text eol=lf
+
+# YAML highlighting on GitHub webpage for CartoCSS MML files.
+*.mml linguist-language=YAML


### PR DESCRIPTION
Changes proposed in this pull request:
- YAML highlighting on GitHub webpage for CartoCSS MML files

It is possible to [force a specific syntax highlighting](https://github.com/github/linguist/blob/master/docs/overrides.md) for specific file types on the GitHub web page. So we can make `*.mml` files, which are currently not highlighted in our repository, get YAML highlighting: `project.mml`

Note that this PR will not have an immediate effect. [Only after the _next_ commit that touches the MML file, the syntax highlighting will be available.](https://webapps.stackexchange.com/questions/31654/force-github-syntax-highlighting-language-on-source-files#comment139871_108676) (I've verified this in my fork before making this PR.)