### PR TITLE
Created symbol for library_dropoff

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1562,7 +1562,7 @@ Layer:
                                                     'car_rental', 'car_wash', 'casino', 'charging_station', 'childcare', 'cinema', 'clinic', 'college',
                                                     'community_centre', 'courthouse', 'dentist', 'doctors', 'drinking_water', 'driving_school',
                                                     'fast_food', 'ferry_terminal', 'fire_station', 'food_court', 'fountain', 'fuel', 'grave_yard',
-                                                    'hospital', 'hunting_stand', 'ice_cream', 'internet_cafe', 'kindergarten', 'library', 'marketplace',
+                                                    'hospital', 'hunting_stand', 'ice_cream', 'internet_cafe', 'kindergarten', 'library', 'library_dropoff', 'marketplace',
                                                     'nightclub', 'nursing_home', 'pharmacy', 'place_of_worship', 'police', 'post_box',
                                                     'post_office', 'prison', 'pub', 'public_bath', 'public_bookcase', 'recycling', 'restaurant', 'school',
                                                     'shelter', 'shower', 'social_facility', 'taxi', 'telephone', 'theatre', 'toilets', 'townhall',

--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -415,6 +415,12 @@
     marker-clip: false;
   }
 
+  [feature = 'amenity_library_dropoff'][zoom >= 16] {
+    marker-file: url('symbols/amenity/library_dropoff.svg');
+    marker-fill: @culture;
+    marker-clip: false;
+  }
+
   [feature = 'amenity_courthouse'][zoom >= 16] {
     marker-file: url('symbols/amenity/courthouse.svg');
     marker-fill: @public-service;
@@ -1695,6 +1701,7 @@
   }
 
   [feature = 'amenity_library'],
+  [feature = 'amenity_library_dropoff'],
   [feature = 'tourism_museum'],
   [feature = 'amenity_theatre'],
   [feature = 'amenity_cinema'],

--- a/symbols/amenity/library_dropoff.svg
+++ b/symbols/amenity/library_dropoff.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg2"
+   viewBox="0 0 16 16"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="dropoff.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="false"
+     inkscape:zoom="26.364602"
+     inkscape:cx="6.1825322"
+     inkscape:cy="7.4721401"
+     inkscape:window-width="1440"
+     inkscape:window-height="763"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <path
+     id="path4176"
+     d="M 3.5917969,2.0676001 C 3.39328,2.0755998 3.1958998,2.1152956 3,2.190647 v 8 c 0,0 3.1875,-0.125 4,3 V 4.7902564 C 6.38001,3.4846578 4.9814151,2.0116022 3.5917969,2.0676001 Z M 7,13.190647 c -2.0625,-1.59375 -5,-2 -5,-2 V 3.5910376 L 1,3.190647 v 9 L 5.2007048,13.590882 7,14.190647 h 2 l 3,-1 3,-1 v -9 l -1,0.4003906 v 8.0000004 l -5,1.599609 c -0.666667,-0.25468 -1.443819,-0.209363 -2,0 z m 6,-11 C 11.00748,2.0840966 8.7073046,3.2803288 7.5,4.3097876 v 8.4648434 c 1.1147712,-0.924639 3.113583,-2.141273 5.5,-2.384765 z"
+     style="fill:#734a08;fill-opacity:1;stroke:none"
+     sodipodi:nodetypes="sccccscccccccccccccccccccc"
+     inkscape:label="book back" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#ff1212;stroke-width:1.13923;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path14-8"
+     transform="rotate(-90)"
+     sodipodi:type="arc"
+     sodipodi:cx="-11.11631"
+     sodipodi:cy="11.743661"
+     sodipodi:rx="3.3560479"
+     sodipodi:ry="3.3560479"
+     sodipodi:start="0"
+     sodipodi:end="3.8659043"
+     sodipodi:arc-type="arc"
+     d="m -7.7602623,11.743661 a 3.3560479,3.3560479 0 0 1 -2.4216157,3.223336 3.3560479,3.3560479 0 0 1 -3.770128,-1.428374 3.3560479,3.3560479 0 0 1 0.322165,-4.0187467"
+     sodipodi:open="true"
+     inkscape:label="path14-8" />
+  <path
+     d="M 12.623047,2.1847876 C 10.724137,2.2321847 8.6318469,3.344671 7.5,4.3097876 V 12.774631 C 8.6147701,11.849993 10.613585,10.633358 13,10.389866 V 2.190647 c -0.124532,-0.00666 -0.250359,-0.00902 -0.376953,-0.00586 z"
+     style="fill:#734a08"
+     id="path4" />
+  <path
+     d="m 7,13.190647 v 1 h 2 l 3,-1 3,-1 v -2.417629 -2.082371 -4.5 l -1,0.4003906 1,4.0996094 v 4.5 l -1.5,0.5 0.5,-1.099609 -5,1.599609 c -0.6666663,-0.25468 -1.4438196,-0.209363 -2,0 z"
+     style="fill:#734a08"
+     id="path3"
+     sodipodi:nodetypes="ccccccccccccccc" />
+  <path
+     sodipodi:type="star"
+     style="fill:#ff1212;fill-opacity:1;stroke:#ff1212;stroke-width:1.41332;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path15-9"
+     inkscape:flatsided="true"
+     sodipodi:sides="3"
+     sodipodi:cx="-13.957118"
+     sodipodi:cy="-1.535283"
+     sodipodi:r1="1.7270269"
+     sodipodi:r2="0.86351347"
+     sodipodi:arg1="0.52359878"
+     sodipodi:arg2="1.5707963"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="m -12.461469,-0.67176949 -2.991298,-2e-8 1.495649,-2.59054039 z"
+     transform="matrix(0,-0.78223063,0.78223063,0,12.990973,-2.9176852)"
+     inkscape:transform-center-x="0.17046396" />
+</svg>


### PR DESCRIPTION
Changes proposed in this pull request:

I'm proposing a symbol for library drop-off points.
Even though there are (currently) only around 650 of those points tagged, some of them might be in obscure places or not that easy to find.

Currently those aren't really easy to see on OSM, the new symbol changes that.

Test rendering with links to the example places:

[Before](https://www.openstreetmap.org/node/13287821507)

<img width="391" height="271" alt="Screenshot 2025-11-12 at 00 09 25" src="https://github.com/user-attachments/assets/d02ab6f1-96b5-41e1-b5bf-4838d44a41c2" />

The drop-off point is located in the wall outside the building, right opposite of the bike racks.
Currently only visible as a house number.

After

<img width="502" height="327" alt="Screenshot 2025-11-11 at 23 54 47" src="https://github.com/user-attachments/assets/c7e6dffa-e85b-460b-bd77-94ba42971dbc" />

(symbol not to scale)