### PR TITLE
Use more reliable OSDN mirror

### DIFF
--- a/scripts/get-fonts.sh
+++ b/scripts/get-fonts.sh
@@ -127,6 +127,6 @@ unzip -oqq "${TMPDIR}/Noto_Emoji.zip" static/NotoEmoji-Regular.ttf static/NotoEm
 mv "${FONTDIR}/static/NotoEmoji-Regular.ttf" "${FONTDIR}"
 mv "${FONTDIR}/static/NotoEmoji-Bold.ttf" "${FONTDIR}"
 
-curl --fail -A "get-fonts.sh/osm-carto" -o "${TMPDIR}/hanazono.zip" -L 'https://osdn.net/frs/redir.php?f=hanazono-font%2F68253%2Fhanazono-20170904.zip'
+curl --fail -A "get-fonts.sh/osm-carto" -o "${TMPDIR}/hanazono.zip" -L 'https://mirrors.dotsrc.org/osdn/hanazono-font/68253/hanazono-20170904.zip'
 
 unzip -oqq "${TMPDIR}/hanazono.zip" HanaMinA.ttf HanaMinB.ttf -d "${FONTDIR}"


### PR DESCRIPTION
By using more reliable mirror, fixes network & certificate issues with osdn.net which has been going on for month, despite reporting the problem to them (no one even acknowledged /replied to the reported issue) .

I've verified that SHA256 sum is the same:
```
571cd4a09ae7da0c642d640fc2442c050aa450ebb0587a95cdd097d41a9c9572  hanazono-20170904.zip
```

<details>

<summary>certificate issues and speed comparison</summary>

```
new:

% wget https://mirrors.dotsrc.org/osdn/hanazono-font/68253/hanazono-20170904.zip
--2023-10-18 18:32:07--  https://mirrors.dotsrc.org/osdn/hanazono-font/68253/hanazono-20170904.zip
Resolving mirrors.dotsrc.org (mirrors.dotsrc.org)... 130.225.254.116, 2001:878:346::116
Connecting to mirrors.dotsrc.org (mirrors.dotsrc.org)|130.225.254.116|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 30546996 (29M) [application/zip]
Saving to: ‘hanazono-20170904.zip’

hanazono-20170904.zip                           100%[======================================================================================================>]  29,13M  5,84MB/s    in 5,1s

2023-10-18 18:32:13 (5,67 MB/s) - ‘hanazono-20170904.zip’ saved [30546996/30546996]

```

Original:
```
wget --no-check-certificate 'https://osdn.net/frs/redir.php?f=hanazono-font%2F68253%2Fhanazono-20170904.zip'
--2023-10-18 18:31:03--  https://osdn.net/frs/redir.php?f=hanazono-font%2F68253%2Fhanazono-20170904.zip
Resolving osdn.net (osdn.net)... 52.35.241.6, 54.212.190.218
Connecting to osdn.net (osdn.net)|52.35.241.6|:443... connected.
HTTP request sent, awaiting response... 504 Gateway Time-out
Retrying.

--2023-10-18 18:31:15--  (try: 2)  https://osdn.net/frs/redir.php?f=hanazono-font%2F68253%2Fhanazono-20170904.zip
Reusing existing connection to osdn.net:443.
HTTP request sent, awaiting response... 504 Gateway Time-out
Retrying.

--2023-10-18 18:31:27--  (try: 3)  https://osdn.net/frs/redir.php?f=hanazono-font%2F68253%2Fhanazono-20170904.zip
Reusing existing connection to osdn.net:443.
HTTP request sent, awaiting response... 302 Found
Location: https://osdn.dl.osdn.net/hanazono-font/68253/hanazono-20170904.zip [following]
--2023-10-18 18:31:29--  https://osdn.dl.osdn.net/hanazono-font/68253/hanazono-20170904.zip
Resolving osdn.dl.osdn.net (osdn.dl.osdn.net)... 44.227.127.205, 54.184.171.155
Connecting to osdn.dl.osdn.net (osdn.dl.osdn.net)|44.227.127.205|:443... connected.
WARNING: The certificate of ‘osdn.dl.osdn.net’ is not trusted.
WARNING: The certificate of ‘osdn.dl.osdn.net’ has expired.
The certificate has expired
HTTP request sent, awaiting response... 200 OK
Length: 30546996 (29M) [application/zip]
Saving to: ‘hanazono-20170904.zip’

hanazono-20170904.zip                           100%[======================================================================================================>]  29,13M  15,9KB/s    in 31m 9s

2023-10-18 19:02:42 (16,0 KB/s) - ‘hanazono-20170904.zip’ saved [30546996/30546996]

```
</details>

Fixes #4864 (id of the issue to be closed)
