### PR TITLE
Added rendering for ref and local_ref on public_transport=stop_positions

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1411,6 +1411,22 @@ Layer:
     properties:
       cache-features: true
       minzoom: 12
+  - id: stop-positions
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+          way, 
+          tags->'public_transport' as public_transport,
+          ref,
+          tags->'local_ref' as local_ref
+        FROM planet_osm_point
+        WHERE (tags->'public_transport' = 'stop_position') AND (tags->'train' = 'yes') AND ((ref IS NOT NULL) OR ((tags->'local_ref') IS NOT NULL))
+        ) AS stop_positions
+    properties:
+      minzoom: 18
   - id: junctions
     geometry: point
     <<: *extents

--- a/style/stations.mss
+++ b/style/stations.mss
@@ -120,3 +120,25 @@
     }
   }
 }
+
+#stop-positions {
+  [public_transport = 'stop_position'][zoom >= 18] {
+    text-name: [ref];
+    [local_ref != null] {
+      text-name: [local_ref];
+    }
+    text-face-name: @bold-fonts;
+    text-fill: @transportation-icon;
+    text-halo-radius: @standard-halo-radius * 1.5;
+    text-halo-fill: @standard-halo-fill;
+    text-wrap-width: 0;
+    text-size: 11;
+    [zoom >= 19] {
+      text-size: 13;
+      text-halo-radius: @standard-halo-radius * 2.0;
+    }
+    [zoom >= 20] {
+      text-size: 15;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4662

Changes proposed in this pull request:
- Added rendering for ref and local_ref on public_transport=stop_positions. The track numbers are only shown when train=yes is set
- Track numbers display from zoom 18 on

Test rendering with links to the example places:
(before left, right after)

https://www.openstreetmap.org/node/2470201868
![MHB17](https://user-images.githubusercontent.com/79519062/229798048-a6758b27-2780-4ce1-99b8-b5019ac13d7c.png)
![MHB18](https://user-images.githubusercontent.com/79519062/229798084-84bc1a6b-a5f5-4b3f-8298-a858eb0b4006.png)
![MHB19](https://user-images.githubusercontent.com/79519062/229798105-2a1547f6-b671-4139-af04-9419003dbae5.png)

https://www.openstreetmap.org/node/2465304880
![OST17](https://user-images.githubusercontent.com/79519062/229798225-3624abf6-d004-4f98-957c-3dd06cee96bc.png)
![OST18](https://user-images.githubusercontent.com/79519062/229798176-63baf1c9-a0f8-425d-a89c-754616a3dc42.png)
![OST19](https://user-images.githubusercontent.com/79519062/229798285-554155c0-e053-407b-b8bc-5f57dc12b21b.png)

https://www.openstreetmap.org/node/2476438979
![Pasing18](https://user-images.githubusercontent.com/79519062/229798343-2a310417-f376-4383-b362-420235442dd1.png)
![Pasing19](https://user-images.githubusercontent.com/79519062/229798364-1fb1a9ea-494b-4897-b18c-9eb32cbe3a54.png)
![Pasing20](https://user-images.githubusercontent.com/79519062/229798386-6c38d278-864a-46b9-a2ae-8fbd896a9676.png)

https://www.openstreetmap.org/node/3135325888
![Neu17](https://user-images.githubusercontent.com/79519062/229798486-19faa751-cbfd-4f78-9e32-bc1dc351bcfe.png)
![Neu18](https://user-images.githubusercontent.com/79519062/229798513-3a6d53b2-f01f-453e-8480-f9e5628f03e9.png)
![Neu19](https://user-images.githubusercontent.com/79519062/229798530-7e9d4308-213d-4e17-90b8-784143704e92.png)

https://www.openstreetmap.org/node/260406611
![Freising18](https://user-images.githubusercontent.com/79519062/229798606-b680cb59-087c-4c69-9d20-331879fcdb62.png)

https://www.openstreetmap.org/node/2499357757
![MUC19](https://user-images.githubusercontent.com/79519062/229798644-e36bc63c-ee03-4168-b310-4cb03335477e.png)

https://www.openstreetmap.org/node/3707303125
![Fisch18](https://user-images.githubusercontent.com/79519062/229798693-7bd55106-7d9b-4208-9b3f-23769138e55e.png)

https://www.openstreetmap.org/node/3183841635
![Altona18](https://user-images.githubusercontent.com/79519062/229798804-bb6ea0be-3956-48b6-abf9-1cb84bf0f5be.png)

