### PR TITLE
fix: move tourism-boundary above the road layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -523,22 +523,6 @@ Layer:
         ) AS landuse_overlay
     properties:
       minzoom: 8
-  - id: tourism-boundary
-    geometry: polygon
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            tourism
-          FROM planet_osm_polygon
-          WHERE tourism = 'theme_park'
-            OR tourism = 'zoo'
-        ) AS tourism_boundary
-    properties:
-      minzoom: 10
   - id: barriers
     geometry: linestring
     <<: *extents
@@ -1154,6 +1138,22 @@ Layer:
         ) AS power_line
     properties:
       minzoom: 14
+  - id: tourism-boundary
+    geometry: polygon
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
+            tourism
+          FROM planet_osm_polygon
+          WHERE tourism = 'theme_park'
+            OR tourism = 'zoo'
+        ) AS tourism_boundary
+    properties:
+      minzoom: 10
   - id: protected-areas
     geometry: polygon
     <<: *extents


### PR DESCRIPTION
Fixes #4682

Changes proposed in this pull request:
- move the "tourism-boundary" between "power-line" and "protected-areas" as the function and rendering of protected-areas and tourism-boundary are very similar.

Test rendering with links to the example places:
[Cedar Point](https://www.openstreetmap.org/relation/11491811)

Before
z16
![boundary-before-z16](https://user-images.githubusercontent.com/52704747/192113808-e9cf3b23-05bb-4550-b456-596ebcd9a43a.PNG)
z19
![boundary-before](https://user-images.githubusercontent.com/52704747/192113809-24e05900-508d-4ee0-96cf-dd10651b2953.PNG)

After
z16
![boundary-after-z16](https://user-images.githubusercontent.com/52704747/192113812-74d4b600-8023-4ce1-8020-e376231865e2.PNG)
z19
![boundary-after](https://user-images.githubusercontent.com/52704747/192113811-bc92cf8d-a88c-47ad-9d34-e47cbda4b39b.PNG)

