### PR TITLE
Define feature order in piers-poly and piers-line for consistent rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -356,6 +356,12 @@ Layer:
             way, man_made
           FROM planet_osm_polygon
           WHERE man_made IN ('pier', 'breakwater', 'groyne')
+          ORDER BY CASE
+              WHEN man_made = 'pier' THEN 3
+              WHEN man_made = 'groyne' THEN 2
+              WHEN man_made = 'breakwater' THEN 1
+              ELSE 0
+            END ASC
         ) AS piers_poly
     properties:
       minzoom: 12
@@ -369,6 +375,12 @@ Layer:
             way, man_made
           FROM planet_osm_line
           WHERE man_made IN ('pier', 'breakwater', 'groyne')
+          ORDER BY CASE
+              WHEN man_made = 'pier' THEN 3
+              WHEN man_made = 'groyne' THEN 2
+              WHEN man_made = 'breakwater' THEN 1
+              ELSE 0
+            END ASC
         ) AS piers_line
     properties:
       minzoom: 12


### PR DESCRIPTION
Fixes #4518

Changes proposed in this pull request:
- Define feature order in piers-poly and piers-line for consistent rendering

Test rendering with links to the example places: https://www.openstreetmap.org/#map=19/47.59530/-122.38722
Before: Inconsistent rendering across renderer runs
After: Defined order:
![grafik](https://user-images.githubusercontent.com/6830724/193449790-29742f9a-06e6-46b9-a349-4b964ea3ed63.png)
