### PR TITLE
Fix `generate_road_colours.py` reference in `INSTALL.md`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,7 +112,7 @@ To display *any* map, a database containing OpenStreetMap data and some utilitie
 Some colours, SVGs and other files are generated with helper scripts. Not all users will need these dependencies.
 
 * [Python](https://www.python.org/downloads/)
-* [`generate_road_colors.py`](./scripts/generate_road_colors.py) and [`generate_unpaved_patterns.py`](./scripts/generate_unpaved_patterns.py) depend on [Color Math](https://github.com/gtaylor/python-colormath) and [`numpy`](https://numpy.org/). To install these, run:
+* [`generate_road_colours.py`](./scripts/generate_road_colours.py) and [`generate_unpaved_patterns.py`](./scripts/generate_unpaved_patterns.py) depend on [Color Math](https://github.com/gtaylor/python-colormath) and [`numpy`](https://numpy.org/). To install these, run:
     ```bash
     python3 -m pip install --break-system-packages --user colormath numpy
     ```


### PR DESCRIPTION
Tracks the change introduced in https://github.com/gravitystorm/openstreetmap-carto/commit/57f503757fe6022f71d554edcf7d02a7514b39be#diff-c9dbabc2d7d239ba319fd6a54c552cf65b8d0b6120a23d04480031b6a25b996e.

Changes proposed in this pull request:
- Fix `generate_road_colours.py` reference in `INSTALL.md`