### PR TITLE
Update of landuse outlines

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -92,10 +92,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way, name, religion, way_pixels, is_building,
+            way, religion, way_pixels, is_building,
             COALESCE(aeroway, golf, amenity, wetland, power, landuse, leisure, man_made, "natural", shop, tourism, highway, railway) AS feature
           FROM (SELECT
-              way, COALESCE(name, '') AS name,
+              way,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway END)) AS aeroway,
               ('golf_' || (CASE WHEN (tags->'golf') IN ('rough', 'fairway', 'driving_range', 'water_hazard', 'green', 'bunker', 'tee') THEN tags->'golf' ELSE NULL END)) AS golf,
               ('amenity_' || (CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',

--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -26,6 +26,8 @@
 @farmyard: #f5dcba;         // Lch(89,20,80)
 @farmyard-line: #d1b48c;    // Lch(75,25,80)
 
+@landuse-outline-width: 0.5; // line width used for most (larger) landuses
+
 // --- Transport ----
 
 @transportation-area: #e9e7e2;
@@ -118,7 +120,7 @@
     polygon-fill: @quarry;
     polygon-pattern-file: url('symbols/quarry.svg');
     [zoom >= 13] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: darken(@quarry, 10%);
     }
     [way_pixels >= 4]  { polygon-pattern-gamma: 0.75; }
@@ -250,11 +252,8 @@
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @residential; }
     [zoom >= 16] {
-      line-width: .5;
+      line-width: @landuse-outline-width;
       line-color: @residential-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -318,11 +317,8 @@
       [way_pixels >= 64] { polygon-pattern-gamma: 0.3;  }
     }
     [zoom >= 16] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: desaturate(darken(@allotments, 10%), 10%);
-      [name != null] {
-        line-width: 0.7;
-      }
     }
   }
 
@@ -338,11 +334,8 @@
   [feature = 'landuse_farmyard'][zoom >= 10] {
     polygon-fill: @farmyard;
       [zoom >= 16] {
-        line-width: 0.5;
+        line-width: @landuse-outline-width;
         line-color: @farmyard-line;
-        [name != ''] {
-          line-width: 0.7;
-        }
       }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -353,7 +346,7 @@
     [zoom >= 5] {
       polygon-fill: @farmland;
       [zoom >= 16] {
-        line-width: .5;
+        line-width: @landuse-outline-width;
         line-color: @farmland-line;
       }
       [way_pixels >= 4]  { polygon-gamma: 0.75; }
@@ -378,14 +371,11 @@
       [zoom >= 12] { polygon-fill: @built-up-z12; }
       [zoom >= 13] { polygon-fill: @retail; }
       [zoom >= 16] {
-        line-width: 0.5;
+        line-width: @landuse-outline-width;
         line-color: @retail-line;
-        [name != ''] {
-          line-width: 0.7;
-        }
-        [way_pixels >= 4]  { polygon-gamma: 0.75; }
-        [way_pixels >= 64] { polygon-gamma: 0.3;  }
       }
+      [way_pixels >= 4]  { polygon-gamma: 0.75; }
+      [way_pixels >= 64] { polygon-gamma: 0.3;  }
     }
   }
 
@@ -394,56 +384,38 @@
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @industrial; }
     [zoom >= 16] {
-      line-width: .5;
+      line-width: @landuse-outline-width;
       line-color: @industrial-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
   }
 
   [feature = 'man_made_works'][zoom >= 16] {
-    line-width: .5;
+    line-width: @landuse-outline-width;
     line-color: @industrial-line;
-    [name != ''] {
-      line-width: 0.7;
-    }
   }
 
   [feature = 'man_made_wastewater_plant'] {
-    polygon-fill: @industrial;
-    [zoom >= 15] {
-      polygon-fill: @wastewater_plant;
-    }
+    polygon-fill: @wastewater_plant;
     [zoom >= 16] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: @wastewater_plant-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
   }
 
   [feature = 'man_made_water_works'] {
-    polygon-fill: @industrial;
-    [zoom >= 15] {
-      polygon-fill: @water_works;
-    }
+    polygon-fill: @water_works;
     [zoom >= 16] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: @water_works-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
   }
 
   [feature = 'landuse_railway'][zoom >= 10] {
     polygon-fill: @railway;
-    [zoom >= 16][name != ''] {
-      line-width: 0.7;
+    [zoom >= 16] {
+      line-width: @landuse-outline-width;
       line-color: @railway-line;
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
@@ -458,11 +430,8 @@
       polygon-fill: @power;
     }
     [zoom >= 16] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: @power-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }
@@ -473,11 +442,8 @@
     [zoom >= 12] { polygon-fill: @built-up-z12; }
     [zoom >= 13] { polygon-fill: @commercial; }
     [zoom >= 16] {
-      line-width: 0.5;
+      line-width: @landuse-outline-width;
       line-color: @commercial-line;
-      [name != ''] {
-        line-width: 0.7;
-      }
     }
     [way_pixels >= 4]  { polygon-gamma: 0.75; }
     [way_pixels >= 64] { polygon-gamma: 0.3;  }


### PR DESCRIPTION

Fixes #5083

Changes proposed in this pull request:

- Remove dependence of outline width on presence of name. Currently the outline for most "larger" landuses with a name is widened from 0.5 px to 0.7 px. This is barely visible and not providing useful mapper feedback. All these outlines now have a common width of `landuse-outline-width` (set to 0.5 px).
- There was a mistake / inconsistency in the `polygon-gamma` filters in `landuse_retail`.
- There was a inconsistency in `landuse=railway` whereby an outline was only shown at all from Z16 if the feature is named. This leads to the only visible change from this PR.
- There was a redundant filter in `man_made=wastewater_plant` and `man_made=water_works` to switch fill colour from `@industrial` to `@wastewater_plant` at Z15+. Since these two colours are the same (and it wouldn't make sense to switch a fill colour at Z15+ anyway), these filters are redundant. 

Test rendering with links to the example places:

[Example](https://www.openstreetmap.org/edit#map=17/54.803990/-1.582015) showing that the change from 0.7 px to 0.5 px for named landuses (retail area and residential area) is not really visible:

Before
![image](https://github.com/user-attachments/assets/c6a246dd-9499-4205-9073-6d43ff4da603)

After
![image](https://github.com/user-attachments/assets/b0c5b031-3bad-4bb6-889e-fdc8a742ed72)

[Example](https://www.openstreetmap.org/edit#map=17/54.766134/-1.605490) of outline on un-named `landuse=railway`: 

Before
![image](https://github.com/user-attachments/assets/cc01ac17-5230-4df2-bc65-0a7d909503b9)

After
![image](https://github.com/user-attachments/assets/05937cf1-9c18-45d3-880d-94ebcf258333)

Queries:

- It might make sense to use an intermediate linewidth i.e. 0.6 px. As it stands, the PR takes a conservative line by using 0.5 px, which will have no effect on the majority of cases.
- It seems odd to have separate MSS code for `man_made=wastewater_plant` and `man_made=water_works` since these are rendered in exactly the same way.
- The starting zooms for outline rendering vary wildly. `leisure=ice_rink` renders a 0.5 px outline from Z10 (really?!), while most outlines considered in this PR start at Z16 (which seems a little late, Z15 better?). 

