### PR TITLE
Render barrier=jersey_barrier

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -570,7 +570,7 @@ Layer:
                   WHERE way && !bbox!
                 ) _
               WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
-                  'handrail', 'hedge', 'retaining_wall', 'wall')
+                  'handrail', 'hedge', 'retaining_wall', 'wall', 'jersey_barrier')
               OR historic = 'citywalls'
               AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
           ) AS features
@@ -2287,7 +2287,7 @@ Layer:
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'jersey_barrier') THEN barrier END
             )  AS feature,
             CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
             way_area,
@@ -2328,7 +2328,7 @@ Layer:
                OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
-               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
+               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'jersey_barrier')
             ORDER BY
               CASE amenity
                 WHEN 'waste_basket' THEN 1

--- a/project.mml
+++ b/project.mml
@@ -2287,7 +2287,7 @@ Layer:
               'amenity_' || CASE WHEN amenity IN ('bench', 'waste_basket', 'waste_disposal') AND way_area IS NULL THEN amenity END,
               'historic_' || CASE WHEN historic IN ('wayside_cross', 'wayside_shrine') AND way_area IS NULL THEN historic END,
               'man_made_' || CASE WHEN man_made IN ('cross') AND way_area IS NULL THEN man_made END,
-              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'jersey_barrier') THEN barrier END
+              'barrier_' || CASE WHEN barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate') THEN barrier END
             )  AS feature,
             CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
             way_area,
@@ -2328,7 +2328,7 @@ Layer:
                OR amenity IN ('bench', 'waste_basket', 'waste_disposal')
                OR historic IN ('wayside_cross', 'wayside_shrine')
                OR man_made IN ('cross')
-               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate', 'jersey_barrier')
+               OR barrier IN ('bollard', 'gate', 'lift_gate', 'swing_gate', 'block', 'log', 'cattle_grid', 'stile', 'motorcycle_barrier', 'cycle_barrier', 'full-height_turnstile', 'turnstile', 'kissing_gate')
             ORDER BY
               CASE amenity
                 WHEN 'waste_basket' THEN 1

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1567,6 +1567,7 @@
   [feature = 'barrier_bollard'],
   [feature = 'barrier_block'],
   [feature = 'barrier_log'],
+  [feature = 'barrier_jersey_barrier'],
   [feature = 'barrier_turnstile'] {
     [zoom >= 17] {
       marker-width: 3;

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1567,7 +1567,6 @@
   [feature = 'barrier_bollard'],
   [feature = 'barrier_block'],
   [feature = 'barrier_log'],
-  [feature = 'barrier_jersey_barrier'],
   [feature = 'barrier_turnstile'] {
     [zoom >= 17] {
       marker-width: 3;


### PR DESCRIPTION

Fixes #4854 

Changes proposed in this pull request:
`barrier=jersey_barrier` on node is rendered as `barrier=block/log` .
`barrier=jersey_barrier` on way is rendered as default barrier, i.e. same as wall, fence.

There doesn't seem any value in introducing a distinct signature for jersey barrier as a way; the point is that the blocks form a continuous barrier. Although personally there doesn't seem much point in even distinguishing a jersey barrier used as a block, from an "ordinary" block, there would be even less point in rendering them differently.

Test rendering with links to the example places:

[Node](https://www.openstreetmap.org/#map=18/54.95838/-1.65994)

Current
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/d1b9d5c0-0291-4b12-bf38-b82f0de99019)

After
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/0d637f5f-61b7-4305-9b9f-512df11753fe)

[Way](https://www.openstreetmap.org/#map=18/54.85075/-1.56567)

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/e7622c93-4706-4317-ae48-a8e1a78b4987)

![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/be42e12a-3e31-45f6-8a8e-b970c5c2163d)

(Example of barrier between carriageways is not the prettiest, but nearest to hand and makes the point)

