### PR TITLE
Remove trailing whitespace from `styles/*.mss` files

### DIFF
--- a/style/roads.mss
+++ b/style/roads.mss
@@ -1682,7 +1682,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-pattern-join: round;
         }
       }
-    }    
+    }
 
     [feature = 'highway_secondary'] {
       [zoom >= 9][link != 'yes'],
@@ -1742,7 +1742,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-pattern-type: repeat;
           line-pattern-alignment: global;
           line-pattern-width: @secondary-width-z12 - 2 * @secondary-casing-width-z12;
-          line-pattern-file: url("symbols/unpaved/unpaved_secondary-fill.svg");          
+          line-pattern-file: url("symbols/unpaved/unpaved_secondary-fill.svg");
           line-pattern-cap: round;
           line-pattern-join: round;
           [zoom >= 13] {
@@ -1841,7 +1841,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-pattern-type: repeat;
           line-pattern-alignment: global;
           line-pattern-width: @tertiary-width-z12 - 2 * @casing-width-z12;
-          line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");          
+          line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
           [zoom >= 13] { line-pattern-width: @tertiary-width-z13 - 2 * @casing-width-z13; }
           [zoom >= 14] { line-pattern-width: @tertiary-width-z14 - 2 * @casing-width-z14; }
           [zoom >= 15] { line-pattern-width: @tertiary-width-z15 - 2 * @casing-width-z15; }
@@ -1932,7 +1932,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 19] { line-pattern-width: @residential-width-z19 - 2 * @casing-width-z19; }
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
         #bridges {
           line-pattern-width: @residential-width-z13 - 2 * @bridge-casing-width-z13;
           [zoom >= 14] { line-pattern-width: @residential-width-z14 - 2 * @bridge-casing-width-z14; }
@@ -1990,7 +1990,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 19] { line-pattern-width: @living-street-width-z19 - 2 * @casing-width-z19; }
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_living-street-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_living-street-fill.svg");
         #bridges {
           line-pattern-width: @living-street-width-z13 - 2 * @casing-width-z13;
           [zoom >= 14] { line-pattern-width: @living-street-width-z14 - 2 * @bridge-casing-width-z14; }
@@ -2003,7 +2003,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         line-pattern-join: round;
         line-pattern-cap: round;
       }
-    }    
+    }
 
     [feature = 'highway_road'] {
       [zoom >= 10] {
@@ -2047,7 +2047,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 19] { line-pattern-width: @road-width-z19 - 2 * @casing-width-z19; }
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_road-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_road-fill.svg");
         #bridges {
           line-pattern-width: @road-width-z14 - 2 * @bridge-casing-width-z14;
           [zoom >= 16] { line-pattern-width: @road-width-z16 - 2 * @bridge-casing-width-z16; }
@@ -2110,7 +2110,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 17][service = 'INT-minor'] {
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_residential-fill.svg");
         [service = 'INT-normal'] {
           line-pattern-width: @service-width-z14 - 2 * @casing-width-z14;
           [zoom >= 16] { line-pattern-width: @service-width-z16 - 2 * @casing-width-z16; }
@@ -2183,7 +2183,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [zoom >= 19] { line-pattern-width: @pedestrian-width-z19 - 2 * @casing-width-z19; }
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_pedestrian-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_pedestrian-fill.svg");
         #bridges {
           line-pattern-width: @pedestrian-width-z14 - 2 * @bridge-casing-width-z14;
           [zoom >= 15] { line-pattern-width: @pedestrian-width-z15 - 2 * @bridge-casing-width-z15; }
@@ -2216,7 +2216,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       [zoom >= 12] {
         line-pattern-type: repeat;
         line-pattern-alignment: global;
-        line-pattern-file: url("symbols/unpaved/unpaved_raceway-fill.svg"); 
+        line-pattern-file: url("symbols/unpaved/unpaved_raceway-fill.svg");
         line-pattern-width: 1.2;
         line-pattern-join: round;
         line-pattern-cap: round;
@@ -2251,7 +2251,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         b/line-pattern-width: 4;
         b/line-pattern-type: repeat;
         b/line-pattern-alignment: global;
-        b/line-pattern-file: url("symbols/unpaved/unpaved_platform-fill.svg"); 
+        b/line-pattern-file: url("symbols/unpaved/unpaved_platform-fill.svg");
         b/line-pattern-cap: round;
         b/line-pattern-join: round;
       }
@@ -2539,6 +2539,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           line-dasharray: 5,2;
         }
       }
+
       [zoom >= 12] {
         #roads-fill, #bridges {
           dark/line-join: round;
@@ -2764,7 +2765,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         b/line-pattern-width: 4;
         b/line-pattern-type: repeat;
         b/line-pattern-alignment: global;
-        b/line-pattern-file: url("symbols/unpaved/unpaved_platform-fill.svg"); 
+        b/line-pattern-file: url("symbols/unpaved/unpaved_platform-fill.svg");
         b/line-pattern-cap: round;
         b/line-pattern-join: round;
       }
@@ -3559,7 +3560,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [int_surface = 'unpaved'] {
           line-pattern-type: repeat;
           line-pattern-alignment: global;
-          line-pattern-file: url("symbols/unpaved/unpaved_aeroway-fill.svg"); 
+          line-pattern-file: url("symbols/unpaved/unpaved_aeroway-fill.svg");
           line-pattern-width: 2;
           [zoom >= 12] { line-pattern-width: 4; }
           [zoom >= 13] { line-pattern-width: 6; }
@@ -3593,7 +3594,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [int_surface = 'unpaved'] {
           line-pattern-type: repeat;
           line-pattern-alignment: global;
-          line-pattern-file: url("symbols/unpaved/unpaved_aeroway-fill.svg"); 
+          line-pattern-file: url("symbols/unpaved/unpaved_aeroway-fill.svg");
           line-pattern-width: 1;
           [zoom >= 13] { line-pattern-width: 2; }
           [zoom >= 14] { line-pattern-width: 4; }

--- a/style/tourism.mss
+++ b/style/tourism.mss
@@ -16,7 +16,7 @@
       line-width: 2.5 + @bridge-casing-width-z16;
       line-color: #000;
       line-join: round;
-      
+
       [tunnel = 'yes'] { line-color: lighten(#000, 20%); }
 
       [zoom >= 17] { line-width: 4 + @bridge-casing-width-z17; }


### PR DESCRIPTION
Ref https://github.com/gravitystorm/openstreetmap-carto/pull/4965#discussion_r1597107518

This PR removes trailing whitespace from files in the `styles` directory.