### PR TITLE
Remove limited catch-all for access restricted POI styling

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1588,7 +1588,7 @@ Layer:
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place END,
                 'golf_' || CASE WHEN tags->'golf' IN ('hole', 'pin') THEN tags->'golf' END
               ) AS feature,
-              CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS access,
+              CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
               CASE
                 WHEN "natural" IN ('peak', 'volcano', 'saddle') 
                      OR tags->'mountain_pass' = 'yes' THEN
@@ -2256,7 +2256,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
             )  AS feature,
-            CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS access,
+            CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
             way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
             FROM

--- a/project.mml
+++ b/project.mml
@@ -1581,14 +1581,14 @@ Layer:
                 'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity END,
                 'amenity_' || CASE WHEN amenity IN ('parking_entrance')
                                         AND tags->'parking' IN ('multi-storey', 'underground')
-                                        AND (access IS NULL OR access NOT IN ('private', 'no'))
+                                        AND (access IS NULL OR access NOT IN ('private', 'no', 'customers', 'permit', 'delivery'))
                                         AND way_area IS NULL
                                    THEN amenity END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism END,
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place END,
                 'golf_' || CASE WHEN tags->'golf' IN ('hole', 'pin') THEN tags->'golf' END
               ) AS feature,
-              access,
+              CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS access,
               CASE
                 WHEN "natural" IN ('peak', 'volcano', 'saddle') 
                      OR tags->'mountain_pass' = 'yes' THEN
@@ -2256,7 +2256,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
               'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
             )  AS feature,
