### PR TITLE
Improve fill colour behaviour for power plants at medium zoom levels

### DIFF
--- a/style/landcover.mss
+++ b/style/landcover.mss
@@ -417,7 +417,9 @@
   [feature = 'power_plant'][zoom >= 10],
   [feature = 'power_generator'][zoom >= 10],
   [feature = 'power_substation'][zoom >= 13] {
-    polygon-fill: @industrial;
+    polygon-fill: @built-up-lowzoom;
+    [zoom >= 12] { polygon-fill: @built-up-z12; }
+    [zoom >= 13] { polygon-fill: @industrial; }
     [zoom >= 15] {
       polygon-fill: @power;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Unification of the fill colour for power plants, generators and substations with the fill colour for industrial landuses for zoom levels 10-12, as it is the case for zoom levels 13-14

Currently, power plants and industrial areas have different fill colours at zoom levels 15 and above. This [might have been intended or not](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/1835#issuecomment-140284833), but that's for another story. For now, let's assume this is fine.  
When zooming out to levels 14 and 13, the power plants change their fill colour to the same colour that the industrial areas have. This seems fine too, as the general trend is that the colouring scheme gets more generic the more we zoom out.  
But when zooming out even further to levels 12 and below, the colours diverge again. Even though the industrial areas are getting grouped into the very broad built-up area fill colour, the power plants retain the `@industrial` fill -- making them stick out like a sore thumb. This seems very counter-intuitive.
