### PR TITLE
Rendering specific access tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         osm2pgsql -G --hstore --style openstreetmap-carto.style --tag-transform-script openstreetmap-carto.lua -d gis -r xml <(echo '<osm version="0.6"/>')
     - name: Create indexes
       run: psql -1Xq -v ON_ERROR_STOP=1 -d gis -f indexes.sql
+    - name: Load functions
+      run: psql -1Xq -v ON_ERROR_STOP=1 -d gis -f functions.sql
     - name: Load empty shapefiles
       run: scripts/get-external-data.py --no-update --cache -D scripts/empty_files
     - name: Test queries are valid

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,13 @@ The indexes can be created in parallel with
 scripts/indexes.py -0 | xargs -0 -P0 -I{} psql -d gis -c "{}"
 ```
 
+### Database functions
+Some functions need to be loaded into the database for current versions. These can be added / re-loaded at any point using:
+
+```sh
+psql -d gis -f functions.sql
+```
+
 ## Scripted download
 Some features are rendered using preprocessed shapefiles.
 

--- a/functions.sql
+++ b/functions.sql
@@ -23,6 +23,22 @@ SELECT
 END
 $$;
 
+/* Try to promote path to cycleway (if bicycle allowed), then bridleway (if horse)
+   This duplicates existing behaviour where designated access is required */
+CREATE OR REPLACE FUNCTION carto_path_primary_mode(bicycle text, horse text)
+	RETURNS text
+	LANGUAGE SQL
+	IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT
+	CASE
+		WHEN bicycle IN ('designated') THEN 'bicycle'
+		WHEN horse IN ('designated') THEN 'horse'
+		ELSE 'foot'
+	END
+END
+$$;
+
 /* Classify highways into access categories which will be treated in the same way
    Default is NULL in which case only the access tag will be used (e.g. highway=track)
    Note that bicycle, horse arguments are only relevant if considering highway=path */

--- a/functions.sql
+++ b/functions.sql
@@ -1,0 +1,76 @@
+/* Additional database functions for openstreetmap-carto */
+
+/* Access functions below adapted from https://github.com/imagico/osm-carto-alternative-colors/tree/591c861112b4e5d44badd108f4cd1409146bca0b/sql/roads.sql */
+
+
+/* Simplified 'yes', 'restricted', 'no', NULL scale for access restriction 
+  'no' is returned if the rendering for highway category does not support 'destination'.
+  NULL is functionally equivalent to 'yes', but indicates the absence of a restriction 
+  rather than a positive access = yes */
+CREATE OR REPLACE FUNCTION carto_int_access(primary_mode text, accesstag text)
+	RETURNS text
+	LANGUAGE SQL
+	IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT
+	CASE
+	WHEN accesstag IN ('yes', 'designated', 'permissive', 'customers') THEN 'yes'
+	WHEN accesstag IN ('destination',  'delivery', 'permit') THEN
+		CASE WHEN primary_mode IN ('motorcar', 'pedestrian') THEN 'restricted' ELSE 'no' END
+	WHEN accesstag IN ('no', 'private', 'agricultural', 'forestry', 'agricultural;forestry') THEN 'no'
+	ELSE NULL
+	END
+END
+$$;
+
+/* Classify highways into access categories which will be treated in the same way
+   Default is NULL in which case only the access tag will be used (e.g. highway=track)
+   Note that bicycle, horse arguments are only relevant if considering highway=path */
+CREATE OR REPLACE FUNCTION carto_highway_primary_mode(highway text, bicycle text, horse text)
+	RETURNS text
+	LANGUAGE SQL
+	IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT
+	CASE 
+    WHEN highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary',
+                 'secondary_link', 'tertiary', 'tertiary_link', 'residential', 'unclassified', 'living_street', 'service', 'road') THEN 'motorcar'
+	WHEN highway = 'pedestrian' THEN 'pedestrian'
+	WHEN highway IN ('footway', 'steps') THEN 'foot'
+	WHEN highway = 'bridleway' THEN 'horse'
+	WHEN highway = 'cycleway' THEN 'bicycle'
+	WHEN highway = 'path' THEN carto_path_primary_mode(bicycle, horse)
+	ELSE NULL
+	END
+END
+$$;
+
+/* Return int_access value which will be used to determine access marking.
+   Only a restricted number of types can be returned, with NULL corresponding to no access restriction */
+CREATE OR REPLACE FUNCTION carto_highway_int_access(highway text, "access" text, foot text, bicycle text, horse text, motorcar text, motor_vehicle text, vehicle text)
+  RETURNS text
+  LANGUAGE SQL
+  IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT
+	CASE carto_highway_primary_mode(highway, bicycle, horse)
+	WHEN 'motorcar' THEN
+		carto_int_access('motorcar', CASE
+			WHEN motorcar IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN motorcar
+			WHEN motor_vehicle IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN motor_vehicle
+			WHEN vehicle IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN vehicle
+			ELSE "access" END)
+	WHEN 'pedestrian' THEN carto_int_access('pedestrian', 'no')
+	WHEN 'foot' THEN carto_int_access('foot', CASE WHEN foot IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN foot ELSE "access" END)
+	WHEN 'bicycle' THEN carto_int_access('bicycle', CASE WHEN bicycle IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN bicycle ELSE "access" END)
+	WHEN 'horse' THEN carto_int_access('horse', CASE WHEN horse IN ('yes', 'designated', 'permissive', 'no', 'private', 'destination', 'customers', 'delivery', 'permit') THEN horse ELSE "access" END)
+	ELSE carto_int_access(NULL, "access")
+	END
+END
+$$;
+
+/* Uncomment lines below to create generated column for int_access 
+ALTER TABLE planet_osm_line DROP COLUMN IF EXISTS int_access;
+ALTER TABLE planet_osm_line
+	ADD int_access text GENERATED ALWAYS AS (CASE WHEN highway IS NOT NULL THEN carto_highway_int_access(highway, "access", foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') ELSE NULL END) STORED;
+*/

--- a/project.mml
+++ b/project.mml
@@ -449,7 +449,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
-            access,
+            int_access,
             construction,
             service,
             link,
@@ -467,9 +467,7 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
-                CASE WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
                   WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text
@@ -496,10 +494,7 @@ Layer:
                 bicycle,
                 tracktype,
                 'null',
-                CASE
-                  WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                NULL,
                 construction,
                 CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,
                 'no' AS link,
@@ -514,7 +509,7 @@ Layer:
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
         ) AS tunnels
     properties:
@@ -686,7 +681,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
-            access,
+            int_access,
             construction,
             service,
             link,
@@ -704,9 +699,7 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
-                CASE WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
                   WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text
@@ -741,10 +734,7 @@ Layer:
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                   ELSE NULL
                 END AS int_surface,
-                CASE
-                  WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                NULL,
                 construction,
                 CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,
                 'no' AS link,
@@ -763,7 +753,7 @@ Layer:
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
             osm_id
         ) AS roads_sql
@@ -918,7 +908,7 @@ Layer:
             bicycle,
             tracktype,
             int_surface,
-            access,
+            int_access,
             construction,
             service,
             link,
@@ -936,9 +926,7 @@ Layer:
                   WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
                                       'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
                 END AS int_surface,
-                CASE WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
                   WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text
@@ -965,10 +953,7 @@ Layer:
                 bicycle,
                 tracktype,
                 'null',
-                CASE
-                  WHEN access IN ('destination') THEN 'destination'::text
-                  WHEN access IN ('no', 'private') THEN 'no'::text
-                END AS access,
+                NULL,
                 construction,
                 CASE WHEN service IN ('parking_aisle', 'drive-through', 'driveway') THEN 'INT-minor'::text ELSE 'INT-normal'::text END AS service,
                 'no' AS link,
@@ -983,7 +968,7 @@ Layer:
             z_order,
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-preserved-ssy', 'railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
-            CASE WHEN access IN ('no', 'private') THEN 0 WHEN access IN ('destination') THEN 1 ELSE 2 END,
+            CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
             CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
         ) AS bridges
     properties:

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -644,7 +644,7 @@
 
     [feature = 'highway_steps'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @steps-width-z14 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -653,7 +653,7 @@
         }
       }
       #tunnels {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @steps-width-z14 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
@@ -666,7 +666,7 @@
     [feature = 'highway_bridleway'],
     [feature = 'highway_path'][horse = 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @bridleway-width-z13 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @bridleway-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -675,7 +675,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-width: @bridleway-width-z13 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @bridleway-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
@@ -688,7 +688,7 @@
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @footway-width-z14 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -700,7 +700,7 @@
         }
       }
       #tunnels {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @footway-width-z14 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
@@ -716,7 +716,7 @@
     [feature = 'highway_cycleway'],
     [feature = 'highway_path'][bicycle = 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @cycleway-width-z13 + 2 * (@paths-background-width + @paths-bridge-casing-width);
           [zoom >= 15] { line-width: @cycleway-width-z15 + 2 * (@paths-background-width + @paths-bridge-casing-width); }
@@ -728,7 +728,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-width: @cycleway-width-z13 + 2 * (@paths-background-width + @paths-tunnel-casing-width);
           [zoom >= 15] { line-width: @cycleway-width-z15 + 2 * (@paths-background-width + @paths-tunnel-casing-width); }
@@ -743,7 +743,7 @@
 
     [feature = 'highway_track'] {
       #bridges {
-        [zoom >= 13][access != 'no'] {
+        [zoom >= 13][int_access != 'no'] {
           line-color: @bridge-casing;
           line-join: round;
           line-width: @track-width-z13 + 2 * (@paths-background-width + @paths-bridge-casing-width);
@@ -767,7 +767,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-color: @tunnel-casing;
           line-dasharray: 4,2;
@@ -870,7 +870,7 @@
     [feature = 'highway_bridleway'],
     [feature = 'highway_path'][horse = 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @bridleway-width-z13 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @bridleway-width-z15 + 2 * @paths-background-width; }
@@ -879,7 +879,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-color: @bridleway-casing;
           line-cap: round;
@@ -893,7 +893,7 @@
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @footway-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @footway-width-z15 + 2 * @paths-background-width; }
@@ -905,7 +905,7 @@
         }
       }
       #tunnels {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-color: @footway-casing;
           line-cap: round;
@@ -922,7 +922,7 @@
     [feature = 'highway_cycleway'],
     [feature = 'highway_path'][bicycle = 'designated'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @cycleway-width-z13 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @cycleway-width-z15 + 2 * @paths-background-width; }
@@ -934,7 +934,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-color: @cycleway-casing;
           line-cap: round;
@@ -950,7 +950,7 @@
 
     [feature = 'highway_steps'] {
       #bridges {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-width: @steps-width-z14 + 2 * @paths-background-width;
           [zoom >= 15] { line-width: @steps-width-z15 + 2 * @paths-background-width; }
@@ -959,7 +959,7 @@
         }
       }
       #tunnels {
-        [zoom >= 14][access != 'no'],
+        [zoom >= 14][int_access != 'no'],
         [zoom >= 15] {
           line-color: @steps-casing;
           line-cap: round;
@@ -973,7 +973,7 @@
     [feature = 'highway_track'] {
       /* We don't set opacity here, so it's 1.0. Aside from that, it's basically a copy of roads-fill::background in the track part of ::fill */
       #bridges {
-        [zoom >= 13][access != 'no'] {
+        [zoom >= 13][int_access != 'no'] {
           line-color: @track-casing;
           line-join: round;
           line-width: @track-width-z13 + 2 * @paths-background-width;
@@ -997,7 +997,7 @@
         }
       }
       #tunnels {
-        [zoom >= 13][access != 'no'],
+        [zoom >= 13][int_access != 'no'],
         [zoom >= 15] {
           line-color: @track-casing;
           line-join: round;
@@ -2258,7 +2258,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_steps'] {
-      [zoom >= 14][access != 'no'],
+      [zoom >= 14][int_access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @steps-casing;
@@ -2268,7 +2268,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           background/line-opacity: 0.4;
         }
         line/line-color: @steps-fill;
-        [access = 'no'] { line/line-color: @steps-fill-noaccess; }
+        [int_access = 'no'] { line/line-color: @steps-fill-noaccess; }
         line/line-dasharray: 2,1;
         line/line-width: @steps-width-z14;
         [zoom >= 15] { line/line-width:  @steps-width-z15; }
@@ -2277,7 +2277,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_bridleway'],
     [feature = 'highway_path'][horse = 'designated'] {
-      [zoom >= 13][access != 'no'],
+      [zoom >= 13][int_access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @bridleway-casing;
@@ -2287,7 +2287,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           background/line-opacity: 0.4;
         }
         line/line-color: @bridleway-fill;
-        [access = 'no'] { line/line-color: @bridleway-fill-noaccess; }
+        [int_access = 'no'] { line/line-color: @bridleway-fill-noaccess; }
         line/line-dasharray: 4,2;
         line/line-width: @bridleway-width-z13;
         [zoom >= 15] { line/line-width: @bridleway-width-z15; }
@@ -2300,7 +2300,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_footway'],
     [feature = 'highway_path'][bicycle != 'designated'][horse != 'designated'] {
-      [zoom >= 14][access != 'no'],
+      [zoom >= 14][int_access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @footway-casing;
@@ -2319,7 +2319,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           }
         }
         line/line-color: @footway-fill;
-        [access = 'no'] { line/line-color: @footway-fill-noaccess; }
+        [int_access = 'no'] { line/line-color: @footway-fill-noaccess; }
         line/line-dasharray: 1,3;
         line/line-join: round;
         line/line-cap: round;
@@ -2343,7 +2343,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [zoom >= 15][int_surface = null] {
           line/line-color: @footway-fill;
-          [access = 'no'] { line/line-color: @footway-fill-noaccess; }
+          [int_access = 'no'] { line/line-color: @footway-fill-noaccess; }
           line/line-dasharray: 1,3,2,4;
           line/line-join: round;
           line/line-cap: round;
@@ -2361,7 +2361,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [zoom >= 15][int_surface = 'unpaved'] {
           line/line-color: @footway-fill;
-          [access = 'no'] { line/line-color: @footway-fill-noaccess; }
+          [int_access = 'no'] { line/line-color: @footway-fill-noaccess; }
           line/line-dasharray: 1,4;
           line/line-join: round;
           line/line-cap: round;
@@ -2381,7 +2381,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
     [feature = 'highway_cycleway'],
     [feature = 'highway_path'][bicycle = 'designated'] {
-      [zoom >= 13][access != 'no'],
+      [zoom >= 13][int_access != 'no'],
       [zoom >= 15] {
         #roads-fill[zoom >= 15] {
           background/line-color: @cycleway-casing;
@@ -2400,7 +2400,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           }
         }
         line/line-color: @cycleway-fill;
-        [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
+        [int_access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
         line/line-dasharray: 1,3;
         line/line-join: round;
         line/line-cap: round;
@@ -2424,7 +2424,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [zoom >= 15][int_surface = null] {
           line/line-color: @cycleway-fill;
-          [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
+          [int_access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
           line/line-dasharray: 1,3,2,4;
           line/line-join: round;
           line/line-cap: round;
@@ -2442,7 +2442,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [zoom >= 15][int_surface = 'unpaved'] {
           line/line-color: @cycleway-fill;
-          [access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
+          [int_access = 'no'] { line/line-color: @cycleway-fill-noaccess; }
           line/line-dasharray: 1,4;
           line/line-join: round;
           line/line-cap: round;
@@ -2461,7 +2461,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     }
 
     [feature = 'highway_track'] {
-      [zoom >= 13][access != 'no'],
+      [zoom >= 13][int_access != 'no'],
       [zoom >= 15] {
         /* The white casing that you mainly see against forests and other dark features */
         #roads-fill[zoom >= 15] {
@@ -2481,7 +2481,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
         /* Set the properties of the brown inside */
         line/line-color: @track-fill;
-        [access = 'no'] { line/line-color: @track-fill-noaccess; }
+        [int_access = 'no'] { line/line-color: @track-fill-noaccess; }
         line/line-dasharray: 5,4,2,4;
         line/line-cap: round;
         line/line-join: round;
@@ -3378,7 +3378,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #tunnels::fill,
 #roads-fill::fill,
 #bridges::fill {
-  [access = 'destination'] {
+  [int_access = 'restricted'] {
     [feature = 'highway_secondary'],
     [feature = 'highway_tertiary'],
     [feature = 'highway_unclassified'],
@@ -3441,7 +3441,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       }
     }
   }
-  [access = 'no'] {
+  [int_access = 'no'] {
     [feature = 'highway_motorway'],
     [feature = 'highway_trunk'],
     [feature = 'highway_primary'],


### PR DESCRIPTION
Fixes #214 

Changes proposed in this pull request:

The code proposed has been extensively discussed in #214, but in summary:

SQL functions introduced that interpret mode-specific access tags in addition to the overall `access` tag.

Tags considered are determined by a "primary mode" inferred from the highway types:
Vehicle road (primary mode: motorcar): motorcar > motor_vehicle > vehicle
cycleway: bicycle
bridleway: horse
footway, steps: foot
[Access tagging on `track` is unchanged, i.e. only determined by `access`]

In this initial PR, the interpretation of path is unchanged, i.e. path is considered to be a cycleway or bridleway if `bicycle=designated` or `horse=designated` respectively. 

The access tags are reduced to a single `int_access` tag tagging the values `no`, `restricted` and `yes` (which is equivalent to NULL). `restricted` used to indicate an intermediate "some restrictions apply" for vehicles. The access marking used is the the current `access=destination`, but the name change reflects the fact that other values are included, e.g. `delivery`.

The `int_access` is generated, as normal practice for this style, on-the-fly. An option to use a generated column to pre-calculate these values is commented out. In practice, the overhead of combining the access tags is likely to be small given the vast amount of in-line SQL in the roads query. Note that some cruft in the railway side of the roads query has been removed.

Other global access tags, such as `access=forestry`, are also now interpreted (equivalent to `no`). `access=agriculture;forestry` is also accepted, although we don't typically interpret multiple-value tags.

The code does not require a database re-load, but does require additional functions to be installed in the Postgres database. These have been placed into a file `functions.sql` so that there is a place where functions for the style can be gathered. This does require an additional step in installing the style, and so installation instructions and the CI test have been adjusted. **The Docker set-up has not been touched and will need fixing by somebody who understands/uses it.**

Test rendering with links to the example places:

[Destination marking](https://www.openstreetmap.org/#map=18/54.77850/-1.56185)
Residential highway tagged with `motor_vehicle=destination`.

Before
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/c654fe19-50dd-4768-8d93-269282cdb819)

After
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/66296481-356c-48f3-bdb5-48286b2cf848)

[No marking](https://www.openstreetmap.org/#map=19/54.96896/-1.60767)
Before
`access=yes, motor_vehicle=no, psv=yes`
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/756cd55f-3313-4d0f-a6f4-798e79e9b5cb)

After
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/5b4a6173-b3bf-448f-8c9f-3a45b4d480d0)

[Honouring foot](https://www.openstreetmap.org/#map=19/54.76070/-1.58423)
North-south footway tagged with `highway=footway, foot=private`

Before
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/90dfb586-3960-4b68-a644-04cb86bea8c7)

After
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/54b04f51-0c9b-467a-a521-7c5de3c7c9b8)

[Honouring bicycle](https://www.openstreetmap.org/#map=19/54.97082/-1.48406)
`highway=cycleway, bicycle=designated, access=no`
Before
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/86e6e715-22f2-457b-8e21-79e8067dd134)

After
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/e7a37078-2216-47e6-ba16-ca3134055d13)

The last example needs discussion since it is a case where `access=no` has been added because the bridge is closed:
![image](https://github.com/gravitystorm/openstreetmap-carto/assets/20069699/66d39624-fcdf-4b25-a412-0a5581d0d4d5)

The logic of access tagging is that the general `access=no` is overridden by the specific `bicycle=designated`, and a router should allow bicycles across. So this usage is arguably tagging for the renderer: retaining perhaps a formal right of way (`bicycle=designated`) but indicating that the way is closed by exploiting Carto's simple approach to access tagging.

It is inevitable that a wider and more correct usage of the access tags will throw up such cases!





