### PR TITLE
Move leisure=track and attraction=water_slide

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -513,6 +513,20 @@ Layer:
       cache-features: true
       group-by: layernotnull
       minzoom: 10
+  - id: leisure-track
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+          way
+          FROM planet_osm_line
+          WHERE leisure = 'track'
+          ORDER BY COALESCE(layer,0)
+        ) AS leisure_track
+    properties:
+      minzoom: 16
   - id: landuse-overlay
     geometry: polygon
     <<: *extents
@@ -804,35 +818,6 @@ Layer:
       table: *turning-circle_sql
     properties:
       minzoom: 15
-  - id: aerialways
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            aerialway,
-            man_made,
-            tags->'substance' AS substance
-          FROM planet_osm_line
-          WHERE aerialway IS NOT NULL
-            OR (man_made = 'pipeline'
-                AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
-                OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
-            OR (man_made = 'goods_conveyor'
-                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
-                AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
-          ORDER BY
-            CASE
-              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
-              WHEN tags-> 'location' = 'overhead' THEN 2
-              WHEN bridge IS NOT NULL THEN 3
-              WHEN aerialway IS NOT NULL THEN 4
-            END
-        ) AS aerialways
-    properties:
-      minzoom: 12
   - id: roads-low-zoom
     geometry: linestring
     <<: *extents
@@ -865,29 +850,19 @@ Layer:
       cache-features: true
       minzoom: 6
       maxzoom: 9
-  - id: waterway-bridges
+  - id: guideways
     geometry: linestring
     <<: *extents
     Datasource:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            waterway,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') 
-              OR waterway = 'canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel,
-            'yes' AS bridge
+            way
           FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
-            AND bridge IN ('yes', 'aqueduct')
-          ORDER BY COALESCE(layer,0)
-        ) AS waterway_bridges
+          WHERE highway = 'bus_guideway'
+        ) AS guideways
     properties:
-      minzoom: 12
+      minzoom: 11
   - id: bridges
     geometry: linestring
     <<: *extents
@@ -966,7 +941,57 @@ Layer:
       cache-features: true
       group-by: layernotnull
       minzoom: 10
-  - id: guideways
+  - id: aeroways
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aeroway,
+            bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct') AS bridge,
+            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
+              WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
+                                  'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
+              ELSE NULL
+            END AS int_surface
+          FROM planet_osm_line
+          WHERE aeroway IN ('runway', 'taxiway')
+          ORDER BY
+            bridge NULLS FIRST,
+            CASE WHEN aeroway = 'runway' THEN 1 ELSE 0 END,
+            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
+                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END
+        ) AS aeroways
+    properties:
+      cache-features: true
+      minzoom: 11
+  - id: waterway-bridges
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            waterway,
+            CASE WHEN tags->'intermittent' IN ('yes')
+              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+              THEN 'yes' ELSE 'no' END AS int_intermittent,
+            CASE WHEN tunnel IN ('yes', 'culvert') 
+              OR waterway = 'canal' AND tunnel = 'flooded'
+              THEN 'yes' ELSE 'no' END AS int_tunnel,
+            'yes' AS bridge
+          FROM planet_osm_line
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+            AND bridge IN ('yes', 'aqueduct')
+          ORDER BY COALESCE(layer,0)
+        ) AS waterway_bridges
+    properties:
+      minzoom: 12
+  - id: waterslide
     geometry: linestring
     <<: *extents
     Datasource:
@@ -975,10 +1000,11 @@ Layer:
         (SELECT
             way
           FROM planet_osm_line
-          WHERE highway = 'bus_guideway'
-        ) AS guideways
+          WHERE tags @> 'attraction=>water_slide'
+          ORDER BY COALESCE(layer,0)
+        ) AS waterslide
     properties:
-      minzoom: 11
+      minzoom: 16
   - id: roller-coaster-gap-fill
     geometry: linestring
     <<: *extents
@@ -1013,6 +1039,35 @@ Layer:
     properties:
       group-by: layernotnull
       minzoom: 15
