### PR TITLE
Add a bash script to allow a user to change the CJK font conveniently

### DIFF
--- a/scripts/change-fonts-cjk.sh
+++ b/scripts/change-fonts-cjk.sh
@@ -2,7 +2,6 @@
 set -e
 
 FONTDIR="./fonts"
-prevcjk=""
 
 mkdir -p "${FONTDIR}"
 
@@ -12,104 +11,35 @@ download() {
   curl --fail --compressed -A "get-fonts.sh/osm-carto" -o "$1" -z "$1" -L "$2" || { echo "Failed to download $1 $2"; rm -f "$1"; exit 1; }
 }
 
-CJKLOCALES="jp
-kr
-tc
-sc
-hk"
-
-echo "--------------------------------------"
-echo -n "1. Japanese (default)"
-if [ -e "./fonts/NotoSansCJKjp-Regular.otf" ]; then
-  echo " [downloaded]"
-  prevcjk=jp
-else
-  echo ""
-fi
-
-echo -n "2. Korean"
-if [ -e "./fonts/NotoSansCJKkr-Regular.otf" ]; then
-  echo " [downloaded]"
-  prevcjk=kr
-else
-  echo ""
-fi
-
-echo -n "3. Simplified Chinese"
-if [ -e "./fonts/NotoSansCJKsc-Regular.otf" ]; then
-  echo " [downloaded]"
-  prevcjk=sc
-else
-  echo ""
-fi
-
-echo -n "4. Traditional Chinese"
-if [ -e "./fonts/NotoSansCJKtc-Regular.otf" ]; then
-  echo " [downloaded]"
-  prevcjk=tc
-else
-  echo ""
-fi
-
-echo -n "5. Traditional Chinese (Hong Kong)"
-if [ -e "./fonts/NotoSansCJKhk-Regular.otf" ]; then
-  echo " [downloaded]"
-  prevcjk=hk
-else
-  echo ""
-fi
-echo "--------------------------------------"
-
-while true; do
-  read -p "Enter which CJK language is prefered above [1-5]: " cjklang
-
-  if [ "$cjklang" = "1" ]; then
-    for font in $CJKLOCALES; do
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
-      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK JP/g" ./style/fonts.mss
-    done
+case "$1" in
+  "JP"|"jp")
     download "${FONTDIR}/NotoSansCJKjp-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf"
     download "${FONTDIR}/NotoSansCJKjp-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf"
-    break
-  elif [ "$cjklang" = "2" ]; then
-    for font in $CJKLOCALES; do
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
-      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK KR/g" ./style/fonts.mss
-    done
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK JP/g" ./style/fonts.mss
+    ;;
+  "KR"|"kr")
     download "${FONTDIR}/NotoSansCJKkr-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"
     download "${FONTDIR}/NotoSansCJKkr-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Bold.otf"
-    break
-  elif [ "$cjklang" = "3" ]; then
-    for font in $CJKLOCALES; do
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
-      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK SC/g" ./style/fonts.mss
-    done
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK KR/g" ./style/fonts.mss
+    ;;
+  "TC"|"tc")
     download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
     download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf"
-    break
-  elif [ "$cjklang" = "4" ]; then
-    for font in $CJKLOCALES; do
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
-      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK TC/g" ./style/fonts.mss
-    done
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK TC/g" ./style/fonts.mss
+    ;;
+  "SC"|"sc")
     download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf"
     download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf"
-    break
-  elif [ "$cjklang" = "5" ]; then
-    for font in $CJKLOCALES; do
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
-      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
-      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK HK/g" ./style/fonts.mss
-    done
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK SC/g" ./style/fonts.mss
+    ;;
+  "HK"|"hk")
     download "${FONTDIR}/NotoSansCJKhk-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Regular.otf"
     download "${FONTDIR}/NotoSansCJKhk-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Bold.otf"
-    break
-  fi
-done
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK HK/g" ./style/fonts.mss
+    ;;
+  *)
+    echo "Usage: change-fonts-cjk.sh jp|kr|sc|tc|hk"
+    ;;
+esac
 
-echo "\nDone."
-echo "Execute 'carto project.mml > mapnik.xml' to apply the change."
+echo "Done."

