### PR TITLE
Introduce sac_scale and trail_visibility on highway=path

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -436,6 +436,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
+            int_difficulty,
             access,
             construction,
             service,
@@ -454,6 +455,11 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
+                CASE WHEN (tags->'sac_scale' IN ('demanding_mountain_hiking', 'alpine_hiking', 'demanding_alpine_hiking', 'difficult_alpine_hiking')
+                  OR
+                  tags->'trail_visibility' IN ('intermediate','bad','horrible','no')) THEN 'demanding'
+                  ELSE 'normal'
+                END AS int_difficulty,
                 CASE WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
                 END AS access,
@@ -483,6 +489,7 @@ Layer:
                 bicycle,
                 tracktype,
                 'null',
+                'null',
                 CASE
                   WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
@@ -502,7 +509,8 @@ Layer:
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
+            CASE WHEN int_difficulty IN ('demanding') THEN 0 ELSE 1 END
         ) AS tunnels
     properties:
       cache-features: true
@@ -690,6 +698,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
+            int_difficulty,
             access,
             construction,
             service,
@@ -708,6 +717,11 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
+                CASE WHEN (tags->'sac_scale' IN ('demanding_mountain_hiking', 'alpine_hiking', 'demanding_alpine_hiking', 'difficult_alpine_hiking')
+                  OR
+                  tags->'trail_visibility' IN ('intermediate','bad','horrible','no')) THEN 'demanding'
+                  ELSE 'normal'
+                END AS int_difficulty,
                 CASE WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
                 END AS access,
@@ -745,6 +759,11 @@ Layer:
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                   ELSE NULL
                 END AS int_surface,
+                CASE WHEN (tags->'sac_scale' IN ('demanding_mountain_hiking', 'alpine_hiking', 'demanding_alpine_hiking', 'difficult_alpine_hiking')
+                  OR
+                  tags->'trail_visibility' IN ('intermediate','bad','horrible','no')) THEN 'demanding'
+                  ELSE 'normal'
+                END AS int_difficulty,
                 CASE
                   WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
@@ -768,6 +787,7 @@ Layer:
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
+            CASE WHEN int_difficulty IN ('demanding') THEN 0 ELSE 1 END,
             osm_id
         ) AS roads_sql
     properties:
@@ -923,6 +943,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
+            int_difficulty,
             access,
             construction,
             service,
@@ -941,6 +962,11 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
+                CASE WHEN (tags->'sac_scale' IN ('demanding_mountain_hiking', 'alpine_hiking', 'demanding_alpine_hiking', 'difficult_alpine_hiking')
+                  OR
+                  tags->'trail_visibility' IN ('intermediate','bad','horrible','no')) THEN 'demanding'
+                  ELSE 'normal'
+                END AS int_difficulty,
                 CASE WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
                 END AS access,
@@ -970,6 +996,7 @@ Layer:
                 bicycle,
                 tracktype,
                 'null',
+                'null',
                 CASE
                   WHEN access IN ('destination') THEN 'destination'::text
                   WHEN access IN ('no', 'private') THEN 'no'::text
@@ -989,7 +1016,8 @@ Layer:
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
+            CASE WHEN int_difficulty IN ('demanding') THEN 0 ELSE 1 END
         ) AS bridges
     properties:
       cache-features: true

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2285,10 +2285,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           background/line-join: round;
           background/line-width: @bridleway-width-z15 + 2 * @paths-background-width;
           background/line-opacity: 0.4;
+          [int_difficulty = 'demanding'] {background/line-opacity: 0.1;}
         }
         line/line-color: @bridleway-fill;
         [access = 'no'] { line/line-color: @bridleway-fill-noaccess; }
         line/line-dasharray: 4,2;
