### PR TITLE
Use common Single Quotes for Strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,27 @@ instead of
   }
 }
 ```
+* Use the PostgreSQL quoting syntax for attributes (columns) and string-values of selectors.
+  Use no quotes or double quotes for attributes (columns) and single quotes for string-values.
+  For Example:
+
+```mss
+#layer[entrance = 'yes'] {
+  marker-width: 6.0;
+}
+#layer["generator:source" = 'wind'] {
+  marker-width: 8.0;
+}
+```
+instead of
+```mss
+#layer[entrance = "yes"] {
+  marker-width: 6.0;
+}
+#layer['generator:source' = 'wind'] {
+  marker-width: 8.0;
+}
+```
 
 ## SQL style guidelines
 Because SQL within JSON or YAML will not generally be syntax highlighted, indentation and caps are particularly important.

--- a/style/buildings.mss
+++ b/style/buildings.mss
@@ -52,29 +52,29 @@
     marker-width: 5.0;
     marker-height: 5.0;
     marker-opacity: 0.0;
-    ["entrance" = "main"] {
+    ["entrance" = 'main'] {
       marker-opacity: 1.0;
       marker-file: url('symbols/square.svg');
     }
   }
   [zoom >= 19]["entrance" != null] {
-    ["entrance" = "yes"],
-    ["entrance" = "main"],
-    ["entrance" = "home"],
-    ["entrance" = "service"],
-    ["entrance" = "staircase"] {
+    ["entrance" = 'yes'],
+    ["entrance" = 'main'],
+    ["entrance" = 'home'],
+    ["entrance" = 'service'],
+    ["entrance" = 'staircase'] {
       marker-opacity: 1.0;
       marker-width: 6.0;
       marker-height: 6.0;
-      ["entrance" = "service"] {
+      ["entrance" = 'service'] {
         marker-file: url('symbols/corners.svg');
       }
     }
-    ["access" = "yes"],
-    ["access" = "permissive"] {
+    ["access" = 'yes'],
+    ["access" = 'permissive'] {
       marker-fill: @entrance-permissive;
     }
-    ["access" = "no"] {
+    ["access" = 'no'] {
       marker-fill: @entrance-normal;
       marker-file: url('symbols/rectdiag.svg');
     }

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -816,10 +816,10 @@
   //Also landuse = forest, converted in the SQL
   [natural = 'wood'][zoom >= 13]::wood {
     polygon-pattern-file: url('symbols/leaftype_unknown.svg'); // Lch(55,30,135)
-    [leaf_type = "broadleaved"] { polygon-pattern-file: url('symbols/leaftype_broadleaved.svg'); }
-    [leaf_type = "needleleaved"] { polygon-pattern-file: url('symbols/leaftype_needleleaved.svg'); }
-    [leaf_type = "mixed"] { polygon-pattern-file: url('symbols/leaftype_mixed.svg'); }
-    [leaf_type = "leafless"] { polygon-pattern-file: url('symbols/leaftype_leafless.svg'); }
+    [leaf_type = 'broadleaved'] { polygon-pattern-file: url('symbols/leaftype_broadleaved.svg'); }
+    [leaf_type = 'needleleaved'] { polygon-pattern-file: url('symbols/leaftype_needleleaved.svg'); }
+    [leaf_type = 'mixed'] { polygon-pattern-file: url('symbols/leaftype_mixed.svg'); }
+    [leaf_type = 'leafless'] { polygon-pattern-file: url('symbols/leaftype_leafless.svg'); }
     polygon-pattern-alignment: global;
     opacity: 0.4; // The entire layer has opacity to handle overlapping forests
   }


### PR DESCRIPTION
Fixes NO issue, just cosmetic change

Changes proposed in this pull request:
- Use single quoting for String constants

Test rendering with links to the example places:
- tested with `carto`; the generated `project.xml` files before and after are identical