### PR TITLE
Prevent disused:shops from being rendered like addresses

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2151,6 +2151,7 @@ Layer:
           FROM planet_osm_point
           WHERE way && !bbox!
             AND (("addr:housenumber" IS NOT NULL) OR ("addr:housename" IS NOT NULL) OR ((tags->'addr:unit') IS NOT NULL) OR ((tags->'addr:flats') IS NOT NULL))
+            AND ((tags->'disused:shop') IS NULL)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS addresses
     properties:


### PR DESCRIPTION
Fixes #4794

Changes proposed in this pull request:
- Prevent disused:shops from being rendered like addresses

Test rendering with links to the example places:
(left before, right after)

Works for nodes (the second Mönckebergstraße 20 is a disused:shop) (https://www.openstreetmap.org/node/2940895591)
![disused1](https://user-images.githubusercontent.com/79519062/228255822-281beb90-3418-4c69-a056-0495a273862f.png)

Buildings like the 112 are not affected by this change (https://www.openstreetmap.org/way/34170899)
![disused2](https://user-images.githubusercontent.com/79519062/228255840-dc928dff-de7b-4b77-9461-162b35366824.png)

Areas were never rendered as addresses (https://www.openstreetmap.org/way/364796594)
![disused3](https://user-images.githubusercontent.com/79519062/228255864-fdae7c9a-7503-462a-8e74-1f4edb916bdc.png)
