### PR TITLE
Change the links to the Carto repository, to point to the new GitHub organization it is maintained by.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ Some colours, SVGs and other files are generated with helper scripts. Not all us
 
 CartoCSS and Mapnik are required for deployment.
 
-* [CartoCSS](https://github.com/mapbox/carto) >= `1.2.0` *(we're using YAML)*
+* [CartoCSS](https://github.com/cartocss/carto) >= `1.2.0` *(we're using YAML)*
 * [Mapnik](https://github.com/mapnik/mapnik/wiki/Mapnik-Installation) >= `3.0.22`
 
 With CartoCSS, these sources are compiled into a Mapnik compatible XML file. When running CartoCSS, specify the Mapnik API version you are using (at least 3.0.22: `carto -a "3.0.22"`).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The general purpose, the cartographic design goals and guidelines for this style
 
 These stylesheets can be used in your own cartography projects, and are designed
 to be easily customised. They work with [Kosmtik](https://github.com/kosmtik/kosmtik)
- and also with the command-line [CartoCSS](https://github.com/mapbox/carto) processor.
+ and also with the command-line [CartoCSS](https://github.com/cartocss/carto) processor.
 
 Since August 2013 these stylesheets have been used on the [OSMF tileservers](https://operations.osmfoundation.org/policies/tiles/) (tile.openstreetmap.org), and
 are updated from each point release. They supersede the previous [XML-based stylesheets](https://github.com/openstreetmap/mapnik-stylesheets).


### PR DESCRIPTION
The current links point to a repository that is archived, giving the impression that a necessary dependency is unmaintained.

Feel free to change anything including the message, in this PR.