### PR TITLE
Remove flex lua file from docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !scripts/tune-postgis.sh
 !openstreetmap-carto.style
+!openstreetmap-carto-flex.lua


### PR DESCRIPTION
This is a one-line change to add the flex lua file to the .dockerignore exlusion list.  Without this, `docker-compose up import` fails.