### PR TITLE
Mini-roundabouts: fixes and trunk road support

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -623,14 +623,15 @@ Layer:
             JOIN planet_osm_line l
               ON ST_DWithin(p.way, l.way, 0.1) -- Assumes Mercator
             JOIN (VALUES
-                ('primary', 1),
-                ('secondary', 2),
-                ('tertiary', 3),
-                ('unclassified', 4),
-                ('residential', 5),
-                ('living_street', 6),
-                ('service', 7),
-                ('track', 8)
+                ('trunk', 1),
+                ('primary', 2),
+                ('secondary', 3),
+                ('tertiary', 4),
+                ('unclassified', 5),
+                ('residential', 6),
+                ('living_street', 7),
+                ('service', 8),
+                ('track', 9)
               ) AS v (highway, prio)
               ON v.highway = l.highway
           WHERE p.highway IN (

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -3133,7 +3133,8 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [int_tc_type = 'primary'] { marker-fill: @primary-casing; }
     [int_tc_type = 'secondary'] { marker-fill: @secondary-casing; }
-    [int_tc_type = 'tertiary'] { marker-fill: @primary-casing; }
+    [int_tc_type = 'tertiary'] { marker-fill: @tertiary-casing; }
+    [int_tc_type = 'unclassified'] { marker-fill: @residential-casing; }
     [int_tc_type = 'residential'] { marker-fill: @residential-casing; }
     [int_tc_type = 'living_street'] { marker-fill: @living-street-casing; }
     [int_tc_type = 'service'] { marker-fill: @service-casing; }

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2782,19 +2782,19 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #turning-circle-casing {
   [int_tc_type = 'primary'][zoom >= 15] {
     marker-fill: @primary-casing;
-    marker-width: @primary-width-z15 * 1.6 + 2 * @casing-width-z15;
-    marker-height: @primary-width-z15 * 1.6 + 2 * @casing-width-z15;
+    marker-width: @primary-width-z15 * 1.6 + 2 * @major-casing-width-z15;
+    marker-height: @primary-width-z15 * 1.6 + 2 * @major-casing-width-z15;
     [zoom >= 17] {
-      marker-width: @primary-width-z17 * 1.6 + 2 * @casing-width-z17;
-      marker-height: @primary-width-z17 * 1.6 + 2 * @casing-width-z17;
+      marker-width: @primary-width-z17 * 1.6 + 2 * @major-casing-width-z17;
+      marker-height: @primary-width-z17 * 1.6 + 2 * @major-casing-width-z17;
     }
     [zoom >= 18] {
-      marker-width: @primary-width-z18 * 1.6 + 2 * @casing-width-z18;
-      marker-height: @primary-width-z18 * 1.6 + 2 * @casing-width-z18;
+      marker-width: @primary-width-z18 * 1.6 + 2 * @major-casing-width-z18;
+      marker-height: @primary-width-z18 * 1.6 + 2 * @major-casing-width-z18;
     }
     [zoom >= 19] {
-      marker-width: @primary-width-z19 * 1.6 + 2 * @casing-width-z19;
-      marker-height: @primary-width-z19 * 1.6 + 2 * @casing-width-z19;
+      marker-width: @primary-width-z19 * 1.6 + 2 * @major-casing-width-z19;
+      marker-height: @primary-width-z19 * 1.6 + 2 * @major-casing-width-z19;
     }
     marker-allow-overlap: true;
     marker-ignore-placement: true;
@@ -2803,23 +2803,23 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
   [int_tc_type = 'secondary'][zoom >= 15] {
     marker-fill: @secondary-casing;
-    marker-width: @secondary-width-z15 * 1.6 + 2 * @casing-width-z15;
-    marker-height: @secondary-width-z15 * 1.6 + 2 * @casing-width-z15;
+    marker-width: @secondary-width-z15 * 1.6 + 2 * @secondary-casing-width-z15;
+    marker-height: @secondary-width-z15 * 1.6 + 2 * @secondary-casing-width-z15;
     [zoom >= 16] {
-      marker-width: @secondary-width-z16 * 1.6 + 2 * @casing-width-z16;
-      marker-height: @secondary-width-z16 * 1.6 + 2 * @casing-width-z16;
+      marker-width: @secondary-width-z16 * 1.6 + 2 * @secondary-casing-width-z16;
+      marker-height: @secondary-width-z16 * 1.6 + 2 * @secondary-casing-width-z16;
     }
     [zoom >= 17] {
-      marker-width: @secondary-width-z17 * 1.6 + 2 * @casing-width-z17;
-      marker-height: @secondary-width-z17 * 1.6 + 2 * @casing-width-z17;
+      marker-width: @secondary-width-z17 * 1.6 + 2 * @secondary-casing-width-z17;
+      marker-height: @secondary-width-z17 * 1.6 + 2 * @secondary-casing-width-z17;
     }
     [zoom >= 18] {
-      marker-width: @secondary-width-z18 * 1.6 + 2 * @casing-width-z18;
-      marker-height: @secondary-width-z18 * 1.6 + 2 * @casing-width-z18;
+      marker-width: @secondary-width-z18 * 1.6 + 2 * @secondary-casing-width-z18;
+      marker-height: @secondary-width-z18 * 1.6 + 2 * @secondary-casing-width-z18;
     }
     [zoom >= 19] {
-      marker-width: @secondary-width-z19 * 1.6 + 2 * @casing-width-z19;
-      marker-height: @secondary-width-z19 * 1.6 + 2 * @casing-width-z19;
+      marker-width: @secondary-width-z19 * 1.6 + 2 * @secondary-casing-width-z19;
+      marker-height: @secondary-width-z19 * 1.6 + 2 * @secondary-casing-width-z19;
     }
     marker-allow-overlap: true;
     marker-ignore-placement: true;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -2780,6 +2780,27 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #turning-circle-casing {
+  [int_tc_type = 'trunk'][zoom >= 15] {
+    marker-fill: @trunk-casing;
+    marker-width: @trunk-width-z15 * 1.6 + 2 * @major-casing-width-z15;
+    marker-height: @trunk-width-z15 * 1.6 + 2 * @major-casing-width-z15;
+    [zoom >= 17] {
+      marker-width: @trunk-width-z17 * 1.6 + 2 * @major-casing-width-z17;
+      marker-height: @trunk-width-z17 * 1.6 + 2 * @major-casing-width-z17;
+    }
+    [zoom >= 18] {
+      marker-width: @trunk-width-z18 * 1.6 + 2 * @major-casing-width-z18;
+      marker-height: @trunk-width-z18 * 1.6 + 2 * @major-casing-width-z18;
+    }
+    [zoom >= 19] {
+      marker-width: @trunk-width-z19 * 1.6 + 2 * @major-casing-width-z19;
+      marker-height: @trunk-width-z19 * 1.6 + 2 * @major-casing-width-z19;
+    }
+    marker-allow-overlap: true;
+    marker-ignore-placement: true;
+    marker-line-width: 0;
+  }
+
   [int_tc_type = 'primary'][zoom >= 15] {
     marker-fill: @primary-casing;
     marker-width: @primary-width-z15 * 1.6 + 2 * @major-casing-width-z15;
@@ -2946,6 +2967,27 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 }
 
 #turning-circle-fill {
+  [int_tc_type = 'trunk'][zoom >= 15] {
+    marker-fill: @trunk-fill;
+    marker-width: @trunk-width-z15 * 1.6;
+    marker-height: @trunk-width-z15 * 1.6;
+    [zoom >= 17] {
+      marker-width: @trunk-width-z17 * 1.6;
+      marker-height: @trunk-width-z17 * 1.6;
+    }
+    [zoom >= 18] {
+      marker-width: @trunk-width-z18 * 1.6;
+      marker-height: @trunk-width-z18 * 1.6;
+    }
+    [zoom >= 19] {
+      marker-width: @trunk-width-z19 * 1.6;
+      marker-height: @trunk-width-z19 * 1.6;
+    }
+    marker-allow-overlap: true;
+    marker-ignore-placement: true;
+    marker-line-width: 0;
+  }
+
   [int_tc_type = 'primary'][zoom >= 15] {
     marker-fill: @primary-fill;
     marker-width: @primary-width-z15 * 1.6;
@@ -3131,6 +3173,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     marker-ignore-placement: true;
     marker-line-width: 0;
 
+    [int_tc_type = 'trunk'] { marker-fill: @trunk-casing; }
     [int_tc_type = 'primary'] { marker-fill: @primary-casing; }
     [int_tc_type = 'secondary'] { marker-fill: @secondary-casing; }
     [int_tc_type = 'tertiary'] { marker-fill: @tertiary-casing; }


### PR DESCRIPTION
These changes fix some issues with mini-roundabouts (as well as turning-circles) and add rendering for them on trunk roads.

Mini-roundabouts on trunk roads:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/204831/c84dba94-0c18-4dae-970e-fac67e214c16)

Casing on primary roads:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/204831/92dd72c1-9aaf-4650-b1b5-2de622ce5925)

Casing on secondary roads:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/204831/73eadac8-8973-4d6a-a655-f9cece0426ca)

Fill on tertiary roads:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/204831/8ae9580d-5523-4ab8-ae30-c2f153e933db)

Fill on unclassified roads:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/204831/15f69130-a6f7-4a86-aecd-3f0816b8e0cd)

Fixes #4380
Fixes #4781