### PR TITLE
Show hole number for named golf holes

### DIFF
--- a/style/golf.mss
+++ b/style/golf.mss
@@ -42,7 +42,7 @@
     text-halo-fill: @standard-halo-fill;
     text-name: "[ref]";
 
-    [name != ''] { text-name: "[name]"; }
+    [name != ''] { text-name: "[ref]. [name]"; }
 
     [zoom >= 17] { text-size: 13; }
   }


### PR DESCRIPTION
When a golf hole has a name, the current style replaces the hole number with the name. This means the rendering no longer shows the order in which holes are played. The sign on a golf course would always show both the hole number and name.

The holes being hidden has caused contributors to (incorrectly) add the numbers to the names, e.g. https://www.openstreetmap.org/changeset/133419688
