### PR TITLE
Unpaved rendering for turning circles

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -611,8 +611,14 @@ Layer:
       <<: *osm2pgsql
       table: &turning-circle_sql |-
         (SELECT DISTINCT ON (p.way)
-            p.way AS way,
+            -- Valid line geometry requires at least two points that are NOT identical, therefore moving them slightly.
+            ST_MakeLine(ST_Translate(p.way, -0.0001, -0.0001), ST_Translate(p.way, 0.0001, 0.0001)) AS way,
             p.highway AS type,
+            CASE WHEN l.surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                    'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
+              WHEN l.surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
+                                    'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
+            END AS int_surface,
             l.highway AS int_tc_type,
             CASE WHEN l.service IN ('parking_aisle', 'drive-through', 'driveway')
               THEN 'INT-minor'::text
@@ -638,7 +644,11 @@ Layer:
             'mini_roundabout')
             AND l.way && !bbox!
             AND p.way && !bbox! -- Both conditions are necessary for good index usage, even with the DWithin above
-          ORDER BY p.way, v.prio
+          ORDER BY
+            p.way,
+            v.prio,
+            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END DESC
         ) AS turning_circle_sql
     properties:
       minzoom: 15

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2946,7 +2946,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #turning-circle-fill {
-  [int_tc_type = 'primary'][zoom >= 15] {
+  [int_tc_type = 'primary'][zoom >= 15][int_surface != 'unpaved'] {
     marker-fill: @primary-fill;
     marker-width: @primary-width-z15 * 1.6;
     marker-height: @primary-width-z15 * 1.6;
@@ -2966,8 +2966,25 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
   }
+  [int_tc_type = 'primary'][zoom >= 15][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @primary-width-z15 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_primary-fill.svg");
+    [zoom >= 17] {
+      line-pattern-width: @primary-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      line-pattern-width: @primary-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      line-pattern-width: @primary-width-z19 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
+  }
 
-  [int_tc_type = 'secondary'][zoom >= 15] {
+  [int_tc_type = 'secondary'][zoom >= 15][int_surface != 'unpaved'] {
     marker-fill: @secondary-fill;
     marker-width: @secondary-width-z15 * 1.6;
     marker-height: @secondary-width-z15 * 1.6;
@@ -2991,8 +3008,28 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
   }
+  [int_tc_type = 'secondary'][zoom >= 15][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @secondary-width-z15 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_secondary-fill.svg");
+    [zoom >= 16] {
+      line-pattern-width: @secondary-width-z16 * 1.6;
+    }
+    [zoom >= 17] {
+      line-pattern-width: @secondary-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      line-pattern-width: @secondary-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      line-pattern-width: @secondary-width-z19 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
+  }
 
-  [int_tc_type = 'tertiary'][zoom >= 15] {
+  [int_tc_type = 'tertiary'][zoom >= 15][int_surface != 'unpaved'] {
     marker-fill: @tertiary-fill;
     marker-width: @tertiary-width-z15 * 1.6;
     marker-height: @tertiary-width-z15 * 1.6;
@@ -3016,9 +3053,29 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
   }
+  [int_tc_type = 'tertiary'][zoom >= 15][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @tertiary-width-z15 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
+    [zoom >= 16] {
+      line-pattern-width: @tertiary-width-z16 * 1.6;
+    }
+    [zoom >= 17] {
+      line-pattern-width: @tertiary-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      line-pattern-width: @tertiary-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      line-pattern-width: @tertiary-width-z19 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
+  }
 
-  [int_tc_type = 'residential'],
-  [int_tc_type = 'unclassified'] {
+  [int_tc_type = 'residential'][int_surface != 'unpaved'],
+  [int_tc_type = 'unclassified'][int_surface != 'unpaved'] {
     [zoom >= 15] {
       marker-fill: @residential-fill;
       marker-width: @residential-width-z15 * 1.6;
@@ -3044,8 +3101,31 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       marker-line-width: 0;
     }
   }
+  [int_tc_type = 'residential'][int_surface = 'unpaved'],
+  [int_tc_type = 'unclassified'][int_surface = 'unpaved'] {
+    [zoom >= 15] {
+      line-pattern-type: repeat;
+      line-pattern-alignment: global;
+      line-pattern-width: @residential-width-z15 * 1.6;
+      line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
+      [zoom >= 16] {
+        line-pattern-width: @residential-width-z16 * 1.6;
+      }
+      [zoom >= 17] {
+        line-pattern-width: @residential-width-z17 * 1.6;
+      }
+      [zoom >= 18] {
+        line-pattern-width: @residential-width-z18 * 1.6;
+      }
+      [zoom >= 19] {
+        line-pattern-width: @residential-width-z19 * 1.6;
+      }
+      line-pattern-cap: round;
+      line-pattern-join: round;
+    }
+  }
 
-  [int_tc_type = 'living_street'][zoom >= 15] {
+  [int_tc_type = 'living_street'][zoom >= 15][int_surface != 'unpaved'] {
     marker-fill: @living-street-fill;
     marker-width: @living-street-width-z15 * 1.6;
     marker-height: @living-street-width-z15 * 1.6;
@@ -3069,8 +3149,28 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
   }
+  [int_tc_type = 'living_street'][zoom >= 15][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @living-street-width-z15 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_living-street-fill.svg");
+    [zoom >= 16] {
+      line-pattern-width: @living-street-width-z16 * 1.6;
+    }
+    [zoom >= 17] {
+      line-pattern-width: @living-street-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      line-pattern-width: @living-street-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      line-pattern-width: @living-street-width-z19 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
+  }
 
-  [int_tc_type = 'service'][int_tc_service = 'INT-normal'][zoom >= 16] {
+  [int_tc_type = 'service'][int_tc_service = 'INT-normal'][zoom >= 16][int_surface != 'unpaved'] {
     marker-fill: @service-fill;
     marker-width: @service-width-z16 * 1.6;
     marker-height: @service-width-z16 * 1.6;
@@ -3094,8 +3194,28 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
   }
+  [int_tc_type = 'service'][int_tc_service = 'INT-normal'][zoom >= 16][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @service-width-z16 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
+    [zoom >= 17] {
+      line-pattern-width: @service-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      line-pattern-width: @service-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      line-pattern-width: @service-width-z19 * 1.6;
+    }
+    [zoom >= 20] {
+      line-pattern-width: @service-width-z20 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
+  }
 
-  [int_tc_type = 'service'][int_tc_service = 'INT-minor'][zoom >= 18] {
+  [int_tc_type = 'service'][int_tc_service = 'INT-minor'][zoom >= 18][int_surface != 'unpaved'] {
     marker-fill: @service-fill;
     marker-width: @minor-service-width-z18 * 1.6;
     marker-height: @minor-service-width-z18 * 1.6;
@@ -3110,6 +3230,20 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-allow-overlap: true;
     marker-ignore-placement: true;
     marker-line-width: 0;
+  }
+  [int_tc_type = 'service'][int_tc_service = 'INT-minor'][zoom >= 18][int_surface = 'unpaved'] {
+    line-pattern-type: repeat;
+    line-pattern-alignment: global;
+    line-pattern-width: @minor-service-width-z18 * 1.6;
+    line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
+    [zoom >= 19] {
+      line-pattern-width: @minor-service-width-z19 * 1.6;
+    }
+    [zoom >= 20] {
+      line-pattern-width: @minor-service-width-z20 * 1.6;
+    }
+    line-pattern-cap: round;
+    line-pattern-join: round;
   }
 
   [int_tc_type = 'track'][zoom >= 15] {


### PR DESCRIPTION
Changes proposed in this pull request:
- Currently, unpaved turning circles are rendered as if they were paved. This PR renders them actually as unpaved. 

Test rendering with links to the example places:
https://www.openstreetmap.org/#map=19/6.53649/2.40256

Before
![before](https://user-images.githubusercontent.com/6830724/213431923-86ad7b93-5b07-48c2-9cf2-bbea5ce38d16.png)

After
![after](https://user-images.githubusercontent.com/6830724/213431946-7a22977d-cf3b-4446-b1d0-bc1d074a29c8.png)
