### PR TITLE
Fix docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !scripts/tune-postgis.sh
 !openstreetmap-carto.style
+!openstreetmap-carto-flex.lua

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,14 @@ RUN apt-get update && apt-get install -y \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
 
-# Install kosmtik from source (as recommended in issue #352)
+# Install kosmtik from source with dependencies (as recommended in issue #352)
 RUN git clone https://github.com/kosmtik/kosmtik.git && \
     cd kosmtik && \
-    npm install -g
+    npm install && \
+    npm link
 
-# Set working directory
-WORKDIR /usr/lib/node_modules/kosmtik/
+# Set working directory to where project files are mounted
+WORKDIR /openstreetmap-carto
 
 # Expose kosmtik port
 EXPOSE 6789

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ WORKDIR /openstreetmap-carto
 EXPOSE 6789
 
 # Default command
-CMD ["kosmtik", "serve", "project.mml"]
+CMD ["kosmtik", "serve", "project.mml", "--host", "0.0.0.0"]

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,4 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:20.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates curl gnupg && rm -rf /var/lib/apt/lists/*
@@ -10,9 +13,45 @@ deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main' > \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    osm2pgsql gdal-bin python3-psycopg2 python3-yaml unzip \
-    python3-requests postgresql-client && rm -rf /var/lib/apt/lists/*
+# Install osm2pgsql from source (newer version with flex support)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libexpat1-dev \
+    libbz2-dev \
+    libpq-dev \
+    libproj-dev \
+    postgresql-server-dev-all \
+    zlib1g-dev \
+    lua5.2-dev \
+    postgresql-client \
+    python3-yaml \
+    python3-requests \
+    python3-psycopg2 \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install nlohmann-json from source
+RUN git clone https://github.com/nlohmann/json.git && \
+    cd json && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make install
+
+# Clone and build osm2pgsql with flex support
+RUN git clone https://github.com/openstreetmap/osm2pgsql.git && \
+    cd osm2pgsql && \
+    git checkout 1.7.0 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
 
 ADD openstreetmap-carto-flex.lua /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   kosmtik:
     image: kosmtik:v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - db
     ports:
-      - "127.0.0.1:6789:6789"
+      - "6789:6789"
     environment:
       - PGHOST=db
       - PGUSER=postgres

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -55,6 +55,9 @@ EOF
 
   # Download fonts
   scripts/get-fonts.py
+
+  # Apply custom SQL functions
+  psql -d gis -f /openstreetmap-carto/functions.sql
   ;;
 
 kosmtik)


### PR DESCRIPTION
Fixes #5031
Fixes #5005
Fixes #4979
Fixes #4684
Fixes #4683

This PR upgrades the openstreetmap-carto docker configuration to support the flex back end and gets kosmtik running again. It upgrades many packages and the base OS in the docker container. I also had to install some packages from source to support the latest osm2pgsql.

This is my kosmtik rendering of Luxembourg using this PR branch:

<img width="959" height="730" alt="image" src="https://github.com/user-attachments/assets/84ceb8a2-af04-44e2-9cb6-e118d9cf19fb" />
