### PR TITLE
Fix draw order for low-zoom amenity points

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1634,6 +1634,7 @@ Layer:
                   CASE
                     WHEN tags->'height' ~ '^\d{1,3}(\.\d+)?( m)?$' THEN (SUBSTRING(tags->'height', '^(\d{1,3}(\.\d+)?)( m)?$'))::NUMERIC
                   END
+                WHEN "highway" IN ('bus_stop') THEN 0 --renders bus stops above other amenity points, such as bus shelters
               END AS score,
               religion,
               tags->'denomination' as denomination,

--- a/project.mml
+++ b/project.mml
@@ -1562,17 +1562,14 @@ Layer:
                                 'landuse_landfill', 'landuse_construction', 'landuse_salt_pond', 'tourism_theme_park', 'tourism_zoo', 'amenity_kindergarten',
                                 'amenity_school', 'amenity_college', 'amenity_university', 'landuse_religious', 'natural_heath', 'natural_scrub', 'natural_beach',
                                 'natural_shoal', 'natural_reef', 'leisure_fitness_centre', 'leisure_fitness_station', 'leisure_sports_centre', 'leisure_stadium',
-                                'leisure_track', 'leisure_dog_park', 'leisure_ice_rink', 'leisure_pitch')
+                                'leisure_track', 'leisure_dog_park', 'leisure_ice_rink', 'leisure_pitch', 'power_plant', 'aeroway_apron', 'highway_services',
+                                'highway_rest_area')
                 AND way_pixels > 3000
                 AND is_building = 'no'
               THEN 10
               WHEN feature in ('shop')
                 AND shop = 'mall'
                 AND location != 'underground'
-                AND way_pixels > 3000
-              THEN 10
-              WHEN feature IN ('power_plant', 'aeroway_apron', 'highway_services', 'highway_rest_area')
-                AND is_building = 'no'
                 AND way_pixels > 3000
               THEN 10
               WHEN feature IN ('power_generator')
@@ -1589,14 +1586,13 @@ Layer:
                 AND way_pixels > 3000
               THEN 11
               WHEN feature IN ('aeroway_aerodrome')
-                AND (int_access = 'restricted' OR 'icao' != null OR 'iata' != null)
               THEN 12
+              WHEN feature IN ('tourism_alpine_hut', 'tourism_wilderness_hut')
+              THEN 13
               WHEN feature IN ('waterway_waterfall')
                 AND height > 20
               THEN 13
-              WHEN feature IN ('tourism_alpine_hut', 'tourism_wilderness_hut')
-              THEN 13
-              WHEN feature IN ('landuse_garages', 'power_substation')
+              WHEN feature IN ('landuse_garages', 'power_substation', 'leisure_swimming_pool')
                 AND is_building = 'no'
                 AND way_pixels > 3000
               THEN 13
@@ -1765,7 +1761,8 @@ Layer:
                   CASE
                     WHEN tags->'height' ~ '^\d{1,3}(\.\d+)?( m)?$' THEN (SUBSTRING(tags->'height', '^(\d{1,3}(\.\d+)?)( m)?$'))::NUMERIC
                   END
-                WHEN "highway" IN ('bus_stop') THEN 0 --renders bus stops above other amenity points, such as bus shelters
+                WHEN "amenity" IN ('bus_station') THEN 1
+                WHEN "highway" IN ('bus_stop') THEN 0 --renders bus stops above other zoom 16 amenity points, such as bus shelters
               END AS score,
               religion,
               tags->'denomination' as denomination,


### PR DESCRIPTION
Fixes #2431 Also partially addresses #3880 for low zoom amenity points.

### Changes proposed in this pull request:
- fixes draw order for amenity features which start rendering at zoom levels 1-15 to render first if their min zoom level is higher
- Draws bus stop and bus station higher than other features which begin rendering at level 16 and higher
As mentioned in #3880  manually working through the layers and adjusting the drawing order to match the order of starting zoom levels is maintenance intensive. However, given the relative low number of amenity points rendered at low zoom levels, and how rarely new ones are added or modified (the last time something was modified in these zoom levels was in January 2021 with #4301 as far as I can tell) this is not a big issue. This can also serve as a starting place for defining rendering levels in the SQL queries if that approach is ever taken (the second suggested approach in #3880)

### Test rendering with links to the example places:

#### Bus stops now render above shelters:
Location: https://www.openstreetmap.org/#map=16/43.0436/-87.9453
Before
![busstop_before](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/2692c5c7-c375-4a58-9b87-68573ae2d532)

After
![busstop_after](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/a0102069-5e57-4dd4-9181-e764c6e06034)

#### Cave no longer obscured by drinking water
A cave entrance (starting zoom 15) is no longer obscured by a drinking water tap (starting zoom 17) at zoom 17. Location: https://www.openstreetmap.org/#map=17/46.32509/9.42185
Before
![cave_before](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/3747b614-9129-4e1d-835a-fe60da859dfc)

After
![cave_after](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/b4875bbb-2915-4a95-919a-ebf4b991c6f9)

#### Large tower no longer obscured by minor dish
A major radio tower (height 374m and starts rendering at zoom 14) is no longer obscured by a small communication dish (starting render zoom 17) at zoom 17. Location: https://www.openstreetmap.org/#map=17/43.11092/-87.92899
Before
![tower_before](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/734fa3af-d1cc-4d6e-9212-2b7b4f75bc94)

After
![tower_after](https://github.com/gravitystorm/openstreetmap-carto/assets/35740782/a814a5de-596b-421f-af4b-89ef476853a9)
