### PR TITLE
Removes amenity-points rendering for golf_hole

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1621,7 +1621,7 @@ Layer:
                                    THEN amenity END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism END,
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place END,
-                'golf_' || CASE WHEN tags->'golf' IN ('hole', 'pin') THEN tags->'golf' END
+                'golf_' || CASE WHEN tags->'golf' IN ('pin') THEN tags->'golf' END
               ) AS feature,
               CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
               CASE

--- a/style/golf.mss
+++ b/style/golf.mss
@@ -49,7 +49,6 @@
 }
 
 #amenity-points[zoom >= 16] {
-  [feature = 'golf_hole'],
   [feature = 'golf_pin'] {
     marker-file: url('symbols/leisure/golf_pin.svg');
     marker-fill: @golf-color;


### PR DESCRIPTION
Fixes #4804 

Changes proposed in this pull request: Removes amenity-points rendering for golf_hole at all levels
- 

Test rendering with links to the example places:

### Left: Before / Right: After
Hi zoom (https://www.openstreetmap.org/node/7674311131)
<img width="1383" alt="Screenshot 2023-08-11 at 18 08 16" src="https://github.com/gravitystorm/openstreetmap-carto/assets/7045569/3f008e6c-36f0-4243-8224-9d0a7abb0b25">
Lower zoom
<img width="1377" alt="Screenshot 2023-08-11 at 18 12 33" src="https://github.com/gravitystorm/openstreetmap-carto/assets/7045569/541b50e6-e19f-468f-83eb-0cee429dad56">
Keeps pins (https://www.openstreetmap.org/node/6287232319#map=16/50.8542/0.4474)
<img width="1383" alt="Screenshot 2023-08-11 at 18 12 45" src="https://github.com/gravitystorm/openstreetmap-carto/assets/7045569/64b0eb68-db4e-41b4-841c-c81c9f49d4b1">

