### PR TITLE
Update list of ignored keys and key prefixes

### DIFF
--- a/openstreetmap-carto-flex.lua
+++ b/openstreetmap-carto-flex.lua
@@ -284,6 +284,7 @@ local ignore_keys = {
     'statscan:rbuid',
     -- RUIAN (CZ)
     'ref:ruian:addr',
+    'ref:ruian:building',
     'ref:ruian',
     'building:ruian:type',
     -- DIBAVOD (CZ)
@@ -328,9 +329,14 @@ local ignore_keys = {
 
     -- misc
     'import',
-    'import_uuid',
-    'OBJTYPE',
     'SK53_bulk:load',
+    'addr:TW:dataset',
+    'at_bev:addr_date',
+    'mml:class',
+    'nysgissam:nysaddresspointid',
+    'ref:RS:kucni_broj',
+    'ref:bygningsnr',
+    'ref:minvskaddress',
 }
 
 -- Tags with the following key prefixes will be ignored.
@@ -346,11 +352,6 @@ local ignore_key_prefixes = {
     'canvec:',
     -- Geobase (CA)
     'geobase:',
-    -- kms (DK)
-    'kms:',
-    -- ngbe (ES)
-    -- See also note:es and source:file above
-    'ngbe:',
     -- Friuli Venezia Giulia (IT)
     'it:fvg:',
     -- KSJ2 (JA)
@@ -361,8 +362,6 @@ local ignore_key_prefixes = {
     -- LINZ (NZ)
     'LINZ2OSM:',
     'LINZ:',
-    -- WroclawGIS (PL)
-    'WroclawGIS:',
     -- Naptan (UK)
     'naptan:',
     -- TIGER (US)
@@ -374,6 +373,10 @@ local ignore_key_prefixes = {
     'nhd:',
     -- mvdgis (Montevideo, UY)
     'mvdgis:',
+    -- Land Information New Zealand
+    'ref:linz:',
+    -- Los Angeles County
+    'lacounty:',
 }
 
 -- Big table for z_order and roads status for certain tags.
@@ -401,7 +404,7 @@ local roads_info = {
         secondary_link  = { z = 210, roads = true },
         tertiary_link   = { z = 200, roads = false },
         busway          = { z = 190, roads = false },
-        bus_guideway	= { z = 180, roads = false },       
+        bus_guideway    = { z = 180, roads = false },
         service         = { z = 150, roads = false },
         track           = { z = 110, roads = false },
         path            = { z = 100, roads = false },


### PR DESCRIPTION
I checked all keys that are in the planet file at least 1 million times and added some uninteresting keys (usually ids from imports) to the list.

Removed a few that are either not in the database any more or where there are only a few objects left with that key.

See #5027 first bullet point