### PR TITLE
prevent running out of memory with glacier rendering in PDF / SVG

### DIFF
--- a/style/water.mss
+++ b/style/water.mss
@@ -7,6 +7,7 @@
 #water-areas {
   [natural = 'glacier']::natural {
     [zoom >= 5] {
+      line-clip: true;
       line-width: 1.0;
       line-color: @glacier-line;
       polygon-fill: @glacier;


### PR DESCRIPTION
I originally filed this as

https://github.com/mapnik/mapnik/issues/4476

seeing that rendering maps of certain areas in Greenland failed with out-of-memory errors on print.get-map.org

Not an issue when rendering PNG tiles as there memory usage is pretty much fixed to the actual output surface size; but with PDF and SVG vector formats unclipped rendering of the Greenland main ice sheet with a dashed line created lots of output outside the actually visible area, eventually exhausting memory.

Adding clipping reduces the actual output to the visible bounding box and so drastically reduces memory consumption.

Fixes # (id of the issue to be closed)

Changes proposed in this pull request:
- 

Test rendering with links to the example places:

Before

After