+        [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
         line/line-width: @bridleway-width-z13;
         [zoom >= 15] { line/line-width: @bridleway-width-z15; }
         #tunnels {
@@ -2308,6 +2310,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           background/line-join: round;
           background/line-width: @footway-width-z15 + 2 * @paths-background-width;
           background/line-opacity: 0.4;
+          [int_difficulty = 'demanding'] {background/line-opacity: 0.1;}
           [zoom >= 16] {
             background/line-width: @footway-width-z16 + 2 * @paths-background-width;
           }
@@ -2321,18 +2324,22 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line/line-color: @footway-fill;
         [access = 'no'] { line/line-color: @footway-fill-noaccess; }
         line/line-dasharray: 1,3;
+        [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
         line/line-join: round;
         line/line-cap: round;
         line/line-width: @footway-width-z14;
         [zoom >= 15][int_surface = 'paved'] {
           line/line-dasharray: 2,3.5;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-width: @footway-width-z15;
           [zoom >= 16] {
             line/line-dasharray: 3,3.5;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
             line/line-width: @footway-width-z16;
           }
           [zoom >= 17] {
             line/line-dasharray: 3,3;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           }
           [zoom >= 18] {
             line/line-width: @footway-width-z18;
@@ -2345,11 +2352,13 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line/line-color: @footway-fill;
           [access = 'no'] { line/line-color: @footway-fill-noaccess; }
           line/line-dasharray: 1,3,2,4;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-join: round;
           line/line-cap: round;
           line/line-width: @footway-width-z15;
           [zoom >= 16] {
             line/line-dasharray: 1,4,2,3;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
             line/line-width: @footway-width-z16;
           }
           [zoom >= 18] {
@@ -2363,6 +2372,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line/line-color: @footway-fill;
           [access = 'no'] { line/line-color: @footway-fill-noaccess; }
           line/line-dasharray: 1,4;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-join: round;
           line/line-cap: round;
           line/line-width: @footway-width-z15;
@@ -2389,6 +2399,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           background/line-join: round;
           background/line-width: @cycleway-width-z15 + 2 * @paths-background-width;
           background/line-opacity: 0.4;
+          [int_difficulty = 'demanding'] {background/line-opacity: 0.1;}
           [zoom >= 16] {
             background/line-width: @cycleway-width-z16 + 2 * @paths-background-width;
           }
@@ -2402,18 +2413,22 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line/line-color: @cycleway-fill;
         [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
         line/line-dasharray: 1,3;
+        [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
         line/line-join: round;
         line/line-cap: round;
         line/line-width: @cycleway-width-z13;
         [zoom >= 15][int_surface = 'paved'] {
           line/line-dasharray: 2,3.5;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-width: @cycleway-width-z15;
           [zoom >= 16] {
             line/line-dasharray: 3,3.5;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
             line/line-width: @cycleway-width-z16;
           }
           [zoom >= 17] {
             line/line-dasharray: 3,3;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           }
           [zoom >= 18] {
             line/line-width: @cycleway-width-z18;
@@ -2426,11 +2441,13 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line/line-color: @cycleway-fill;
           [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
           line/line-dasharray: 1,3,2,4;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-join: round;
           line/line-cap: round;
           line/line-width: @cycleway-width-z15;
           [zoom >= 16] {
             line/line-dasharray: 1,4,2,3;
+            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
             line/line-width: @cycleway-width-z16;
           }
           [zoom >= 18] {
@@ -2444,6 +2461,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line/line-color: @cycleway-fill;
           [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
           line/line-dasharray: 1,4;
+          [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
           line/line-join: round;
           line/line-cap: round;
           line/line-width:  @cycleway-width-z15;


### PR DESCRIPTION
This is a first step to fix #1500 , attempted to be the least disturbing as possible from the current style. From this, future change can be made and (heavily) discussed, either more elaborate (fine-grain tuning for hikers), or less (don't render at all). 

**Changes proposed in this pull request:**
Introduce tags sac_scale and trail_visibility, and draws an arbitrary limit on what an average walker would expect.
```
                CASE WHEN (tags->'sac_scale' IN ('demanding_mountain_hiking', 'alpine_hiking', 'demanding_alpine_hiking', 'difficult_alpine_hiking')
                  OR
                  tags->'trail_visibility' IN ('intermediate','bad','horrible','no')) THEN 'demanding'
                  ELSE 'normal'
                END AS int_difficulty,
```
The style change is 'naive' and aim at reducing visibility of most 'demanding' path by introducing wide dash and reduced background visibility:
```
          [int_difficulty = 'demanding'] {background/line-opacity: 0.1;}
          ...
            [int_difficulty = 'demanding'] {line/line-dasharray: 1,12;}
```
This style is extended to bridleways and cycleways in order to keep in line with the current stylesheet.

**Test rendering with comparison with surface tags (null, paved, unpaved), bridleway, cycleway, and access=no:**
![demanding_path](https://user-images.githubusercontent.com/506919/190982534-129b8d32-2c13-43b4-a33a-7ab6852d9d59.png)


