### PR TITLE
Remove virtual border lines on the antimeridian

### DIFF
--- a/openstreetmap-carto.lua
+++ b/openstreetmap-carto.lua
@@ -696,7 +696,7 @@ end
 function osm2pgsql.process_way(object)
     if osm2pgsql.stage == 2 then
         -- Stage two processing is called on ways that are part of admin boundary relations
-        if phase2_admin_ways_level[object.id] then
+        if object.tags.closure_segment ~= 'yes' and phase2_admin_ways_level[object.id] then
             tables.admin:add_row({admin_level = phase2_admin_ways_level[object.id],
                                   multiple_relations = (phase2_admin_ways_parents[object.id] > 1),
                                   way = { create = 'line' }})

--- a/scripts/lua/test.lua
+++ b/scripts/lua/test.lua
@@ -487,7 +487,7 @@ table_contents.planet_osm_transport_polygon = {}
 
 --[[
     This sets up an
-    1. admin_level=2 relation with ways 1, 2, 3, 5, 7, 8, 9
+    1. admin_level=2 relation with ways 1, 2, 3, 5, 7, 8, 9, 10
     2. admin_level=2 relation with ways 1, 2, 6, 7, 8
     3. admin_level=4 relation with ways 1, 3, 4
 
@@ -505,7 +505,8 @@ local test_ways = {
     { id = 6, tags = { boundary = "administrative", admin_level = "2"} },
     { id = 7, tags = { boundary = "administrative", admin_level = "3"} }, -- incorrect tags
     { id = 8, tags = { } }, -- incorrect tags
-    { id = 9, tags = { boundary = "administrative", admin_level = "2", highway = "road"} }
+    { id = 9, tags = { boundary = "administrative", admin_level = "2", highway = "road"} },
+    { id = 10, tags = { boundary = "administrative", admin_level = "2", closure_segment = "yes"} } -- closure segments are used on the antimeridian
 }
 -- add another way that isn't part of a relation
 local test_relations = {
@@ -517,7 +518,8 @@ local test_relations = {
                   {type = 'w', ref = 5, role = "outer"},
                   {type = 'w', ref = 7, role = "outer"},
                   {type = 'w', ref = 8, role = "outer"},
-                  {type = 'w', ref = 9, role = "outer"} } },
+                  {type = 'w', ref = 9, role = "outer"}
+                  {type = 'w', ref = 10, role = "outer"} } },
     { id = 2, tags = {type = "boundary", boundary = "administrative", admin_level = "2"},
       members = { {type = 'w', ref = 1, role = "outer"},
                   {type = 'w', ref = 2, role = "outer"},


### PR DESCRIPTION
Remove "virtual" border lines on the antimeridian by excluding all features tagged as closure segment.

Fixes #3504

Changes proposed in this pull request:
Remove virtual borders on the antimeridian by making use of the enhanced capabilities of osm2pgsql 'flex output' and associated LUA configuration.

Test rendering with links to the example places:

Before
[#3504 (comment)](https://github.com/gravitystorm/openstreetmap-carto/issues/3504#issue-379292094)
After
[#3504 (comment)](https://github.com/gravitystorm/openstreetmap-carto/issues/3504#issuecomment-1268260068)
