### PR TITLE
Implement issue 2288 (render natural=earth_bank)

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -585,7 +585,7 @@ Layer:
         (SELECT
             way, "natural", man_made
           FROM planet_osm_line
-          WHERE "natural" IN ('arete', 'cliff', 'ridge') OR man_made = 'embankment'
+          WHERE "natural" IN ('arete', 'cliff', 'ridge', 'earth_bank') OR man_made = 'embankment'
         ) AS cliffs
     properties:
       cache-features: true
@@ -2073,7 +2073,7 @@ Layer:
               OR aerialway IN ('cable_car', 'gondola', 'mixed_lift', 'goods', 'chair_lift', 'drag_lift', 't-bar', 'j-bar', 'platter', 'rope_tow', 'zip_line')
               OR leisure IN ('slipway', 'track')
               OR waterway IN ('dam', 'weir')
-              OR "natural" IN ('arete', 'cliff', 'ridge'))
+              OR "natural" IN ('arete', 'cliff', 'ridge', 'earth_bank'))
             AND name IS NOT NULL)
             OR (tags @> 'golf=>hole' AND ref IS NOT NULL)
         ) AS text_line

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -856,6 +856,9 @@
   [man_made = 'embankment'][zoom >= 15]::man_made {
     line-pattern-file: url('symbols/embankment.svg');
   }
+  [natural = 'earth_bank'][zoom >= 14] {
+    line-pattern-file: url('symbols/earth_bank.svg');
+  }  
 }
 
 #barriers {

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -853,12 +853,12 @@
       line-pattern-file: url('symbols/arete2.svg');
     }
   }
-  [man_made = 'embankment'][zoom >= 15]::man_made {
-    line-pattern-file: url('symbols/embankment.svg');
-  }
   [natural = 'earth_bank'][zoom >= 14] {
     line-pattern-file: url('symbols/earth_bank.svg');
   }  
+  [man_made = 'embankment'][zoom >= 15]::man_made {
+    line-pattern-file: url('symbols/embankment.svg');
+  }
 }
 
 #barriers {

--- a/symbols/earth_bank.svg
+++ b/symbols/earth_bank.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="5" viewBox="0 0 12 5">
+  <rect width="12" height="5" fill="none"/>
+  <path d="m0,2 v1 h5 l.25,2 h1.5 l.25,-2 h5 v-1 z" fill="#008000"/>
+</svg>


### PR DESCRIPTION
Fixes #2288 

People use natural=cliff everywhere instead of natural=earth_bank because natural=earth_bank is not rendered. However, it is very similar to man_made=embankment (which is rendered) in landscape impact.

Changes proposed in this pull request:
- Render natural=earth_bank similarly to man_made=embankment (smaller than natural=cliff)

Visual style for natural=earth_bank is in earth_bank.svg, so it can be changed/adjusted later.

Before
![image](https://user-images.githubusercontent.com/3242603/217049177-40f8123a-f608-455b-abe4-5ca5d2448b86.png)

After
![image](https://user-images.githubusercontent.com/3242603/217049159-28e1134c-3658-4db6-abf3-9c910b0c8e0e.png)