### PR TITLE
Added color to `man_made=charge_point` marker

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -326,6 +326,14 @@
     }
   }
 
+  [feature = 'man_made_charge_point'][zoom >= 17] {
+    marker-fill: @transportation-icon;
+    marker-clip: false;
+    [int_access = 'restricted'] {
+      marker-opacity: @private-opacity;
+    }
+  }
+
   [feature = 'amenity_fuel'][zoom >= 17] {
     marker-file: url('symbols/amenity/fuel.svg');
     marker-fill: @transportation-icon;


### PR DESCRIPTION
Changes proposed in this pull request:
Added transportation color to `man_made=charge_point`

No example as icon is not changing, only color of the marker to an establish value.