### PR TITLE
Step down as maintainer

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ When using the OpenStreetMap Carto spaces you should act in the spirit of the va
 
 The OpenStreetMap Carto maintainers are responsible for handling conduct-related issues. Their goal is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties.
 
-If you encounter a conduct-related issue, you should report it to the maintainers by sending them [all an email](mailto:openstreetmap-carto@gravitystorm.co.uk,chris_hormann@gmx.de,daniel@xn--ko-wla.pl,sommerluk@gmail.com,joseph.eisenberg@gmail.com). In the event that you wish to make a complaint against a maintainer, you may instead contact the other maintainers.
+If you encounter a conduct-related issue, you should report it to the maintainers by sending them [all an email](mailto:chris_hormann@gmx.de,daniel@xn--ko-wla.pl,sommerluk@gmail.com,joseph.eisenberg@gmail.com). In the event that you wish to make a complaint against a maintainer, you may instead contact the other maintainers.
 
 **Note that the goal of the Code of Conduct and the maintainers is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bans and other forceful measures are to be employed only as a last resort.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ maps using Mapnik, many based on this project. Some alternatives are:
 
 # Maintainers
 
-* Andy Allan [@gravitystorm](https://github.com/gravitystorm)
 * Daniel Koć [@kocio-pl](https://github.com/kocio-pl)
 * Christoph Hormann [@imagico](https://github.com/imagico)
 * Lukas Sommer [@sommerluk](https://github.com/sommerluk)
@@ -96,6 +95,7 @@ maps using Mapnik, many based on this project. Some alternatives are:
 
 ## Previous maintainers
 
+* Andy Allan [@gravitystorm](https://github.com/gravitystorm)
 * Paul Norman [@pnorman](https://github.com/pnorman)
 * Michael Glanznig [@nebulon42](https://github.com/nebulon42)
 * Matthijs Melissen [@matthijsmelissen](https://github.com/matthijsmelissen)


### PR DESCRIPTION
It's been over 10 years since my last substantial contribution to this project! 

Given my ongoing work over at [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website) and elsewhere, I don't think I'll have spare volunteering capacity in the foreseeable future so it's unlikely I'll be involved here at any point soon. And I don't think it's a good idea to claim to be a maintainer, or for the project to have me on the maintainers list, since it just leads to confusion as to who is actually doing what.

As part of stepping down, I've also transferred this project to a new Github organization, and I've invited all the existing maintainers to be owners of that organization. When that's complete and everyone is set up as owners, I'll remove myself from the organization too. This finally takes care of the one main limitation of running this project under my personal account, which was that Github doesn't allow you to give other people equal permissions - technically I had more permissions than other maintainers on the repo, and that never felt right to me!