### PR TITLE
Create charge_double_cross.svg

### DIFF
--- a/symbols/man_made/charge_double_cross.svg
+++ b/symbols/man_made/charge_double_cross.svg
@@ -1,0 +1,1 @@
+<svg width="14" height="14"><title>charge-double-cross</title><path opacity="1" fill-opacity="1" d="M7 0H8V3H11V4H8V7H12V8H8V15H7V8H3V7H7V4H4V3H7V0Z"/></svg>


### PR DESCRIPTION
SVG icon charge_double_cross.svg added to symbols\man_made folder. 
The charge refers to coat of arms and heraldy terminology https://en.wikipedia.org/wiki/Charge_(heraldry) .