--- a/scripts/change-fonts-cjk.sh
+++ b/scripts/change-fonts-cjk.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+set -e
+
+FONTDIR="./fonts"
+prevcjk=""
+
+mkdir -p "${FONTDIR}"
+
+# download filename url
+download() {
+  ## Download if newer, and if curl fails, clean up and exit
+  curl --fail --compressed -A "get-fonts.sh/osm-carto" -o "$1" -z "$1" -L "$2" || { echo "Failed to download $1 $2"; rm -f "$1"; exit 1; }
+}
+
+CJKLOCALES="jp
+kr
+tc
+sc
+hk"
+
+echo "--------------------------------------"
+echo -n "1. Japanese (default)"
+if [ -e "./fonts/NotoSansCJKjp-Regular.otf" ]; then
+  echo " [downloaded]"
+  prevcjk=jp
+else
+  echo ""
+fi
+
+echo -n "2. Korean"
+if [ -e "./fonts/NotoSansCJKkr-Regular.otf" ]; then
+  echo " [downloaded]"
+  prevcjk=kr
+else
+  echo ""
+fi
+
+echo -n "3. Simplified Chinese"
+if [ -e "./fonts/NotoSansCJKsc-Regular.otf" ]; then
+  echo " [downloaded]"
+  prevcjk=sc
+else
+  echo ""
+fi
+
+echo -n "4. Traditional Chinese"
+if [ -e "./fonts/NotoSansCJKtc-Regular.otf" ]; then
+  echo " [downloaded]"
+  prevcjk=tc
+else
+  echo ""
+fi
+
+echo -n "5. Traditional Chinese (Hong Kong)"
+if [ -e "./fonts/NotoSansCJKhk-Regular.otf" ]; then
+  echo " [downloaded]"
+  prevcjk=hk
+else
+  echo ""
+fi
+echo "--------------------------------------"
+
+while true; do
+  read -p "Enter which CJK language is prefered above [1-5]: " cjklang
+
+  if [ "$cjklang" = "1" ]; then
+    for font in $CJKLOCALES; do
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
+      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK JP/g" ./style/fonts.mss
+    done
+    download "${FONTDIR}/NotoSansCJKjp-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKjp-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf"
+    break
+  elif [ "$cjklang" = "2" ]; then
+    for font in $CJKLOCALES; do
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
+      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK KR/g" ./style/fonts.mss
+    done
+    download "${FONTDIR}/NotoSansCJKkr-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKkr-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Bold.otf"
+    break
+  elif [ "$cjklang" = "3" ]; then
+    for font in $CJKLOCALES; do
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
+      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK SC/g" ./style/fonts.mss
+    done
+    download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf"
+    break
+  elif [ "$cjklang" = "4" ]; then
+    for font in $CJKLOCALES; do
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
+      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK TC/g" ./style/fonts.mss
+    done
+    download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf"
+    break
+  elif [ "$cjklang" = "5" ]; then
+    for font in $CJKLOCALES; do
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Regular.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Regular.otf"; fi
+      if [ -e "${FONTDIR}/NotoSansCJK${font}-Bold.otf" ]; then rm "${FONTDIR}/NotoSansCJK${font}-Bold.otf"; fi
+      sed -i "s/Noto Sans CJK `echo ${font} | tr [:lower:] [:upper:]`/Noto Sans CJK HK/g" ./style/fonts.mss
+    done
+    download "${FONTDIR}/NotoSansCJKhk-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKhk-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Bold.otf"
+    break
+  fi
+done
+
+echo "\nDone."
+echo "Execute 'carto project.mml > mapnik.xml' to apply the change."

--- a/scripts/change-fonts-cjk.sh
+++ b/scripts/change-fonts-cjk.sh
@@ -23,13 +23,13 @@ case "$1" in
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK KR/g" ./style/fonts.mss
     ;;
   "TC"|"tc")
-    download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
-    download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf"
+    download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKtc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKtc-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK TC/g" ./style/fonts.mss
     ;;
   "SC"|"sc")
-    download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf"
-    download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf"
+    download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKsc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKsc-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK SC/g" ./style/fonts.mss
     ;;
   "HK"|"hk")

--- a/scripts/change-fonts-cjk.sh
+++ b/scripts/change-fonts-cjk.sh
@@ -12,33 +12,33 @@ download() {
 }
 
 case "$1" in
-  "JP"|"jp")
+  ja)
     download "${FONTDIR}/NotoSansCJKjp-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf"
     download "${FONTDIR}/NotoSansCJKjp-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK JP/g" ./style/fonts.mss
     ;;
