### PR TITLE
more visible cell towers: lower zoom levels and tower operators in the name

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -1934,7 +1934,7 @@
   [feature = 'man_made_tower'][zoom >= 17],
   [feature = 'man_made_storage_tank'][zoom >= 18],
   [feature = 'man_made_silo'][zoom >= 18],
-  [feature = 'man_made_communications_tower'][zoom >= 17],
+  [feature = 'man_made_communications_tower'][zoom >= 12],
   [feature = 'man_made_telescope']["telescope:type" != 'optical']["telescope:type" != null][zoom >= 16],
   [feature = 'man_made_telescope'][zoom >= 17],
   [feature = 'man_made_water_tower'][zoom >= 17],


### PR DESCRIPTION
standard carto display com towers at 17 that could be moved up significantly everyone needs to communicate not only explorers . I moved it to twelve the same level that display smaller trails for us that do NOT use gas guzzlers  or big metal boxes with one ton batteries. i use electric scooter or push bikes or soles . OSM should have a philosophical sympathy with this minority that is not wasting resources on this planet and not using major roads and are only interested in small trails and com towers

 # where are the topo and cycling maps

but this is irrelevant for.me since I don't use standard carto only topo and cycling and  I need a more trivial task HELP to **find the style sheets** for these maps ? ? where are theyI know the website and tile server but not the source code location . I need to know where these map styles are stored  so I can submit the proposed edits. there are five thousand ignored changes on this forum I need to submit the code if anything is going to happen

curl http://a.tile.opencyclemap.org/cycle/17/73626/36774.png
curl https://a.tile.opentopomap.org/17/73626/36774.png

~~~
gh repo list gravitystorm -L 999|v
nothing here
gh repo list openstreetmap -L 999|v
or here
~~~

 # topo map

topo display towers at zoom 13 that could be moved up to 12 the same layer as most cyclable trails appear .  it lacks names that has to be added

 # cycling map

com towers are conspicuously absent from the cycling map and has to be added I would prefer level 11 and trails moved from 13 to 11 if this is rejected I will use the French fork with the same name and add towers to that map

 # operators in the name tag

I have created tower names like this to indicate who is sharing the tower

Elisa, Telia
DNA, Elisa, Telia

cell mapper has this info but they refuse to import it to OSM . they apparently know who shares the tower and who is absent from the tower but won't share the data with anyone. everyone that contribute to cell mapper add absent operators to overpass OSM instead why contribute to a commercial Gollum enterprise that Is nearly unusable technically I have to take screen shots when I finally find the tower i needit's so incredibly slow to operate from a phone . psyberia on the other.hand is pure java lightning  fast android API

 # zoom level in my tile viewer

I have tried to refer to standard zoom levels even though my app use a different numbering . for some unexplained reasons they skip zoom levels and the numbers are messed up so 11 becomes 7

~~~
COM.113.AQX
<name>OpenTopoMap</name>
<zoom-values>3,5,7,8,9,10,11,12,13,14,15,16,17</zoom-values>
<server><![CDATA[https://a.tile.opentopomap.org/{$z}/{$x}/{$y}.png]]></server>
~~~

they also serve the same mape from their own server in Russia which is quite slow.

~~~
OSM.AQX
<name>Open Topo Map</name>
<zoom-values>1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16</zoom-values>
<server><![CDATA[http://ptc.psyberia.org/OTMC/?p={$ptc}&c={$app-c}]]></server>
~~~

I have tried to talk with them to no avail their app is by far the best nothing open comes even close unfortunately I have planned to start an open project but it is much work when psyberia still works despite the closed source and communication problems

 # to-do where is the food

 I am walking around this planet and all I need to know is where the food is. please show the food stores clearly. not everyone goes to the same store their whole life. I only visit every shop once. this is so important to me but I have to zoom to such ridiculous levels that I use the Google layer instead that has reasonable zoom levels for food stores despite everyone knowing where they are presumably from experience
