### PR TITLE
Add avalanche_protector to tunnel types

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1971,7 +1971,6 @@ Layer:
               WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
               ELSE railway
             END AS railway,
-            CASE WHEN (tunnel IN ('yes', 'building_passage', 'avalanche_protector') OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
             tags->'highspeed' as highspeed,
             tags->'usage' as usage,
             construction,


### PR DESCRIPTION
Fixes #3837

[Formally #3837 is discussing `covered`, but the "presenting issue" involved an avalanche protector. For completeness, this tag was previously discussed in #1921 when relatively new.] 

`tunnel=avalanche_protector` now looks to be a well-established and well-defined tag (2.9k), despite its somewhat niche nature. No other `tunnel=X` uses on highways/railways look suitable for rendering (e.g. `covered` and `passage`)

Changes proposed in this pull request:
- Add `avalanche_protector` to rendered `tunnel` subtypes (alongside `yes` and `building_passage`)
- Like `bridge`, don't attempt to visually distinguish subtypes.
- Minor tidying of SQL to use `IN` consistently
- Render `avalanche_protector` on railways and highways, but not roller coaster and aerialways (likely to be mistake). 

Test rendering with links to the example places:

[Link](https://www.openstreetmap.org/#map=15/46.18520/8.08056)

Before
<img width="362" height="158" alt="image" src="https://github.com/user-attachments/assets/f9e96d75-7ff7-4505-b70b-6bb2f14d885f" />

After
<img width="338" height="184" alt="image" src="https://github.com/user-attachments/assets/fcc1b3df-fd3c-4159-8acf-f6f7f68aaea3" />
