### PR TITLE
Restore reef name rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1592,7 +1592,7 @@ Layer:
                                                     'construction', 'salt_pond', 'military', 'plant_nursery') THEN landuse END,
                 'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'cave_entrance') AND way_area IS NULL THEN "natural" END,
                 'natural_' || CASE WHEN "natural" IN ('wood', 'water', 'mud', 'wetland', 'bay', 'spring', 'scree', 'shingle', 'bare_rock', 'sand', 'heath',
-                                                      'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape')
+                                                      'grassland', 'scrub', 'beach', 'glacier', 'tree', 'strait', 'cape', 'reef')
                                                       THEN "natural" END,
                 'mountain_pass' || CASE WHEN tags->'mountain_pass' IN ('yes') THEN '' END, -- after natural=saddle to give priority to that tag on the same node
                 'waterway_' || CASE WHEN "waterway" IN ('waterfall') AND way_area IS NULL THEN waterway END,


### PR DESCRIPTION
Fixes #4898

Changes proposed in this pull request:

Restore rendering of reef name removed in #3712. mss code still present, just fixing SQL query.

Test rendering with links to the example places:

[Black Middens](https://www.openstreetmap.org/#map=16/55.01298/-1.42160&layers=N) at Z16

Before

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/56c35639-68d7-4829-9c59-564e2beb7d85)

After

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/1c313c0b-6f12-4fb4-b8d3-56b84621ccf0)

(Modified render chain hence different typeface, but otherwise identical to standard tile server)
