### PR TITLE
Tidy up leisure polygon labelling

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2217,7 +2217,7 @@
   [feature = 'natural_beach'],
   [feature = 'natural_shoal'],
   [feature = 'natural_reef'],
-  [feature = 'leisure_sports_centre'],
+  [feature = 'leisure_sports_centre'][sport != 'swimming'],
   [feature = 'leisure_stadium'],
   [feature = 'leisure_track'],
   [feature = 'leisure_ice_rink'],


### PR DESCRIPTION
Mostly addresses: #4620 

Changes proposed in this pull request:
- Remove `landuse`-style (variable size, italic) name rendering for leisure tags (`fitness_station`, `fitness_centre` and `dog_park`) which have a POI symbol. The name rendering starts at Z17, consistent with other POIs, rather than starting early (Z14 onwards) for areas above 3000 pixels. This rendering seems to be a hangover/mistake for `fitness_station` and `fitness_centre`, which both also had a "normal POI" rendering, leading to different results depending on whether `building` tags are present (see below).
- Similarly remove "early start" rendering (Z14+, areas above 3000 pixels) for `water_park`, `swimming_area` and "swimming `sports_centre`". Consistent with other POIs, start at Z17, except for `water_park` (Z16), i.e. `water_park` icon will appear one zoom level earlier than currently, but large area water parks won't receive name labels until Z16.
- Overall effect is that the name for these tags will only appear together with the POI symbols, removing the issue with inconsistent offsets.
- The inconsistency in the outlining remains (i.e. #4620 not fully addressed).

Queries:
- In some places, `text-halo-radius` is set to 0 for text with `private-opacity`, but not consistently. I would guess that eliminating the halo is the Right Thing for reduced visibility text.
- `playground`, `fitness_station` etc. do not use `private-opacity` for the name when `int_restricted` is set, but rather instead sets the colour to `darken(@park, 50%)`. This is inconsistent with the icon which uses the `private_opacity` approach.

I tried not to mess with the controversial dog park rendering, but ultimately it didn't make sense for this to be only the only POI with landuse-style labelling. I would dearly like to remove the clashing fill pattern too...
 
I haven't been able to fully test all the combinations, since they didn't exist in my test area (e.g. large area fitness stations, private swimming areas etc.). The test patches in #4620 and/or StyleInfo would be the best way to thoroughly test.

Test rendering with links to the example places:

[Fitness centre not in building](https://www.openstreetmap.org/#map=17/54.600672/-1.573029&layers=N) 
Before
<img width="87" height="113" alt="image" src="https://github.com/user-attachments/assets/5db0ea7d-7b26-4a0a-85f6-13919e13ced0" />

After
<img width="113" height="137" alt="image" src="https://github.com/user-attachments/assets/ac5f179a-238e-468c-8a74-9b2182210f14" />

[Fitness centre with building tagging](https://www.openstreetmap.org/#map=17/54.533006/-1.552730)
Before:
<img width="105" height="114" alt="image" src="https://github.com/user-attachments/assets/f01578df-184a-4c3e-bd3c-fd273a2d8a8f" />

After:
<img width="113" height="123" alt="image" src="https://github.com/user-attachments/assets/f9b45b90-c2a3-4881-88b8-f1665584ba14" />
(i.e. now consistent)


