### PR TITLE
fix merge errors in #3750 (bay/strait labeling)

### DIFF
--- a/style/water.mss
+++ b/style/water.mss
@@ -289,30 +289,24 @@
   [feature = 'natural_water'],
   [feature = 'landuse_reservoir'],
   [feature = 'landuse_basin'],
-  [feature = 'waterway_dock'],
-  [feature = 'natural_strait'],
-  [feature = 'natural_bay'] {
+  [feature = 'waterway_dock'] {
     [zoom >= 5][way_pixels > 3000][way_pixels <= 768000],
-    [zoom >= 14][way_pixels <= 768000][feature = 'natural_bay'],
-    [zoom >= 14][way_pixels <= 768000][feature = 'natural_strait'],
     [zoom >= 17][way_pixels <= 768000] {
       text-name: "[name]";
       text-size: 10;
       text-wrap-width: 25; // 2.5 em
       text-line-spacing: -1.5; // -0.15 em
-      [way_pixels > 12000][feature != 'natural_strait'][feature != 'natural_bay'],
-      [zoom >= 15][feature = 'natural_strait'],
-      [zoom >= 15][feature = 'natural_bay'] {
+      [way_pixels > 12000] {
         text-size: 12;
         text-wrap-width: 37; // 3.1 em
         text-line-spacing: -1.6; // -0.13 em
       }
-      [way_pixels > 48000][feature != 'natural_strait'][feature != 'natural_bay'] {
+      [way_pixels > 48000] {
         text-size: 15;
         text-wrap-width: 59; // 3.9 em
         text-line-spacing: -1.5; // -0.10 em
       }
-      [way_pixels > 192000][feature != 'natural_strait'][feature != 'natural_bay'] {
+      [way_pixels > 192000] {
         text-size: 19;
         text-wrap-width: 95; // 5.0 em
         text-line-spacing: -0.95; // -0.05 em
@@ -322,6 +316,26 @@
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: interior;
+    }
+  }
+}
+
+#text-point[zoom >= 14] {
+  [feature = 'natural_bay'],
+  [feature = 'natural_strait'] {
+    text-name: "[name]";
+    text-size: 10;
+    text-wrap-width: 25; // 2.5 em
+    text-line-spacing: -1.5; // -0.15 em
+    text-fill: @water-text;
+    text-face-name: @oblique-fonts;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @standard-halo-fill;
+    text-placement: interior;
+    [zoom >= 15] {
+      text-size: 12;
+      text-wrap-width: 37; // 3.1 em
+      text-line-spacing: -1.6; // -0.13 em
     }
   }
 }


### PR DESCRIPTION
Merging of #3750 substantially changed the functionality of the PR compared to the reviewed version.  It also resulted in [hard to understand code](https://github.com/gravitystorm/openstreetmap-carto/blob/aef9179ca4ed40d8f901cd087c01d15533ea0ebb/style/water.mss#L287-L327).

Current de facto rendering can be seen on

https://imagico.de/map/styleinfo/#style=osmcarto&section=tags&key=natural&value=bay

This change implements what @jeisenbe intended in #3750 (i.e. label all natural=bay/strait from z14 independent of how they are mapped).  It also makes the code easier to understand by separating the labeling of water features with a blue fill (like natural=water) from the rendering of water features with label only rendering (natural=bay/strait).
