### PR TITLE
Move leisure=track

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1782,7 +1782,7 @@ Layer:
           COALESCE(
            'highway_' || CASE WHEN tags -> 'ford' IN ('yes', 'stepping_stones') THEN 'ford' END,
            'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure END
-            ) AS feature,
+            ) AS feature
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
           WHERE tags -> 'ford' IN ('yes', 'stepping_stones')

--- a/project.mml
+++ b/project.mml
@@ -151,9 +151,17 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way
+            way,
+            COALESCE(
+               'leisure_' || CASE WHEN leisure = 'track' THEN 'track' END,
+               'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END,
+               'man_made_' || CASE WHEN man_made = 'cutline' THEN 'cutline' END
+            ) AS feature
           FROM planet_osm_line
-          WHERE man_made = 'cutline'
+          WHERE leisure = 'track'
+            OR tags @> 'attraction=>water_slide'
+            OR man_made = 'cutline'
+          ORDER BY COALESCE(layer,0)
         ) AS landcover_line
     properties:
       minzoom: 14
@@ -1772,15 +1780,13 @@ Layer:
         (SELECT
           way,
           COALESCE(
-           'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' END,
-           'leisure_' || CASE WHEN leisure IN ('slipway', 'track') THEN leisure END,
-           'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END
-            ) AS feature
+           'highway_' || CASE WHEN tags -> 'ford' IN ('yes', 'stepping_stones') THEN 'ford' END,
+           'leisure_' || CASE WHEN leisure IN ('slipway') THEN leisure END
+            ) AS feature,
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
-          WHERE tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
-            OR leisure IN ('slipway', 'track')
-            OR tags @> 'attraction=>water_slide'
+          WHERE tags -> 'ford' IN ('yes', 'stepping_stones')
+            OR leisure = 'slipway'
           ORDER BY COALESCE(layer,0)
         ) AS amenity_line
     properties:

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -3006,42 +3006,6 @@
     marker-file: url('symbols/leisure/slipway.svg');
     marker-fill: @transportation-icon;
   }
-
-  [feature = 'leisure_track'] {
-    [zoom >= 16] {
-      [zoom >= 17] {
-        bridgecasing/line-color: saturate(darken(@pitch, 30%), 20%);
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: 1.25;
-        [zoom >= 18] { bridgecasing/line-width: 2.5; }
-        [zoom >= 19] { bridgecasing/line-width: 5; }
-      }
-      line-color: @pitch;
-      line-join: round;
-      line-cap: round;
-      line-width: 1;
-      [zoom >= 18] { line-width: 2; }
-      [zoom >= 19] { line-width: 4; }
-    }
-  }
-
-  [feature = 'attraction_water_slide'] {
-    [zoom >= 16] {
-      [zoom >= 17] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: 1.25;
-        [zoom >= 18] { bridgecasing/line-width: 2.5; }
-        [zoom >= 19] { bridgecasing/line-width: 5; }
-      }
-      line-color: @pitch;
-      line-join: round;
-      line-cap: round;
-      line-width: 1;
-      [zoom >= 18] { line-width: 2; }
-      [zoom >= 19] { line-width: 4; }
-    }
-  }
 }
 
 #text-line {

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -724,18 +724,55 @@
 }
 }
 
-/* man_made=cutline */
 #landcover-line {
-  [zoom >= 14] {
-    line-width: 3;
-    line-join: round;
-    line-cap: square;
-    line-color: @grass;
-    [zoom >= 16] {
-      line-width: 6;
-      [zoom >= 18] {
-        line-width: 12;
+  [feature = 'man_made_cutline'] {
+    [zoom >= 14] {
+      line-width: 3;
+      line-join: round;
+      line-cap: square;
+      line-color: @grass;
+      [zoom >= 16] {
+        line-width: 6;
+        [zoom >= 18] {
+          line-width: 12;
+        }
       }
+    }
+  }
+
+  [feature = 'leisure_track'] {
+    [zoom >= 16] {
+      [zoom >= 17] {
+        bridgecasing/line-color: saturate(darken(@pitch, 30%), 20%);
+        bridgecasing/line-join: round;
+        bridgecasing/line-width: 1.25;
+        [zoom >= 18] { bridgecasing/line-width: 2.5; }
+        [zoom >= 19] { bridgecasing/line-width: 5; }
+      }
+      line-color: @pitch;
+      line-join: round;
+      line-cap: round;
+      line-width: 1;
+      [zoom >= 18] { line-width: 2; }
+      [zoom >= 19] { line-width: 4; }
+    }
+  }
+
+  [feature = 'attraction_water_slide'] {
+    [zoom >= 16] {
+      [zoom >= 17] {
+        bridgecasing/line-color: black;
+        bridgecasing/line-join: round;
+        bridgecasing/line-width: 1.25;
+        [zoom >= 18] { bridgecasing/line-width: 2.5; }
+        [zoom >= 19] { bridgecasing/line-width: 5; }
+      }
+      line-color: @pitch;
+      line-join: round;
+      line-cap: round;
+      line-width: 1;
+      [zoom >= 18] { line-width: 2; }
+      [zoom >= 19] { line-width: 4; }
     }
   }
 }


### PR DESCRIPTION
Fixes #4726 

Changes proposed in this pull request:

Move `leisure=track` and `attraction=water_slide` from `amenity-line` to `landcover-line` layer

[Also tweak to `highway=ford` SQL query to simplify hstore query]

Test rendering with links to the example places:

Before

[Power line vs. track ordering](https://www.openstreetmap.org/note/2495452#map=18/54.833971/-1.602923)
![image](https://github.com/user-attachments/assets/78c1fbe2-689e-418f-bdb1-1aff6b130c6b)

After

![image](https://github.com/user-attachments/assets/c845b24e-0fc4-44e9-b96e-53d89309c7eb)

Unchanged renders for:

[Ford as linear way](https://www.openstreetmap.org/note/2495452#map=19/54.797344/-1.540874)
![image](https://github.com/user-attachments/assets/063f9163-a46e-4e19-93bf-869fe1c502fd)

[`attraction=water_slide`](https://www.openstreetmap.org/note/2495452#map=18/54.295969/-0.412698)
![image](https://github.com/user-attachments/assets/43ff73fb-0e9f-490a-b3d5-15b04080ab1a)

**Comments**

As a ground-level feature, `leisure=track` is a very natural fit for early rendering in `landcover-line`. It's less obvious that water slides should be rendered e.g. before roller-coasters. Perhaps a future optimisation would be to merge many of these layers, so that the `layer` tag can be properly exploited?

[Note that #4104 proposes moving `leisure=track` to the roads layer (tricky) or `aerialways` and `attraction=water_slide` to `waterway-bridges`. It would make sense to consider these alternatives.]