-            access,
+            CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS access,
             way_area,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
             FROM

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -58,7 +58,7 @@
     }
     marker-fill: @accommodation-icon;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -129,7 +129,7 @@
     marker-file: url('symbols/amenity/bbq.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -161,7 +161,7 @@
   }
 
   [feature = 'highway_elevator'][zoom >= 18] {
-    [access = 'yes'] {
+    [int_access = 'yes'] {
       marker-file: url('symbols/highway/elevator.svg');
       marker-fill: @transportation-icon;
     }
@@ -321,7 +321,7 @@
     marker-file: url('symbols/amenity/charging_station.svg');
     marker-fill: @transportation-icon;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -348,7 +348,7 @@
     marker-file: url('symbols/amenity/bicycle_repair_station.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -431,7 +431,7 @@
     marker-file: url('symbols/amenity/shower.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -691,7 +691,7 @@
     marker-file: url('symbols/amenity/recycling.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -721,12 +721,12 @@
   }
 
   [feature = 'amenity_toilets'] {
-    [access = 'yes'][zoom >= 18],
+    [int_access = 'yes'][zoom >= 18],
     [zoom >= 19] {
       marker-file: url('symbols/amenity/toilets.svg');
       marker-fill: @amenity-brown;
       marker-clip: false;
-      [access = 'restricted'] {
+      [int_access = 'restricted'] {
         marker-opacity: @private-opacity;
       }
     }
@@ -736,7 +736,7 @@
     marker-file: url('symbols/amenity/drinking_water.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1237,7 +1237,7 @@
     marker-file: url('symbols/leisure/fitness.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1252,7 +1252,7 @@
     marker-file: url('symbols/leisure/playground.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1273,7 +1273,7 @@
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1282,7 +1282,7 @@
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @man-made-icon;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1291,7 +1291,7 @@
     marker-file: url('symbols/leisure/firepit.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1357,8 +1357,8 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' = 'yes']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'restricted'][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['int_access' = 'yes']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
+  [feature = 'aeroway_aerodrome']['int_access' = 'restricted'][zoom >= 12][zoom < 18],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
     [way_pixels <= 192000],
@@ -1457,7 +1457,7 @@
 
   // waste_disposal tagging on ways - tagging on nodes is defined later
   [feature = 'amenity_waste_disposal'][zoom >= 19] {
-    [access = 'yes'] {
+    [int_access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
     }
@@ -1481,7 +1481,7 @@
       [feature = 'amenity_parking_entrance']["parking"='multi-storey'] { marker-file: url('symbols/amenity/parking_entrance_multistorey.svg'); }
       marker-clip: false;
       marker-fill: @transportation-icon;
-      [access = 'restricted'] { marker-opacity: @private-opacity; }
+      [int_access = 'restricted'] { marker-opacity: @private-opacity; }
     }
   }
 }
@@ -1578,7 +1578,7 @@
   [feature = 'amenity_bench'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/bench.svg');
     marker-fill: @man-made-icon;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1586,14 +1586,14 @@
   [feature = 'amenity_waste_basket'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/waste_basket.svg');
     marker-fill: @man-made-icon;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
 
   // waste_disposal tagging on nodes - tagging on ways is defined earlier
   [feature = 'amenity_waste_disposal'][zoom >= 19]::amenity {
-    [access = 'yes'] {
+    [int_access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
     }
@@ -1817,7 +1817,7 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    [access = 'restricted'] {
+    [int_access = 'restricted'] {
       text-opacity: @private-opacity;
       text-halo-radius: 0;
     }
@@ -2058,7 +2058,7 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      [access = 'restricted'] {
+      [int_access = 'restricted'] {
         text-fill: darken(@park, 50%);
       }
     }
@@ -2327,7 +2327,7 @@
       [feature = 'leisure_fitness_centre'],
       [feature = 'leisure_fitness_station'] {
         text-fill: @leisure-green;
-        [access = 'restricted'] {
+        [int_access = 'restricted'] {
           text-opacity: @private-opacity;
           text-halo-radius: 0;
         }
@@ -2421,7 +2421,7 @@
     [feature = 'tourism_alpine_hut'],
     [feature = 'tourism_wilderness_hut'],
     [feature = 'amenity_shelter'] {
-      [access = 'restricted'] {
+      [int_access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }
@@ -2457,7 +2457,7 @@
       [feature = 'highway_bus_stop'] {
         text-dy: 9;
       }
-      [access = 'restricted'] {
+      [int_access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }
@@ -2859,8 +2859,8 @@
     text-halo-fill: @standard-halo-fill;
   }
 
-  [feature = 'aeroway_aerodrome']['access' = 'yes']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'restricted'][zoom >= 13][zoom < 18],
+  [feature = 'aeroway_aerodrome']['int_access' = 'yes']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
+  [feature = 'aeroway_aerodrome']['int_access' = 'restricted'][zoom >= 13][zoom < 18],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 18],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 18] {
     [way_pixels <= 192000],
@@ -2954,7 +2954,7 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      [access = 'restricted'] {
+      [int_access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -58,7 +58,7 @@
     }
     marker-fill: @accommodation-icon;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -129,7 +129,7 @@
     marker-file: url('symbols/amenity/bbq.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -161,7 +161,6 @@
   }
 
   [feature = 'highway_elevator'][zoom >= 18] {
-    [access = null],
     [access = 'yes'] {
       marker-file: url('symbols/highway/elevator.svg');
       marker-fill: @transportation-icon;
@@ -322,7 +321,7 @@
     marker-file: url('symbols/amenity/charging_station.svg');
     marker-fill: @transportation-icon;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -349,7 +348,7 @@
     marker-file: url('symbols/amenity/bicycle_repair_station.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -432,7 +431,7 @@
     marker-file: url('symbols/amenity/shower.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -692,7 +691,7 @@
     marker-file: url('symbols/amenity/recycling.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -727,7 +726,7 @@
       marker-file: url('symbols/amenity/toilets.svg');
       marker-fill: @amenity-brown;
       marker-clip: false;
-      [access != ''][access != 'permissive'][access != 'yes'] {
+      [access = 'restricted'] {
         marker-opacity: @private-opacity;
       }
     }
@@ -737,7 +736,7 @@
     marker-file: url('symbols/amenity/drinking_water.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1238,7 +1237,7 @@
     marker-file: url('symbols/leisure/fitness.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1253,7 +1252,7 @@
     marker-file: url('symbols/leisure/playground.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1274,7 +1273,7 @@
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @leisure-green;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1283,7 +1282,7 @@
     marker-file: url('symbols/tourism/picnic.svg');
     marker-fill: @man-made-icon;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1292,7 +1291,7 @@
     marker-file: url('symbols/leisure/firepit.svg');
     marker-fill: @amenity-brown;
     marker-clip: false;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1358,8 +1357,8 @@
     marker-fill: @airtransport;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 12][zoom < 18],
+  [feature = 'aeroway_aerodrome']['access' = 'yes']['icao' != null]['iata' != null][zoom >= 10][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'restricted'][zoom >= 12][zoom < 18],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 12][zoom < 18],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 12][zoom < 18] {
     [way_pixels <= 192000],
@@ -1458,8 +1457,6 @@
 
   // waste_disposal tagging on ways - tagging on nodes is defined later
   [feature = 'amenity_waste_disposal'][zoom >= 19] {
-    [access = null],
-    [access = 'permissive'],
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
@@ -1484,7 +1481,7 @@
       [feature = 'amenity_parking_entrance']["parking"='multi-storey'] { marker-file: url('symbols/amenity/parking_entrance_multistorey.svg'); }
       marker-clip: false;
       marker-fill: @transportation-icon;
-      [access != ''][access != 'permissive'][access != 'yes'] { marker-opacity: @private-opacity; }
+      [access = 'restricted'] { marker-opacity: @private-opacity; }
     }
   }
 }
@@ -1581,7 +1578,7 @@
   [feature = 'amenity_bench'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/bench.svg');
     marker-fill: @man-made-icon;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
@@ -1589,15 +1586,13 @@
   [feature = 'amenity_waste_basket'][zoom >= 19]::amenity {
     marker-file: url('symbols/amenity/waste_basket.svg');
     marker-fill: @man-made-icon;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       marker-opacity: @private-opacity;
     }
   }
 
   // waste_disposal tagging on nodes - tagging on ways is defined earlier
   [feature = 'amenity_waste_disposal'][zoom >= 19]::amenity {
-    [access = null],
-    [access = 'permissive'],
     [access = 'yes'] {
       marker-file: url('symbols/amenity/waste_disposal.svg');
       marker-fill: @man-made-icon;
@@ -1822,7 +1817,7 @@
     text-face-name: @standard-font;
     text-halo-radius: @standard-halo-radius;
     text-halo-fill: @standard-halo-fill;
-    [access != ''][access != 'permissive'][access != 'yes'] {
+    [access = 'restricted'] {
       text-opacity: @private-opacity;
       text-halo-radius: 0;
     }
@@ -2063,7 +2058,7 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      [access != ''][access != 'permissive'][access != 'yes'] {
+      [access = 'restricted'] {
         text-fill: darken(@park, 50%);
       }
     }
@@ -2332,7 +2327,7 @@
       [feature = 'leisure_fitness_centre'],
       [feature = 'leisure_fitness_station'] {
         text-fill: @leisure-green;
-        [access != ''][access != 'permissive'][access != 'yes'] {
+        [access = 'restricted'] {
           text-opacity: @private-opacity;
           text-halo-radius: 0;
         }
@@ -2426,7 +2421,7 @@
     [feature = 'tourism_alpine_hut'],
     [feature = 'tourism_wilderness_hut'],
     [feature = 'amenity_shelter'] {
-      [access != ''][access != 'permissive'][access != 'yes'] {
+      [access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }
@@ -2462,7 +2457,7 @@
       [feature = 'highway_bus_stop'] {
         text-dy: 9;
       }
-      [feature = 'amenity_charging_station'][access != ''][access != 'permissive'][access != 'yes'] {
+      [access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }
@@ -2864,8 +2859,8 @@
     text-halo-fill: @standard-halo-fill;
   }
 
-  [feature = 'aeroway_aerodrome']['access' != 'private']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
-  [feature = 'aeroway_aerodrome']['access' = 'private'][zoom >= 13][zoom < 18],
+  [feature = 'aeroway_aerodrome']['access' = 'yes']['icao' != null]['iata' != null][zoom >= 11][zoom < 17],
+  [feature = 'aeroway_aerodrome']['access' = 'restricted'][zoom >= 13][zoom < 18],
   [feature = 'aeroway_aerodrome']['icao' = null][zoom >= 13][zoom < 18],
   [feature = 'aeroway_aerodrome']['iata' = null][zoom >= 13][zoom < 18] {
     [way_pixels <= 192000],
@@ -2959,7 +2954,7 @@
       text-face-name: @standard-font;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      [access != ''][access != 'permissive'][access != 'yes'] {
+      [access = 'restricted'] {
         text-opacity: @private-opacity;
         text-halo-radius: 0;
       }


### PR DESCRIPTION
Fixes #4568

Before (`access=foo` is interpreted as restricted):

![access_catchall](https://imagico.de/files/access_catchall.png)

After (`access=foo` is ignored):

![access_nocatchall](https://imagico.de/files/access_nocatchall.png)

This removes the only limited catch-all interpretation on secondary tags in this style (that is the only case where we render all values with a certain key in a special styling variant except for some specific values -  `yes` and `permissive` in this case).  Beyond the problematic mapper feedback this creates a special difficulty when analyzing which tags the style interprets, because it interprets an indefinite number of access values, but not all.

The list of values to be interpreted as restricted is based on the values commonly used on POI features.  See [here](https://taginfo.openstreetmap.org/keys/access?filter=nodes#values) for a more extensive list of values but note that most of these are used on barrier features - which we don't style based on access tagging.

I did not change anything about which POI types get dedicated rendering with a restricted access tag - there is definitely need to re-evaluate that though.  Interpretation of `access=customers` should probably also be considered depending on the type of POI (see #4568)