+  - id: aerialways
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            aerialway,
+            man_made,
+            tags->'substance' AS substance
+          FROM planet_osm_line
+          WHERE aerialway IS NOT NULL
+            OR (man_made = 'pipeline'
+                AND tags-> 'location' IN ('overground', 'overhead', 'surface', 'outdoor')
+                OR bridge IN ('yes', 'aqueduct', 'cantilever', 'covered', 'trestle', 'viaduct'))
+            OR (man_made = 'goods_conveyor'
+                AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
+                AND (tunnel NOT IN ('yes') OR tunnel IS NULL))
+          ORDER BY
+            CASE
+              WHEN man_made IN ('goods_conveyor', 'pipeline') THEN 1
+              WHEN tags-> 'location' = 'overhead' THEN 2
+              WHEN bridge IS NOT NULL THEN 3
+              WHEN aerialway IS NOT NULL THEN 4
+            END
+        ) AS aerialways
+    properties:
+      minzoom: 12
   - id: entrances
     geometry: point
     <<: *extents
@@ -1030,33 +1085,6 @@ Layer:
         AS entrances
     properties:
       minzoom: 18
-  - id: aeroways
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            aeroway,
-            bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct') AS bridge,
-            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
-                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
-              WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes',
-                                  'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
-              ELSE NULL
-            END AS int_surface
-          FROM planet_osm_line
-          WHERE aeroway IN ('runway', 'taxiway')
-          ORDER BY
-            bridge NULLS FIRST,
-            CASE WHEN aeroway = 'runway' THEN 1 ELSE 0 END,
-            CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
-                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END
-        ) AS aeroways
-    properties:
-      cache-features: true
-      minzoom: 11
   - id: golf-line
     geometry: linestring
     <<: *extents
@@ -1577,7 +1605,7 @@ Layer:
                               THEN historic END,
                 'military_'|| CASE WHEN military IN ('danger_area', 'bunker') THEN military END,
                 'highway_' || CASE WHEN highway IN ('services', 'rest_area', 'bus_stop', 'elevator', 'traffic_signals') THEN highway END,
-                'highway_'|| CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' AND way_area IS NULL THEN 'ford' END,
+                'highway_'|| CASE WHEN tags->'ford' IN ('yes', 'stepping_stones') AND way_area IS NULL THEN 'ford' END,
                 'boundary_' || CASE WHEN boundary IN ('aboriginal_lands', 'national_park')
                                           OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6'))
                                           THEN boundary END,
@@ -1730,15 +1758,13 @@ Layer:
         (SELECT
           way,
           COALESCE(
-           'highway_' || CASE WHEN tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones' THEN 'ford' END,
-           'leisure_' || CASE WHEN leisure IN ('slipway', 'track') THEN leisure END,
-           'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END
+           'highway_' || CASE WHEN tags->'ford' IN ('yes', 'stepping_stones') THEN 'ford' END,
+           'leisure_' || CASE WHEN leisure = 'slipway' THEN leisure END
             ) AS feature
           FROM planet_osm_line
           -- The upcoming where clause is needed for performance only, as the CASE statements would end up doing the equivalent filtering
-          WHERE tags @> 'ford=>yes' OR tags @> 'ford=>stepping_stones'
-            OR leisure IN ('slipway', 'track')
-            OR tags @> 'attraction=>water_slide'
+          WHERE tags->'ford' IN ('yes', 'stepping_stones')
+            OR leisure = 'slipway'
           ORDER BY COALESCE(layer,0)
         ) AS amenity_line
     properties:

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -3013,42 +3013,38 @@
     marker-file: url('symbols/leisure/slipway.svg');
     marker-fill: @transportation-icon;
   }
+}
 
-  [feature = 'leisure_track'] {
-    [zoom >= 16] {
-      [zoom >= 17] {
-        bridgecasing/line-color: saturate(darken(@pitch, 30%), 20%);
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: 1.25;
-        [zoom >= 18] { bridgecasing/line-width: 2.5; }
-        [zoom >= 19] { bridgecasing/line-width: 5; }
-      }
-      line-color: @pitch;
-      line-join: round;
-      line-cap: round;
-      line-width: 1;
-      [zoom >= 18] { line-width: 2; }
-      [zoom >= 19] { line-width: 4; }
-    }
+#leisure-track {
+  [zoom >= 17] {
+	bridgecasing/line-color: saturate(darken(@pitch, 30%), 20%);
+	bridgecasing/line-join: round;
+	bridgecasing/line-width: 1.25;
+	[zoom >= 18] { bridgecasing/line-width: 2.5; }
+	[zoom >= 19] { bridgecasing/line-width: 5; }
   }
+  line-color: @pitch;
+  line-join: round;
+  line-cap: round;
+  line-width: 1;
+  [zoom >= 18] { line-width: 2; }
+  [zoom >= 19] { line-width: 4; }
+}
 
