### PR TITLE
Remove operator label on ATM

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2368,7 +2368,6 @@
     text-dy: 7;
   }
 
-  [feature = 'amenity_atm'][zoom >= 19],
   [feature = 'amenity_vending_machine'][vending = 'public_transport_tickets'][zoom >= 19] {
     text-name: "[operator]";
     text-size: @standard-font-size;


### PR DESCRIPTION
Fixes #4575

Changes proposed in this pull request:
There was agreement in the discussion of #4575  that the current rendering of the `operator` tag on ATMs was unsatisfactory: adding visual clutter for map users, and not providing useful feedback for mappers. Overall, removing the labelling seemed the best option.

Test rendering with links to the example places:

[Example where decluttering is helpful](https://www.openstreetmap.org/#map=19/54.776899/-1.575763):

Before

![image](https://github.com/user-attachments/assets/92d706be-a964-4060-9091-15f39ff7471b)

After

![image](https://github.com/user-attachments/assets/cee37a97-a294-430d-aeb1-b418dd728983)

Note helpful de-duplication of bank vs ATM names, in particular when the bank name is now visible (HSBC UK in bottom right)
