### PR TITLE
Remove unused code in amenity-points.mss

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2268,7 +2268,6 @@
       [feature = 'landuse_farmyard'] {
         text-fill: darken(@farmyard, 50%);
       }
-      [feature = 'landuse_farm'],
       [feature = 'landuse_farmland'],
       [feature = 'landuse_greenhouse_horticulture'] {
         text-fill: darken(@farmland, 50%);


### PR DESCRIPTION


Fixes #4767

Changes proposed in this pull request:
Remove unreached code in amenity-points.mss. `landuse=farm` is incorrect tagging and is not rendered anyway (not selected by SQL query for text-point layer)

Test rendering with links to the example places:
N/A