-  "KR"|"kr")
+  ko)
     download "${FONTDIR}/NotoSansCJKkr-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"
     download "${FONTDIR}/NotoSansCJKkr-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK KR/g" ./style/fonts.mss
     ;;
-  "TC"|"tc")
-    download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKtc-Regular.otf"
-    download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKtc-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK TC/g" ./style/fonts.mss
-    ;;
-  "SC"|"sc")
-    download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKsc-Regular.otf"
-    download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKsc-Bold.otf"
+  zh-[Hh]ans)
+    download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK SC/g" ./style/fonts.mss
     ;;
-  "HK"|"hk")
+  zh-[Hh]ant-[Tt][Ww])
+    download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf"
+    download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf"
+    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK TC/g" ./style/fonts.mss
+    ;;
+  zh-[Hh]ant-[Hh][Kk])
     download "${FONTDIR}/NotoSansCJKhk-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Regular.otf"
     download "${FONTDIR}/NotoSansCJKhk-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Bold.otf"
     sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK HK/g" ./style/fonts.mss
     ;;
   *)
-    echo "Usage: change-fonts-cjk.sh jp|kr|sc|tc|hk"
+    echo "Usage: change-fonts-cjk.sh ja|ko|zh-Hans|zh-Hant-TW|zh-Hant-HK"
     ;;
 esac
 

--- a/scripts/change-fonts-cjk.sh
+++ b/scripts/change-fonts-cjk.sh
@@ -15,30 +15,31 @@ case "$1" in
   ja)
     download "${FONTDIR}/NotoSansCJKjp-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf"
     download "${FONTDIR}/NotoSansCJKjp-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK JP/g" ./style/fonts.mss
+    sed -i "s/Noto Sans CJK \(JP\|KR\|SC\|TC\|HK\)/Noto Sans CJK JP/g" ./style/fonts.mss
     ;;
   ko)
     download "${FONTDIR}/NotoSansCJKkr-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"
     download "${FONTDIR}/NotoSansCJKkr-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK KR/g" ./style/fonts.mss
+    sed -i "s/Noto Sans CJK \(JP\|KR\|SC\|TC\|HK\)/Noto Sans CJK KR/g" ./style/fonts.mss
     ;;
   zh-[Hh]ans)
     download "${FONTDIR}/NotoSansCJKsc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"
     download "${FONTDIR}/NotoSansCJKsc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK SC/g" ./style/fonts.mss
+    sed -i "s/Noto Sans CJK \(JP\|KR\|SC\|TC\|HK\)/Noto Sans CJK SC/g" ./style/fonts.mss
     ;;
   zh-[Hh]ant-[Tt][Ww])
     download "${FONTDIR}/NotoSansCJKtc-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf"
     download "${FONTDIR}/NotoSansCJKtc-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK TC/g" ./style/fonts.mss
+    sed -i "s/Noto Sans CJK \(JP\|KR\|SC\|TC\|HK\)/Noto Sans CJK TC/g" ./style/fonts.mss
     ;;
   zh-[Hh]ant-[Hh][Kk])
     download "${FONTDIR}/NotoSansCJKhk-Regular.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Regular.otf"
     download "${FONTDIR}/NotoSansCJKhk-Bold.otf" "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChineseHK/NotoSansCJKhk-Bold.otf"
-    sed -i "s/Noto Sans CJK (JP|KR|SC|TC|HK)/Noto Sans CJK HK/g" ./style/fonts.mss
+    sed -i "s/Noto Sans CJK \(JP\|KR\|SC\|TC\|HK\)/Noto Sans CJK HK/g" ./style/fonts.mss
     ;;
   *)
     echo "Usage: change-fonts-cjk.sh ja|ko|zh-Hans|zh-Hant-TW|zh-Hant-HK"
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
Changes proposed in this pull request:
- When building an instance for those who use **particular** characters (here, for example, Korean, Chinese, etc.), this script allows a user to automatically download the proper Noto Font, and edit `style/fonts.mss` from "Noto Sans CJK JP" to "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", or "Noto Sans CJK HK". In the case of those who don't want to change the settings (i.e. want to remain "Noto Sans CJK JP"), just do not execute the script. #2208 

- It may be helpful #4547 ...?

Test rendering with links to the example places:
- Only in the case of executing the script, some glyphs of Han scripts changed to forms familiar to those who use specific characters.
