### PR TITLE
Additional access marking

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -66,7 +66,8 @@ SELECT
 				WHEN 'bridleway' THEN carto_int_access(horse, FALSE)
 				ELSE carto_int_access(COALESCE(NULLIF(foot, 'unknown'), "access"), FALSE)
 			END
-		WHEN highway IN ('pedestrian', 'footway', 'steps') THEN carto_int_access(COALESCE(NULLIF(foot, 'unknown'), "access"), FALSE)
+		WHEN highway = 'pedestrian' THEN carto_int_access(COALESCE(NULLIF(foot, 'unknown'), "access"), TRUE)
+		WHEN highway IN ('footway', 'steps') THEN carto_int_access(COALESCE(NULLIF(foot, 'unknown'), "access"), FALSE)
 		WHEN highway = 'cycleway' THEN carto_int_access(COALESCE(NULLIF(bicycle, 'unknown'), "access"), FALSE)
 		WHEN highway = 'bridleway' THEN carto_int_access(COALESCE(NULLIF(horse, 'unknown'), "access"), FALSE)
 		ELSE carto_int_access("access", TRUE)

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -3397,6 +3397,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 #roads-fill::fill,
 #bridges::fill {
   [int_access = 'restricted'] {
+    [feature = 'highway_motorway'],
+    [feature = 'highway_trunk'],
+    [feature = 'highway_primary'],
     [feature = 'highway_secondary'],
     [feature = 'highway_tertiary'],
     [feature = 'highway_unclassified'],
@@ -3406,6 +3409,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         access/line-color: @access-marking;
         [int_surface = 'unpaved'] {
           access/line-color: @access-marking-white-unpaved;
+        }
+        [feature = 'highway_primary'] {
+          access/line-color: @access-marking-primary;
         }
         [feature = 'highway_secondary'] {
           access/line-color: @access-marking-secondary;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -27,6 +27,7 @@
 @access-marking-secondary: #e4e4e4;
 @access-marking-white-unpaved: #e0e0e0;
 @access-marking-road: #f0f0f0;
+@access-marking-pedestrian: white;
 @access-marking-living-street: #d4d4d4;
 
 @default-casing: white;
@@ -3404,6 +3405,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'highway_tertiary'],
     [feature = 'highway_unclassified'],
     [feature = 'highway_residential'],
+    [feature = 'highway_pedestrian'], 
     [feature = 'highway_living_street'] {
       [zoom >= 15] {
         access/line-color: @access-marking;
@@ -3415,6 +3417,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [feature = 'highway_secondary'] {
           access/line-color: @access-marking-secondary;
+        }
+        [feature = 'highway_pedestrian'] {
+          access/line-color: @access-marking-pedestrian;
         }
         [feature = 'highway_living_street'] {
           access/line-color: @access-marking-living-street;
@@ -3473,6 +3478,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
     [feature = 'highway_tertiary'],
     [feature = 'highway_unclassified'],
     [feature = 'highway_residential'],
+    [feature = 'highway_pedestrian'], 
     [feature = 'highway_living_street'] {
       [zoom >= 15] {
         access/line-color: @access-marking;
@@ -3488,6 +3494,9 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [feature = 'highway_secondary'] {
           access/line-color: @access-marking-secondary;
+        }
+        [feature = 'highway_pedestrian'] {
+          access/line-color: @access-marking-pedestrian;
         }
         [feature = 'highway_living_street'] {
           access/line-color: @access-marking-living-street;

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -23,11 +23,10 @@
 @taxiway-fill: @aeroway-fill;
 @helipad-fill: @aeroway-fill;
 @access-marking: #eaeaea;
-@access-marking-primary: #f0f0f0;
+/* access-marking-light is used on some darker highways for better contrast */
+@access-marking-light: #f0f0f0;
 @access-marking-secondary: #e4e4e4;
 @access-marking-white-unpaved: #e0e0e0;
-@access-marking-road: #f0f0f0;
-@access-marking-pedestrian: white;
 @access-marking-living-street: #d4d4d4;
 
 @default-casing: white;
@@ -3412,14 +3411,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         [int_surface = 'unpaved'] {
           access/line-color: @access-marking-white-unpaved;
         }
-        [feature = 'highway_primary'] {
-          access/line-color: @access-marking-primary;
+        [feature = 'highway_primary'],
+		[feature = 'highway_pedestrian'] {
+          access/line-color: @access-marking-light;
         }
         [feature = 'highway_secondary'] {
           access/line-color: @access-marking-secondary;
-        }
-        [feature = 'highway_pedestrian'] {
-          access/line-color: @access-marking-pedestrian;
         }
         [feature = 'highway_living_street'] {
           access/line-color: @access-marking-living-street;
@@ -3442,7 +3439,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           access/line-color: @access-marking-white-unpaved;
         }
         [feature = 'highway_road'] {
-          access/line-color: @access-marking-road;
+          access/line-color: @access-marking-light;
         }
         access/line-join: round;
         access/line-cap: round;
@@ -3489,14 +3486,12 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
             access/line-color: @access-marking-white-unpaved;
           }
         }
-        [feature = 'highway_primary'] {
-          access/line-color: @access-marking-primary;
+        [feature = 'highway_primary'],
+		[feature = 'highway_pedestrian'] {
+          access/line-color: @access-marking-light;
         }
         [feature = 'highway_secondary'] {
           access/line-color: @access-marking-secondary;
-        }
-        [feature = 'highway_pedestrian'] {
-          access/line-color: @access-marking-pedestrian;
         }
         [feature = 'highway_living_street'] {
           access/line-color: @access-marking-living-street;
@@ -3519,7 +3514,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
           access/line-color: @access-marking-white-unpaved;
         }
         [feature = 'highway_road'] {
-          access/line-color: @access-marking-road;
+          access/line-color: @access-marking-light;
         }
         access/line-join: round;
         access/line-cap: round;


### PR DESCRIPTION
Fixes #5024 
Fixes #4998 

**Changes proposed in this pull request**:
- Render "restricted" access (e.g. `access=destination`) on `highway=motorway/trunk/primary` (currently only `access=no` shown)
- Add access rendering for `highway=pedestrian` using white as contrasting colour.

Note that a tweak to `functions.sql` is needed to allow `highway=pedestrian` to support "restricted" access marking. 

**Test rendering**:

"restricted" access on major highways is not expected to be valid tagging. The purpose of the PR is to highlight potentially incorrect tagging.

Illustrations are taken from a hacked legend rendering, with `access=destination` on all highways.

![image](https://github.com/user-attachments/assets/85d458f1-47ee-48e2-814c-e79916092a6d)

![image](https://github.com/user-attachments/assets/000918a0-9f85-4b7b-b177-c0b02a812061)

Note that the increased "coverage" of access tags needs to be weighed against a 7% increase in lines of XML. This is a result of all the added combinations of road types / 3 SQL queries / 3 access types.

