### PR TITLE
Restored rendering for railway=platform + covered=yes

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -751,8 +751,9 @@ Layer:
                 z_order
               FROM planet_osm_line
               WHERE (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))
-                AND (covered IS NULL OR NOT covered = 'yes')
+                AND (covered IS NULL OR NOT covered = 'yes' OR railway IN ('platform'))
                 AND (bridge IS NULL OR NOT bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct'))
+                AND (railway NOT IN ('platform') OR (tags->'location' NOT IN ('underground')) OR (tags->'location') IS NULL)
                 AND railway IS NOT NULL -- end of rail select
             ) AS features
           ORDER BY

--- a/project.mml
+++ b/project.mml
@@ -654,16 +654,14 @@ Layer:
               'highway_' || (CASE WHEN highway IN ('pedestrian', 'footway', 'service', 'platform') THEN highway END)),
               ('railway_' || (CASE WHEN (railway IN ('platform')
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL))
                               THEN railway END))
             ) AS feature
           FROM planet_osm_polygon
           WHERE highway IN ('pedestrian', 'footway', 'service', 'platform')
             OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                AND (covered NOT IN ('yes') OR covered IS NULL))
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL))
           ORDER BY COALESCE(layer,0), way_area DESC
         ) AS highway_area_casing
     properties:
@@ -782,8 +780,7 @@ Layer:
                                                     'platform', 'services') THEN highway END)),
               ('railway_' || (CASE WHEN (railway IN ('platform')
                               AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                              AND (covered NOT IN ('yes') OR covered IS NULL))
+                              AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL))
                               THEN railway END)),
               (('aeroway_' || CASE WHEN aeroway IN ('runway', 'taxiway', 'helipad') THEN aeroway ELSE NULL END))
             ) AS feature,
@@ -797,8 +794,7 @@ Layer:
           WHERE highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform', 'services')
             OR (railway IN ('platform')
                 AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL)
-                AND (covered NOT IN ('yes') OR covered IS NULL))
+                AND (tunnel NOT IN ('yes', 'building_passage') OR tunnel IS NULL))
             OR aeroway IN ('runway', 'taxiway', 'helipad')
           ORDER BY COALESCE(layer,0), way_area desc
         ) AS highway_area_fill


### PR DESCRIPTION
Fixes #4008

Changes proposed in this pull request:
- Restored rendering for railway=platform + covered=yes

Test rendering with links to the example places:
https://www.openstreetmap.org/way/160042477 (left before, right after)
![platform19](https://user-images.githubusercontent.com/79519062/228065901-42d7ceeb-1fbf-421a-bfa4-46d4eb72bccb.png)
![platform18](https://user-images.githubusercontent.com/79519062/228066561-6155aa0a-8094-4f6e-b814-efaf2f1ed090.png)
