### PR TITLE
Display man_made=utility_pole the same as power=pole

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1775,9 +1775,10 @@ Layer:
       table: |-
         (SELECT
             way,
-            power
+            power,
+            man_made
         FROM planet_osm_point
-        WHERE power IN ('tower', 'pole')
+        WHERE power IN ('tower', 'pole') OR man_made in ('utility_pole')
         ORDER BY
           CASE power
             WHEN 'tower' THEN 2

--- a/style/power.mss
+++ b/style/power.mss
@@ -51,4 +51,9 @@
     marker-fill: #928f8f;
     marker-width: 3;
   }
+  [man_made = 'utility_pole'][zoom >= 16] {
+    marker-file: url('symbols/square.svg');
+    marker-fill: #928f8f;
+    marker-width: 3;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/gravitystorm/openstreetmap-carto/issues/4949

aims to render `man_made=utility_pole` the same as `power=pole` 

