### PR TITLE
Fix rendering of highway=track that was broken in PR #4666

### DIFF
--- a/style/tourism.mss
+++ b/style/tourism.mss
@@ -1,7 +1,7 @@
 /* For tourism features like roller coasters */
 
-@track-casing: #707070;
-@track-fill: #ddd;
+@roller-coaster-casing: #707070;
+@roller-coaster-fill: #ddd;
 
 /* The purpose of “roller-coaster-gap-fill” layer is to fill in the gaps between sections of roller coaster track. */
 #roller-coaster-gap-fill[zoom >= 15] {
@@ -27,14 +27,14 @@
 
     ::casing {
       line-width: 1;
-      line-color: mix(@track-casing, @track-fill, 50%);
+      line-color: mix(@roller-coaster-casing, @roller-coaster-fill, 50%);
       line-join: round;
 
       [tunnel = 'yes'][zoom >= 16] {
-        line-color: lighten(@track-casing, 20%);
+        line-color: lighten(@roller-coaster-casing, 20%);
       }
       [zoom >= 16] { 
-        line-color: @track-casing;
+        line-color: @roller-coaster-casing;
         line-width: 2.5;
       }
       [zoom >= 17] { line-width: 4; }
@@ -45,11 +45,11 @@
 
     ::fill[zoom >= 16] {
       line-width: 1.25;
-      line-color: @track-fill;
+      line-color: @roller-coaster-fill;
       line-join: round;
 
       [tunnel = 'yes'] {
-        line-color: lighten(@track-fill, 5%);
+        line-color: lighten(@roller-coaster-fill, 5%);
       }
       [zoom >= 17] { line-width: 2; }
       [zoom >= 18] { line-width: 3; }


### PR DESCRIPTION
Fixes #4881

This PR has no new features but a bugfix:
- `highway=track` is fixed and again rendered like it is in the current release
- `roller_coaster=track` has no visual changes

## Examples
### Before
`highway=track` is rendered like it is a roller coast track
<img width="872" alt="image" src="https://github.com/gravitystorm/openstreetmap-carto/assets/6886880/2384f6b2-6219-492b-b23e-0d53316339be">

### After
`highway=track` is rendered correctly again
<img width="870" alt="image" src="https://github.com/gravitystorm/openstreetmap-carto/assets/6886880/8750bac8-4768-411d-a631-87a7f834e45e">

### Before
`roller_coaster=track` is rendered
<img width="1014" alt="image" src="https://github.com/gravitystorm/openstreetmap-carto/assets/6886880/2612512e-945f-4386-ae23-6ce3679f986a">

### After
`roller_coaster=track` is still rendered the same way, no visual changes
<img width="1014" alt="image" src="https://github.com/gravitystorm/openstreetmap-carto/assets/6886880/fa8a3b67-dad5-40f2-b11a-6e100932c6b3">
