### PR TITLE
Fix osm2pgsql index statement creation

### DIFF
--- a/scripts/indexes.py
+++ b/scripts/indexes.py
@@ -37,10 +37,10 @@ def parse(index_function):
 
 # The same as parse, but for osm2pgsql-built indexes
 def osm2pgsql_parse(index_function):
-    print(index_function('point', 'index', None, None), end=separator)
-    print(index_function('line', 'index', None, None), end=separator)
-    print(index_function('polygon', 'index', None, None), end=separator)
-    print(index_function('roads', 'index', None, None), end=separator)
+    print(index_function('point', 'way_idx', 'way', None), end=separator)
+    print(index_function('line', 'way_idx', 'way', None), end=separator)
+    print(index_function('polygon', 'way_idx', 'way', None), end=separator)
+    print(index_function('roads', 'way_idx', 'way', None), end=separator)
 
 def generate_statement(table, name, function, where):
     return index_statement(table, name, function, where, args.concurrent, args.notexist, args.fillfactor)


### PR DESCRIPTION
Fix osm2pgsql index statement creation

Currently, indexes.py creates syntactically wrong `CREATE INDEX` statements for osm2pgsql indexes (using the `--osm2pgsql` option). This is because the target field for the index is specified as `None` (should be `'way'`):
``` SQL
CREATE INDEX planet_osm_point_index ON planet_osm_point USING GIST (None);
```
Additionally, osm2pgsql creates _unnamed_ indexes and so lets the database chooses a meaningful name, which results in `<table_name>_way_idx`. Since re-indexing won't work with unnamed indexes, indexes.py must use a defined index name. However, I recommend using `'way_idx'` as the index name for osm2pgsql indexes (instead of `'index'`) in order to be in line with osm2pgsql.
``` SQL
CREATE INDEX planet_osm_point_way_idx ON planet_osm_point USING GIST (way);
```
I've modified indexes.py so that it's emitting `CREATE INDEX` statements of the second type (named `'way_idx'` and using `'way'` as the target field). If you actually prefer a different index name, feel free to modify my changes after merging. 

Changes proposed in this pull request:
- specify 'way' as the target field for osm2pgsql indexes
- rename osm2pgsql indexes to '<table_name>_way_idx' (as created by osm2pgsql)

Test rendering with links to the example places:
- no impact on rendering