### PR TITLE
Remove tree_row transparency

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -3082,48 +3082,40 @@
 }
 
 #trees [zoom >= 16] {
-  ::canopy {
-    opacity: 0.6;
-    [natural = 'tree_row'] {
-      line-color: darken(@forest,10%);
-      line-cap: round;
-      line-width: 2.5;
-      [zoom >= 17] {
-        line-width: 5;
-      }
-      [zoom >= 18] {
-        line-width: 10;
-      }
-      [zoom >= 19] {
-        line-width: 15;
-      }
-      [zoom >= 20] {
-        line-width: 30;
-      }
+  [natural = 'tree_row'] {
+    line-color: @forest;
+    line-cap: round;
+    line-width: 2.5;
+    [zoom >= 17] {
+      line-width: 5;
     }
-    [natural = 'tree'] {
-      marker-fill: darken(@forest,10%);
-      marker-allow-overlap: true;
-      marker-line-width: 0;
-      marker-ignore-placement: true;
-      marker-width: 2.5;
-      marker-height: 2.5;
-      [zoom >= 17] {
-        marker-width: 5;
-        marker-height: 5;
-      }
-      [zoom >= 18] {
-        marker-width: 10;
-        marker-height: 10;
-      }
-      [zoom >= 19] {
-        marker-width: 15;
-        marker-height: 15;
-      }
-      [zoom >= 20] {
-        marker-width: 30;
-        marker-height: 30;
-      }
+    [zoom >= 18] {
+      line-width: 10;
+    }
+    [zoom >= 19] {
+      line-width: 15;
+    }
+    [zoom >= 20] {
+      line-width: 30;
+    }
+  }
+  [natural = 'tree']::canopy {
+    marker-fill: darken(@forest,10%);
+    marker-allow-overlap: true;
+    marker-line-width: 0;
+    marker-ignore-placement: true;
+    marker-width: 2.5;
+    [zoom >= 17] {
+      marker-width: 5;
+    }
+    [zoom >= 18] {
+      marker-width: 10;
+    }
+    [zoom >= 19] {
+      marker-width: 15;
+    }
+    [zoom >= 20] {
+      marker-width: 30;
     }
   }
   [natural = 'tree']::trunk {
@@ -3133,16 +3125,13 @@
       trunk/marker-allow-overlap: true;
       trunk/marker-line-width: 0;
       trunk/marker-width: 2;
-      trunk/marker-height: 2;
       trunk/marker-ignore-placement: true;
     }
     [zoom >= 19] {
       trunk/marker-width: 3;
-      trunk/marker-height: 3;
     }
     [zoom >= 20] {
       trunk/marker-width: 6;
-      trunk/marker-height: 6;
     }
   }
 }


### PR DESCRIPTION


Fixes #2392

Changes proposed in this pull request:
- Remove transparency in `natural=tree_row` rendering to avoid colour mixing in overlaps.
- Clean-up of trees MSS (remove unnecessary `marker-height`; `marker-width` is sufficient for circular markers)

Test rendering with links to the example places:

Before

[Here](https://www.openstreetmap.org/#map=19/54.754047/-1.766562):
<img width="190" height="181" alt="image" src="https://github.com/user-attachments/assets/e49ceee0-28af-45e3-863b-0300660be2bc" />

After
<img width="174" height="155" alt="image" src="https://github.com/user-attachments/assets/05602392-d433-4958-87dd-264b3f909550" />

This is an initial conservative change. But we should review the position of `natural=tree_row` (and `natural=tree`) in the layer stack, as removing the transparency makes it more important to get the order right.

Personally tree rows feel more like landcover features and ought to be quite early. I would be inclined to render them in the `barriers` layer, not least so that by rendering them ahead of other barriers, then you could sensibly render a tree row adjacent to a wall / fence. With no layer change, removing the transparency will have the effect of completely over-writing a wall/fence overlapped by a tree row. In contrast, tree rows overlapping with the road layers will be over-drawn, as happens for barriers parallel to roads. This seems like the Right Thing.

We should also consider whether to remove the transparency from `natural=tree`. It feels cute to allow the tree canopy to "leak" what is behind, but I think transparency just tends to make things more muddled. This, for instance, is an orchard in which individual trees have been mapped:
<img width="173" height="164" alt="image" src="https://github.com/user-attachments/assets/63179397-3680-40b8-9906-280b522df2b3" />

Graveyard with trees:
<img width="97" height="70" alt="image" src="https://github.com/user-attachments/assets/8bdc60d1-ef3b-43f1-934b-a352689b54d4" />