-  [feature = 'attraction_water_slide'] {
-    [zoom >= 16] {
-      [zoom >= 17] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: 1.25;
-        [zoom >= 18] { bridgecasing/line-width: 2.5; }
-        [zoom >= 19] { bridgecasing/line-width: 5; }
-      }
-      line-color: @pitch;
-      line-join: round;
-      line-cap: round;
-      line-width: 1;
-      [zoom >= 18] { line-width: 2; }
-      [zoom >= 19] { line-width: 4; }
-    }
+#waterslide {
+  [zoom >= 17] {
+	bridgecasing/line-color: black;
+	bridgecasing/line-join: round;
+	bridgecasing/line-width: 1.25;
+	[zoom >= 18] { bridgecasing/line-width: 2.5; }
+	[zoom >= 19] { bridgecasing/line-width: 5; }
   }
+  line-color: @pitch;
+  line-join: round;
+  line-cap: round;
+  line-width: 1;
+  [zoom >= 18] { line-width: 2; }
+  [zoom >= 19] { line-width: 4; }
 }
 
 #text-line {


### PR DESCRIPTION

Fixes #4726

**Changes proposed in this pull request**:

As discussed in #5041:
Move `leisure=track` from `amenity-line` (late in layer stack) to new layer between `tunnels` and `landuse-overlay`.
Optimisation of layer ordering from end of road fill to roller coaster.
Move `attraction=water_slide` from `amenity-line` to new layer between `aeroways` and roller coaster.

[Also tweak to `highway=ford` SQL query to simplify hstore query]

Test rendering with links to the example places:

[Link](https://www.openstreetmap.org/#map=18/54.833971/-1.603862):
Before
![image](https://github.com/user-attachments/assets/f292a1d9-5f01-4e75-ab46-7ee63ac4d075)

After

![image](https://github.com/user-attachments/assets/b26cfbec-bd8c-4f4e-ae06-e5149d121dca)

[Ford as linear way](https://www.openstreetmap.org/#map=19/54.797344/-1.540874)

![image](https://github.com/user-attachments/assets/31c24110-aaea-44c3-aa5f-64aa998720fd)

[attraction=water_slide](https://www.openstreetmap.org/#map=18/54.295969/-0.412698)
![image](https://github.com/user-attachments/assets/b4bd65f5-b8f4-4639-8ff5-31c881c3a4bf)

Notes:

The git diff for `project.mml` is not easy to untangle. Here is the debug output from `nik4.py` showing the layer ordering (new layers highlighted):
layers=landcover-low-zoom,landcover,landcover-line,water-lines-low-zoom,water-lines,water-areas,ocean-lz,ocean,landcover-area-symbols,marinas-area,water-barriers-line,water-barriers-poly,piers-poly,piers-line,water-barriers-point,bridge,buildings,tunnels,**leisure-track**,landuse-overlay,barriers,cliffs,ferry-routes,turning-circle-casing,highway-area-casing,roads-casing,highway-area-fill,roads-fill,turning-circle-fill,roads-low-zoom,guideways,bridges,aeroways,waterway-bridges,**waterslide**,roller-coaster-gap-fill,roller-coaster,aerialways,entrances,golf-line,necountries,admin-low-zoom,admin-mid-zoom,admin-high-zoom,power-minorline,power-line,tourism-boundary,protected-areas,trees,country-names,capital-names,state-names,placenames-medium,placenames-small,stations,junctions,bridge-text,county-names,amenity-points,amenity-line,power-towers,roads-text-ref-low-zoom,roads-text-ref,roads-area-text-name,roads-text-name,paths-text-name,railways-text-name,roads-text-ref-minor,text-poly-low-zoom,text-line,text-point,building-text,interpolation,addresses,water-lines-text,ferry-routes-text,admin-text,protected-areas-text,amenity-low-priority,text-low-priority


It seems to me that the SQL query in `amenity-line`:

           COALESCE(
           'highway_' || CASE WHEN tags->'ford' IN ('yes', 'stepping_stones') THEN 'ford' END,
           'leisure_' || CASE WHEN leisure = 'slipway' THEN leisure END
            ) AS feature

could be further simplified to:
 
>          CASE
>          WHEN tags->'ford' IN ('yes', 'stepping_stones') THEN 'highway_ford'
>          WHEN leisure = 'slipway' THEN 'leisure_' || leisure
>          END AS feature
? 