### PR TITLE
fix color of ref label for subway entrance

### DIFF
--- a/style/stations.mss
+++ b/style/stations.mss
@@ -10,7 +10,7 @@
       text-name: [ref];
       text-face-name: @book-fonts;
       text-size: 10;
-      text-fill: @transportation-icon;
+      text-fill: @transportation-text;
       text-dy: 10;
       text-halo-radius: @standard-halo-radius * 1.5;
       text-halo-fill: @standard-halo-fill;


### PR DESCRIPTION
Fixes #4758 

Changes proposed in this pull request:
- Change the color of the ref label from transportation-icon to transportation-text

Test rendering with links to the example places:

Before
![subway_before](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/72482be5-a410-4df8-bad4-ce2047de7095)


After
![subway_after](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/eaff65ad-1d4c-4261-b17c-e3c3e04d8fd7)

As mentioned in the issue, the difference is quite subtle.