### PR TITLE
render barrier=planter

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2289,7 +2289,7 @@ Layer:
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'planter') THEN barrier END
             )  AS feature,
             CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
             way_area,
@@ -2330,7 +2330,7 @@ Layer:
                OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
-               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
+               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'planter')
             ORDER BY
               CASE amenity
                 WHEN 'waste_basket' THEN 1

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1561,6 +1561,7 @@
   }
 
   [feature = 'barrier_bollard'],
+  [feature = 'barrier_planter'],
   [feature = 'barrier_block'],
   [feature = 'barrier_log'],
   [feature = 'barrier_turnstile'] {


### PR DESCRIPTION
Fixes #4751

Changes proposed in this pull request:
- Render `barrier=planter` in the same style as `barrier=bollard/log/block/turnstile`

Test rendering with links to the example places:

https://www.openstreetmap.org/node/1084062161

Before

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/3888578/3fa39edb-318f-4063-ba46-7d96573210bb)

After

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/3888578/6cacf053-f6bc-4266-b377-7bb4c7f2e28e)