### PR TITLE
Make text transparent exclusivly when also corresponding icon is made transparent

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2460,7 +2460,7 @@
       [feature = 'highway_bus_stop'] {
         text-dy: 9;
       }
-      [access != ''][access != 'permissive'][access != 'yes'] {
+      [feature = 'amenity_charging_station'][access != ''][access != 'permissive'][access != 'yes'] {
         text-opacity: 0.33;
         text-halo-radius: 0;
       }


### PR DESCRIPTION
Fixes #4571

Test rendering with links to the example places:

https://www.openstreetmap.org/node/4508663884#map=17/50.09751/8.52788
Before:
![grafik](https://user-images.githubusercontent.com/6830724/193402952-56cfffcd-433e-4d89-8e9a-e7ebdd9f26e6.png)
After:
![grafik](https://user-images.githubusercontent.com/6830724/193403123-b717bb3e-d1d4-422a-a73d-abf146339d1e.png)

https://www.openstreetmap.org/node/287007387#map=18/41.63605/2.29384
Before:
![grafik](https://user-images.githubusercontent.com/6830724/193403197-5c8b826b-8bbe-4964-a83a-d508fabe7e97.png)
After:
![grafik](https://user-images.githubusercontent.com/6830724/193403223-99ae45e7-6c53-4334-9543-50a0d1884611.png)

https://www.openstreetmap.org/node/4191051281#map=18/37.48069/-122.16901
Before:
![grafik](https://user-images.githubusercontent.com/6830724/193403266-d9ddceff-5b82-4ef6-ac16-02a513f62702.png)
After:
![grafik](https://user-images.githubusercontent.com/6830724/193403291-b048be22-7e14-4721-b6ff-132142cd0a2f.png)

https://www.openstreetmap.org/node/9048858681#map=17/-10.82673/40.50762
Before:
![grafik](https://user-images.githubusercontent.com/6830724/193403344-7303d3f0-cf84-474a-900a-f4508a77cc12.png)
After:
![grafik](https://user-images.githubusercontent.com/6830724/193403362-39178c14-02ba-47ce-a2e0-c32fb34cbb26.png)
