### PR TITLE
Rework waterway lines

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -194,20 +194,26 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            way,
-            waterway,
-            name,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') 
-              OR waterway = 'canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel,
+            *,
             'no' AS bridge
-          FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
-            AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
-          ORDER BY COALESCE(layer,0)
+          FROM
+          (SELECT -- This subselect allows sorting on the int_tunnel column
+              way,
+              waterway,
+              CASE WHEN tags->'intermittent' IN ('yes')
+                OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+                THEN 'yes' ELSE 'no' END AS int_intermittent,
+              CASE WHEN tunnel IN ('yes', 'culvert') 
+                OR waterway = 'canal' AND tunnel = 'flooded'
+                THEN 'yes' ELSE 'no' END AS int_tunnel,
+              COALESCE(layer,0) AS layernotnull
+            FROM planet_osm_line
+            WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+              AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
+          ) _
+          ORDER BY
+            layernotnull,
+            CASE WHEN int_tunnel = 'yes' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
       minzoom: 12

--- a/style/water.mss
+++ b/style/water.mss
@@ -310,7 +310,7 @@
   [waterway = 'drain'] {
     [int_intermittent != 'yes'][zoom >= 14],
     [zoom >= 15] {
-      [int_tunnel = 'yes'][zoom >= 15] {
+      [int_tunnel = 'yes'] {
         // Background for dashed tunnel casings
         // The line widths are adjusted later - this just "books in" the background layer
         background/line-color: @water-tunnelfill-color;
@@ -339,7 +339,7 @@
         water/line-join: round;
       }
 
-      [int_tunnel = 'yes'][zoom >= 15]  {
+      [int_tunnel = 'yes']  {
         water/line-dasharray: 4,2;
         // PROBLEM HERE: join/cap not set, differs from river/canal
         background/line-width: @ditchdrain-width-z14 + 1.5;

--- a/style/water.mss
+++ b/style/water.mss
@@ -17,9 +17,6 @@
 @river-width-z17:         10;
 @river-width-z18:         12;
 
-@canal-scale-factor-z12z13:  0.8;
-@canal-scale-factor:      0.6;
-
 @stream-width-z12:        0.8;
 @stream-width-z13:        1.4;
 @stream-width-z14:        2;
@@ -28,9 +25,7 @@
 @stream-width-z17:        3.5;
 @stream-width-z18:        4;
 
-@ditchdrain-width-z14:        1.5;
-@ditchdrain-width-z16:        2;
-@ditchdrain-width-z18:        2.5;
+@canal-scale-factor:      1.4;
 
 #water-areas {
   [natural = 'glacier']::natural {
@@ -81,33 +76,23 @@
 #waterway-bridges::casing {
   // white glow used when water stroke width is less than 3 px and only at "mid zoom" (13 - 17)
 
-  [waterway = 'stream'] {
-    [int_tunnel = 'no'][zoom < 16] {
+  [waterway = 'canal'][int_tunnel = 'no'][zoom = 13][int_intermittent != 'yes'] {
+    line-color: white;
+    line-opacity: 0.75;
+    line-width: (@stream-width-z13 * @canal-scale-factor) + 0.4;
+  }
+
+  [waterway = 'ditch'][zoom < 18],
+  [waterway = 'drain'][zoom < 18],
+  [waterway = 'stream'][zoom < 16] {
+    [int_tunnel = 'no'] {
       [zoom = 13][int_intermittent != 'yes'],
       [zoom >= 14] {
         line-color: white;
         line-opacity: 0.75;
         line-width: @stream-width-z13 + 0.5;
         [zoom >= 14] { line-width: @stream-width-z14 + 0.4; }
-        [zoom >= 15] { line-width: @stream-width-z15 + 0.3; }
-        [int_intermittent = 'yes'] {
-          line-dasharray: 4,3;
-          line-cap: butt;
-          line-join: round;
-        }
-      }
-    }
-  }
-
-  [waterway = 'ditch'],
-  [waterway = 'drain'] {
-    [int_tunnel = 'no'][zoom < 18] {
-      [zoom = 14][int_intermittent != 'yes'],
-      [zoom >= 15] {
-        line-opacity: 0.75;
-        line-color: white;
-        line-width: @ditchdrain-width-z14 + 0.5;
-        [zoom >= 16] { line-width: @ditchdrain-width-z16 + 0.4; }
+        [waterway = 'stream'][zoom >= 15] { line-width: @stream-width-z15 + 0.3; }
         [int_intermittent = 'yes'] {
           line-dasharray: 4,3;
           line-cap: butt;
@@ -121,7 +106,6 @@
 
 #water-lines,
 #waterway-bridges {
-  [waterway = 'canal'][zoom >= 12],
   [waterway = 'river'][zoom >= 12] {
     [int_tunnel = 'yes'] {
       // Background for dashed tunnel casings
@@ -133,15 +117,6 @@
       [zoom >= 16] { background/line-width: @river-width-z16; }
       [zoom >= 17] { background/line-width: @river-width-z17; }
       [zoom >= 18] { background/line-width: @river-width-z18; }
-      [waterway = 'canal'] {
-        background/line-width: @river-width-z12 * @canal-scale-factor-z12z13;
-        [zoom >= 13] { background/line-width: @river-width-z13 * @canal-scale-factor-z12z13; }
-        [zoom >= 14] { background/line-width: @river-width-z14 * @canal-scale-factor; }
-        [zoom >= 15] { background/line-width: @river-width-z15 * @canal-scale-factor; }
-        [zoom >= 16] { background/line-width: @river-width-z16 * @canal-scale-factor; }
-        [zoom >= 17] { background/line-width: @river-width-z17 * @canal-scale-factor; }
-        [zoom >= 18] { background/line-width: @river-width-z18 * @canal-scale-factor; }
-      }
       background/line-cap: round;
       background/line-join: round;
       // PROBLEM HERE. Initially round+round, then redefined as butt+miter
@@ -157,13 +132,6 @@
       [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
       [zoom >= 17] { bridgecasing/line-width: @river-width-z17 + 1; }
       [zoom >= 18] { bridgecasing/line-width: @river-width-z18 + 1; }
-      [waterway = 'canal'] {
-        bridgecasing/line-width: @river-width-z14 * @canal-scale-factor + 1;
-        [zoom >= 15] { bridgecasing/line-width: @river-width-z15 * @canal-scale-factor + 1; }
-        [zoom >= 16] { bridgecasing/line-width: @river-width-z16 * @canal-scale-factor + 1; }
-        [zoom >= 17] { bridgecasing/line-width: @river-width-z17 * @canal-scale-factor + 1; }
-        [zoom >= 18] { bridgecasing/line-width: @river-width-z18 * @canal-scale-factor + 1; }
-      }
 
       [int_intermittent = 'yes'] {
         bridgefill/line-color: white;
@@ -173,13 +141,6 @@
         [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
         [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
         [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
-        [waterway = 'canal'] {
-          bridgefill/line-width: @river-width-z14 * @canal-scale-factor;
-          [zoom >= 15] { bridgefill/line-width: @river-width-z15 * @canal-scale-factor; }
-          [zoom >= 16] { bridgefill/line-width: @river-width-z16 * @canal-scale-factor; }
-          [zoom >= 17] { bridgefill/line-width: @river-width-z17 * @canal-scale-factor; }
-          [zoom >= 18] { bridgefill/line-width: @river-width-z18 * @canal-scale-factor; }
-        }
       }
     }
 
@@ -191,15 +152,6 @@
     [zoom >= 16] { water/line-width: @river-width-z16; }
     [zoom >= 17] { water/line-width: @river-width-z17; }
     [zoom >= 18] { water/line-width: @river-width-z18; }
-    [waterway = 'canal'] {
-      water/line-width: @river-width-z12 * @canal-scale-factor-z12z13;
-      [zoom >= 13] { water/line-width: @river-width-z13 * @canal-scale-factor-z12z13; }
-      [zoom >= 14] { water/line-width: @river-width-z14 * @canal-scale-factor; }
-      [zoom >= 15] { water/line-width: @river-width-z15 * @canal-scale-factor; }
-      [zoom >= 16] { water/line-width: @river-width-z16 * @canal-scale-factor; }
-      [zoom >= 17] { water/line-width: @river-width-z17 * @canal-scale-factor; }
-      [zoom >= 18] { water/line-width: @river-width-z18 * @canal-scale-factor; }
-    }
     water/line-cap: round;
     water/line-join: round;
 
@@ -221,18 +173,11 @@
       [zoom >= 16] { tunnelfill/line-width: @river-width-z16 - 3; }
       [zoom >= 17] { tunnelfill/line-width: @river-width-z17 - 3; }
       [zoom >= 18] { tunnelfill/line-width: @river-width-z18 - 4; }
-      [waterway= 'canal'] {
-        tunnelfill/line-width: (@river-width-z12 - 1.5) * @canal-scale-factor-z12z13;
-        [zoom >= 13] { tunnelfill/line-width: (@river-width-z13 - 2) * @canal-scale-factor-z12z13; }
-        [zoom >= 14] { tunnelfill/line-width: (@river-width-z14 - 3) * @canal-scale-factor; }
-        [zoom >= 15] { tunnelfill/line-width: (@river-width-z15 - 3) * @canal-scale-factor; }
-        [zoom >= 16] { tunnelfill/line-width: (@river-width-z16 - 3.5) * @canal-scale-factor; }
-        [zoom >= 17] { tunnelfill/line-width: (@river-width-z17 - 3.5) * @canal-scale-factor; }
-        [zoom >= 18] { tunnelfill/line-width: (@river-width-z18 - 4) * @canal-scale-factor; }
-      }
     }
   }
 
+  [waterway = 'ditch'],
+  [waterway = 'drain'],
   [waterway = 'stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {
@@ -247,26 +192,32 @@
         bridgecasing/line-color: black;
         bridgecasing/line-join: round;
         bridgecasing/line-width: @stream-width-z14 + 1;
-        [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
-        [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
-        [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
-        [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
+        [waterway = 'stream'] {
+          [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
+          [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
+          [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
+          [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
+        }
         bridgefill/line-color: white;
         bridgefill/line-join: round;
         bridgefill/line-width: @stream-width-z14;
-        [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
-        [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
-        [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
-        [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+        [waterway = 'stream'] {
+          [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
+          [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
+          [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
+          [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+        }
       }
 
       water/line-width: @stream-width-z12;
       [zoom >= 13] { water/line-width: @stream-width-z13; }
       [zoom >= 14] { water/line-width: @stream-width-z14; }
-      [zoom >= 15] { water/line-width: @stream-width-z15; }
-      [zoom >= 16] { water/line-width: @stream-width-z16; }
-      [zoom >= 17] { water/line-width: @stream-width-z17; }
-      [zoom >= 18] { water/line-width: @stream-width-z18; }
+      [waterway = 'stream'] {
+        [zoom >= 15] { water/line-width: @stream-width-z15; }
+        [zoom >= 16] { water/line-width: @stream-width-z16; }
+        [zoom >= 17] { water/line-width: @stream-width-z17; }
+        [zoom >= 18] { water/line-width: @stream-width-z18; }
+      }
       water/line-color: @water-color;
 
       [int_intermittent = 'yes'] {
@@ -282,80 +233,103 @@
         water/line-width: @stream-width-z14 + 1;
         tunnelfill/line-width: @stream-width-z14 - 0.5;
         tunnelfill/line-color: @water-tunnelfill-color;
-        [zoom >= 15] { 
-          background/line-width: @stream-width-z15 + 1.5;
-          water/line-width: @stream-width-z15 + 1.5;
-          tunnelfill/line-width: @stream-width-z15 - 1;
-        }
-        [zoom >= 16] { 
-          background/line-width: @stream-width-z16 + 1;
-          water/line-width: @stream-width-z16 + 1;
-          tunnelfill/line-width: @stream-width-z16 - 1.5;
-        }
-        [zoom >= 17] { 
-          background/line-width: @stream-width-z17 + 1;
-          water/line-width: @stream-width-z17 + 1;
-          tunnelfill/line-width: @stream-width-z17 - 1.5;
-        }
-        [zoom >= 18] { 
-          background/line-width: @stream-width-z18 + 1;
-          water/line-width: @stream-width-z18 + 1;
-          tunnelfill/line-width: @stream-width-z18 - 1.5;
+        [waterway = 'stream'] {
+          [zoom >= 15] { 
+            background/line-width: @stream-width-z15 + 1.5;
+            water/line-width: @stream-width-z15 + 1.5;
+            tunnelfill/line-width: @stream-width-z15 - 1;
+          }
+          [zoom >= 16] { 
+            background/line-width: @stream-width-z16 + 1;
+            water/line-width: @stream-width-z16 + 1;
+            tunnelfill/line-width: @stream-width-z16 - 1.5;
+          }
+          [zoom >= 17] { 
+            background/line-width: @stream-width-z17 + 1;
+            water/line-width: @stream-width-z17 + 1;
+            tunnelfill/line-width: @stream-width-z17 - 1.5;
+          }
+          [zoom >= 18] { 
+            background/line-width: @stream-width-z18 + 1;
+            water/line-width: @stream-width-z18 + 1;
+            tunnelfill/line-width: @stream-width-z18 - 1.5;
+          }
         }
       }
     }
   }
 
-  [waterway = 'ditch'],
-  [waterway = 'drain'] {
-    [int_intermittent != 'yes'][zoom >= 14],
-    [zoom >= 15] {
-      [int_tunnel = 'yes'] {
-        // Background for dashed tunnel casings
-        // The line widths are adjusted later - this just "books in" the background layer
-        background/line-color: @water-tunnelfill-color;
-      }
+  [waterway = 'canal'][zoom >= 12] {
+    [int_tunnel = 'yes'][zoom >= 13] {
+      // Background for dashed tunnel casings
+      // The line widths are adjusted later - this just "books in" the background layer
+      background/line-color: @water-tunnelfill-color;
+      // PROBLEM HERE: Join/cap style not specified?
+    }
 
-      [bridge = 'yes'] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: @ditchdrain-width-z14 + 1;
-        [zoom >= 16] { bridgecasing/line-width: @ditchdrain-width-z16 + 1; }
-        [zoom >= 18] { bridgecasing/line-width: @ditchdrain-width-z18 + 1; }
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @ditchdrain-width-z14;
-        [zoom >= 16] { bridgefill/line-width: @ditchdrain-width-z16; }
-        [zoom >= 18] { bridgefill/line-width: @ditchdrain-width-z18; }
-      }
+    [bridge = 'yes'][zoom >= 14] {
+      bridgecasing/line-color: black;
+      bridgecasing/line-join: round;
+      bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+      [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
+      [zoom >= 16] { bridgecasing/line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
+      [zoom >= 17] { bridgecasing/line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
+      [zoom >= 18] { bridgecasing/line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
+      bridgefill/line-color: white;
+      bridgefill/line-join: round;
+      bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
+      [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
+      [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
+      [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
+      [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+    }
 
-      water/line-width: @ditchdrain-width-z14;
-      [zoom >= 16] { water/line-width: @ditchdrain-width-z16; }
-      [zoom >= 18] { water/line-width: @ditchdrain-width-z18; }
-      water/line-color: @water-color;
-      [int_intermittent = 'yes'] {
-        water/line-dasharray: 4,3;
-        water/line-cap: butt;
-        water/line-join: round;
-      }
+    water/line-width: @stream-width-z12 * @canal-scale-factor;
+    [zoom >= 13] { water/line-width: @stream-width-z13 * @canal-scale-factor; }
+    [zoom >= 14] { water/line-width: @stream-width-z14 * @canal-scale-factor; }
+    [zoom >= 15] { water/line-width: @stream-width-z15 * @canal-scale-factor; }
+    [zoom >= 16] { water/line-width: @stream-width-z16 * @canal-scale-factor; }
+    [zoom >= 17] { water/line-width: @stream-width-z17 * @canal-scale-factor; }
+    [zoom >= 18] { water/line-width: @stream-width-z18 * @canal-scale-factor; }
+    water/line-color: @water-color;
 
-      [int_tunnel = 'yes']  {
-        water/line-dasharray: 4,2;
-        // PROBLEM HERE: join/cap not set, differs from river/canal
-        background/line-width: @ditchdrain-width-z14 + 1.5;
-        water/line-width: @ditchdrain-width-z14 + 1.5;
-        tunnelfill/line-width: @ditchdrain-width-z14 - 0.5;
-        tunnelfill/line-color: @water-tunnelfill-color;
-        [zoom >= 16] {
-          background/line-width: @ditchdrain-width-z16 + 1.5;
-          water/line-width: @ditchdrain-width-z16 + 1.5;
-          tunnelfill/line-width: @ditchdrain-width-z16 - 1.5;
-        }
-        [zoom >= 18] {
-          background/line-width: @ditchdrain-width-z18 + 1;
-          water/line-width: @ditchdrain-width-z18 + 1;
-          tunnelfill/line-width: @ditchdrain-width-z18 - 1;
-        }
+    [int_intermittent = 'yes'] {
+      water/line-dasharray: 4,3;
+      water/line-cap: butt;
+      water/line-join: round;
+    }
+    
+    [int_tunnel = 'yes'][zoom >= 13] {
+      water/line-dasharray: 4,2;
+      // PROBLEM HERE: join/cap not set, differs from river/canal
+      background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+      water/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+      tunnelfill/line-width: (@stream-width-z13 * @canal-scale-factor) - 1;
+      tunnelfill/line-color: @water-tunnelfill-color;
+      [zoom >= 14] { 
+        background/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        tunnelfill/line-width: (@stream-width-z14 * @canal-scale-factor) - 1.5;
+      }
+      [zoom >= 15] { 
+        background/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
+        tunnelfill/line-width: (@stream-width-z15 * @canal-scale-factor) - 1.5;
+      }
+      [zoom >= 16] { 
+        background/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
+        tunnelfill/line-width: (@stream-width-z16 * @canal-scale-factor) - 1.5;
+      }
+      [zoom >= 17] { 
+        background/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
+        tunnelfill/line-width: (@stream-width-z17 * @canal-scale-factor) - 1.5;
+      }
+      [zoom >= 18] { 
+        background/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
+        tunnelfill/line-width: (@stream-width-z18 * @canal-scale-factor) - 1.5;
       }
     }
   }
@@ -401,10 +375,13 @@
       [zoom >= 14] { text-size: 12; }
     }
 
+    [waterway = 'drain'][zoom >= 15],
+    [waterway = 'ditch'][zoom >= 15],
     [waterway = 'stream'][zoom >= 15] {
       text-name: "[name]";
       text-size: 10;
-      text-face-name: @oblique-fonts;
+      text-face-name: @standard-font;
+      [waterway = 'stream'] { text-face-name: @oblique-fonts; }
       text-fill: @water-text;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
@@ -415,22 +392,6 @@
       text-repeat-distance: @waterway-text-repeat-distance;
     }
 
-    [waterway = 'drain'],
-    [waterway = 'ditch'] {
-      [zoom >= 16] {
-        text-name: "[name]";
-        text-size: 10;
-        text-face-name: @standard-font;
-        text-fill: @water-text;
-        text-halo-radius: @standard-halo-radius;
-        text-halo-fill: @standard-halo-fill;
-        text-spacing: @waterway-text-spacing;
-        text-placement: line;
-        text-vertical-alignment: middle;
-        text-dy: 8;
-        text-repeat-distance: @waterway-text-repeat-distance;
-      }
-    }
   }
   [natural = 'bay'][zoom >= 14],
   [natural = 'strait'][zoom >= 14] {

--- a/style/water.mss
+++ b/style/water.mss
@@ -1,8 +1,36 @@
 @water-text: #4d80b3;
 @glacier: #ddecec;
 @glacier-line: #9cf;
-
+//@water-tunnelfill-color: #f3f7f7;
+@water-tunnelfill-color: lighten(@water-color, 20%);
 @waterway-text-repeat-distance: 200;
+
+@river-width-z8:          0.7;
+@river-width-z9:          1.2;
+@river-width-z10:         1.5;
+@river-width-z11:         1.8;
+@river-width-z12:         2.3;
+@river-width-z13:         3;
+@river-width-z14:         4.5;
+@river-width-z15:         6;
+@river-width-z16:         8;
+@river-width-z17:         10;
+@river-width-z18:         12;
+
+@canal-scale-factor-z12z13:  0.8;
+@canal-scale-factor:      0.6;
+
+@stream-width-z12:        0.8;
+@stream-width-z13:        1.4;
+@stream-width-z14:        2;
+@stream-width-z15:        2.5;
+@stream-width-z16:        3;
+@stream-width-z17:        3.5;
+@stream-width-z18:        4;
+
+@ditchdrain-width-z14:        1.5;
+@ditchdrain-width-z16:        2;
+@ditchdrain-width-z18:        2.5;
 
 #water-areas {
   [natural = 'glacier']::natural {
@@ -41,157 +69,293 @@
       line-dasharray: 8,4;
       line-cap: butt;
       line-join: round;
-      line-clip: false;
     }
     line-color: @water-color;
-    line-width: 0.7;
-    [zoom >= 9] { line-width: 1.2; }
-    [zoom >= 10] { line-width: 1.6; }
+    line-width: @river-width-z8;
+    [zoom >= 9] { line-width: @river-width-z9; }
+    [zoom >= 10] { line-width: @river-width-z10; }
   }
 }
 
-#water-lines::casing {
-  [waterway = 'stream'],
-  [waterway = 'ditch'],
-  [waterway = 'drain'] {
-    [int_tunnel = 'no'] {
-      [int_intermittent != 'yes'][zoom >= 14],
-      [zoom >= 15] {
-        line-width: 2.5;
+#water-lines::casing, 
+#waterway-bridges::casing {
+  // white glow used when water stroke width is less than 3 px and only at "mid zoom" (13 - 17)
+
+  [waterway = 'stream'] {
+    [int_tunnel = 'no'][zoom < 16] {
+      [zoom = 13][int_intermittent != 'yes'],
+      [zoom >= 14] {
         line-color: white;
-        [waterway = 'stream'][zoom >= 15] {
-          line-width: 3.5;
-        }
+        line-opacity: 0.75;
+        line-width: @stream-width-z13 + 0.5;
+        [zoom >= 14] { line-width: @stream-width-z14 + 0.4; }
+        [zoom >= 15] { line-width: @stream-width-z15 + 0.3; }
         [int_intermittent = 'yes'] {
           line-dasharray: 4,3;
           line-cap: butt;
           line-join: round;
-          line-clip: false;
         }
       }
     }
   }
+
+  [waterway = 'ditch'],
+  [waterway = 'drain'] {
+    [int_tunnel = 'no'][zoom < 18] {
+      [zoom = 14][int_intermittent != 'yes'],
+      [zoom >= 15] {
+        line-opacity: 0.75;
+        line-color: white;
+        line-width: @ditchdrain-width-z14 + 0.5;
+        [zoom >= 16] { line-width: @ditchdrain-width-z16 + 0.4; }
+        [int_intermittent = 'yes'] {
+          line-dasharray: 4,3;
+          line-cap: butt;
+          line-join: round;
+        }
+      }
+    }
+  }
+
 }
 
 #water-lines,
 #waterway-bridges {
   [waterway = 'canal'][zoom >= 12],
   [waterway = 'river'][zoom >= 12] {
-    // the additional line of land color is used to provide a background for dashed casings
     [int_tunnel = 'yes'] {
-      background/line-color: @land-color;
-      background/line-width: 2;
+      // Background for dashed tunnel casings
+      background/line-color: @water-tunnelfill-color;
+      background/line-width: @river-width-z12;
+      [zoom >= 13] { background/line-width: @river-width-z13; }
+      [zoom >= 14] { background/line-width: @river-width-z14; }
+      [zoom >= 15] { background/line-width: @river-width-z15; }
+      [zoom >= 16] { background/line-width: @river-width-z16; }
+      [zoom >= 17] { background/line-width: @river-width-z17; }
+      [zoom >= 18] { background/line-width: @river-width-z18; }
+      [waterway = 'canal'] {
+        background/line-width: @river-width-z12 * @canal-scale-factor-z12z13;
+        [zoom >= 13] { background/line-width: @river-width-z13 * @canal-scale-factor-z12z13; }
+        [zoom >= 14] { background/line-width: @river-width-z14 * @canal-scale-factor; }
+        [zoom >= 15] { background/line-width: @river-width-z15 * @canal-scale-factor; }
+        [zoom >= 16] { background/line-width: @river-width-z16 * @canal-scale-factor; }
+        [zoom >= 17] { background/line-width: @river-width-z17 * @canal-scale-factor; }
+        [zoom >= 18] { background/line-width: @river-width-z18 * @canal-scale-factor; }
+      }
       background/line-cap: round;
       background/line-join: round;
+      // PROBLEM HERE. Initially round+round, then redefined as butt+miter
+      background/line-cap: butt;
+      background/line-join: miter;
     }
 
-    [bridge = 'yes'] {
-      [zoom >= 14] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-join: round;
-        bridgecasing/line-width: 6;
-        [zoom >= 15] { bridgecasing/line-width: 7; }
-        [zoom >= 17] { bridgecasing/line-width: 11; }
-        [zoom >= 18] { bridgecasing/line-width: 13; }
+    [bridge = 'yes'][zoom >= 14] {
+      bridgecasing/line-color: black;
+      bridgecasing/line-join: round;
+      bridgecasing/line-width: @river-width-z14 + 1;
+      [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
+      [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
+      [zoom >= 17] { bridgecasing/line-width: @river-width-z17 + 1; }
+      [zoom >= 18] { bridgecasing/line-width: @river-width-z18 + 1; }
+      [waterway = 'canal'] {
+        bridgecasing/line-width: @river-width-z14 * @canal-scale-factor + 1;
+        [zoom >= 15] { bridgecasing/line-width: @river-width-z15 * @canal-scale-factor + 1; }
+        [zoom >= 16] { bridgecasing/line-width: @river-width-z16 * @canal-scale-factor + 1; }
+        [zoom >= 17] { bridgecasing/line-width: @river-width-z17 * @canal-scale-factor + 1; }
+        [zoom >= 18] { bridgecasing/line-width: @river-width-z18 * @canal-scale-factor + 1; }
+      }
+
+      [int_intermittent = 'yes'] {
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @river-width-z14;
+        [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
+        [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
+        [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
+        [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
+        [waterway = 'canal'] {
+          bridgefill/line-width: @river-width-z14 * @canal-scale-factor;
+          [zoom >= 15] { bridgefill/line-width: @river-width-z15 * @canal-scale-factor; }
+          [zoom >= 16] { bridgefill/line-width: @river-width-z16 * @canal-scale-factor; }
+          [zoom >= 17] { bridgefill/line-width: @river-width-z17 * @canal-scale-factor; }
+          [zoom >= 18] { bridgefill/line-width: @river-width-z18 * @canal-scale-factor; }
+        }
       }
     }
 
     water/line-color: @water-color;
-    water/line-width: 2;
+    water/line-width: @river-width-z12;
+    [zoom >= 13] { water/line-width: @river-width-z13; }
+    [zoom >= 14] { water/line-width: @river-width-z14; }
+    [zoom >= 15] { water/line-width: @river-width-z15; }
+    [zoom >= 16] { water/line-width: @river-width-z16; }
+    [zoom >= 17] { water/line-width: @river-width-z17; }
+    [zoom >= 18] { water/line-width: @river-width-z18; }
+    [waterway = 'canal'] {
+      water/line-width: @river-width-z12 * @canal-scale-factor-z12z13;
+      [zoom >= 13] { water/line-width: @river-width-z13 * @canal-scale-factor-z12z13; }
+      [zoom >= 14] { water/line-width: @river-width-z14 * @canal-scale-factor; }
+      [zoom >= 15] { water/line-width: @river-width-z15 * @canal-scale-factor; }
+      [zoom >= 16] { water/line-width: @river-width-z16 * @canal-scale-factor; }
+      [zoom >= 17] { water/line-width: @river-width-z17 * @canal-scale-factor; }
+      [zoom >= 18] { water/line-width: @river-width-z18 * @canal-scale-factor; }
+    }
     water/line-cap: round;
     water/line-join: round;
 
     [int_intermittent = 'yes'] {
-      [bridge = 'yes'][zoom >= 14] {
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: 4;
-        [zoom >= 15] { bridgefill/line-width: 5; }
-        [zoom >= 17] { bridgefill/line-width: 9; }
-        [zoom >= 18] { bridgefill/line-width: 11; }
-      }
       water/line-dasharray: 4,3;
       water/line-cap: butt;
-      water/line-join: round;
-      water/line-clip: false;
     }
 
-    [zoom >= 13] { water/line-width: 3; }
-    [zoom >= 14] { water/line-width: 5; }
-    [zoom >= 15] { water/line-width: 6; }
-    [zoom >= 17] { water/line-width: 10; }
-    [zoom >= 18] { water/line-width: 12; }
-
     [int_tunnel = 'yes'] {
-      [zoom >= 13] { background/line-width: 3; }
-      [zoom >= 14] { background/line-width: 5; }
-      [zoom >= 15] { background/line-width: 6; }
-      [zoom >= 17] { background/line-width: 10; }
-      [zoom >= 18] { background/line-width: 12; }
-
+      // This provides the blue dashed casing of waterway tunnels
       water/line-dasharray: 4,2;
-      background/line-cap: butt;
-      background/line-join: miter;
       water/line-cap: butt;
       water/line-join: miter;
-      tunnelfill/line-color: #f3f7f7;
-      tunnelfill/line-width: 1;
-      [zoom >= 14] { tunnelfill/line-width: 2; }
-      [zoom >= 15] { tunnelfill/line-width: 3; }
-      [zoom >= 17] { tunnelfill/line-width: 7; }
-      [zoom >= 18] { tunnelfill/line-width: 8; }
+      tunnelfill/line-color: @water-tunnelfill-color;
+      tunnelfill/line-width: @river-width-z12 - 1.5;
+      [zoom >= 13] { tunnelfill/line-width: @river-width-z13 - 2; }
+      [zoom >= 14] { tunnelfill/line-width: @river-width-z14 - 3; }
+      [zoom >= 15] { tunnelfill/line-width: @river-width-z15 - 3; }
+      [zoom >= 16] { tunnelfill/line-width: @river-width-z16 - 3; }
+      [zoom >= 17] { tunnelfill/line-width: @river-width-z17 - 3; }
+      [zoom >= 18] { tunnelfill/line-width: @river-width-z18 - 4; }
+      [waterway= 'canal'] {
+        tunnelfill/line-width: (@river-width-z12 - 1.5) * @canal-scale-factor-z12z13;
+        [zoom >= 13] { tunnelfill/line-width: (@river-width-z13 - 2) * @canal-scale-factor-z12z13; }
+        [zoom >= 14] { tunnelfill/line-width: (@river-width-z14 - 3) * @canal-scale-factor; }
+        [zoom >= 15] { tunnelfill/line-width: (@river-width-z15 - 3) * @canal-scale-factor; }
+        [zoom >= 16] { tunnelfill/line-width: (@river-width-z16 - 3.5) * @canal-scale-factor; }
+        [zoom >= 17] { tunnelfill/line-width: (@river-width-z17 - 3.5) * @canal-scale-factor; }
+        [zoom >= 18] { tunnelfill/line-width: (@river-width-z18 - 4) * @canal-scale-factor; }
+      }
     }
   }
 
-  [waterway = 'stream'],
-  [waterway = 'ditch'],
-  [waterway = 'drain'] {
-    [int_intermittent != 'yes'][zoom >= 14],
-    [zoom >= 15] {
-      // the additional line of land color is used to provide a background for dashed casings
-      [int_tunnel = 'yes'] {
-        background/line-width: 2;
-        background/line-color: @land-color;
+  [waterway = 'stream'] {
+    [int_intermittent != 'yes'][zoom >= 12],
+    [zoom >= 13] {
+      [int_tunnel = 'yes'][zoom >= 14] {
+        // Background for dashed tunnel casings
+        // The line widths are adjusted later - this just "books in" the background layer
+        background/line-color: @water-tunnelfill-color;
+      // PROBLEM HERE: Join/cap style not specified?
       }
-      water/line-width: 2;
-      water/line-color: @water-color;
 
-      [bridge = 'yes'] {
+      [bridge = 'yes'][zoom >= 14] {
         bridgecasing/line-color: black;
         bridgecasing/line-join: round;
-        bridgecasing/line-width: 4;
-        [waterway = 'stream'][zoom >= 15] { bridgecasing/line-width: 4; }
-        bridgeglow/line-color: white;
-        bridgeglow/line-join: round;
-        bridgeglow/line-width: 3;
-        [waterway = 'stream'][zoom >= 15] { bridgeglow/line-width: 3; }
+        bridgecasing/line-width: @stream-width-z14 + 1;
+        [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
+        [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
+        [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
+        [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @stream-width-z14;
+        [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
+        [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
+        [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
+        [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
       }
+
+      water/line-width: @stream-width-z12;
+      [zoom >= 13] { water/line-width: @stream-width-z13; }
+      [zoom >= 14] { water/line-width: @stream-width-z14; }
+      [zoom >= 15] { water/line-width: @stream-width-z15; }
+      [zoom >= 16] { water/line-width: @stream-width-z16; }
+      [zoom >= 17] { water/line-width: @stream-width-z17; }
+      [zoom >= 18] { water/line-width: @stream-width-z18; }
+      water/line-color: @water-color;
 
       [int_intermittent = 'yes'] {
         water/line-dasharray: 4,3;
         water/line-cap: butt;
         water/line-join: round;
-        water/line-clip: false;
       }
 
-      [waterway = 'stream'][zoom >= 15] {
-        water/line-width: 3;
-
-        [int_tunnel = 'yes'] {
-          background/line-width: 3;
-        }
-      }
-      [int_tunnel = 'yes'][zoom >= 15] {
-        background/line-width: 3.5;
-        water/line-width: 3.5;
-        [waterway = 'stream'] {
-          background/line-width: 4.5;
-          water/line-width: 4.5;
-        }
+      [int_tunnel = 'yes'][zoom >= 14] {
         water/line-dasharray: 4,2;
-        tunnelfill/line-width: 1;
-        [waterway = 'stream'] { tunnelfill/line-width: 2; }
-        tunnelfill/line-color: #f3f7f7;
+        // PROBLEM HERE: join/cap not set, differs from river/canal
+        background/line-width: @stream-width-z14 + 1;
+        water/line-width: @stream-width-z14 + 1;
+        tunnelfill/line-width: @stream-width-z14 - 0.5;
+        tunnelfill/line-color: @water-tunnelfill-color;
+        [zoom >= 15] { 
+          background/line-width: @stream-width-z15 + 1.5;
+          water/line-width: @stream-width-z15 + 1.5;
+          tunnelfill/line-width: @stream-width-z15 - 1;
+        }
+        [zoom >= 16] { 
+          background/line-width: @stream-width-z16 + 1;
+          water/line-width: @stream-width-z16 + 1;
+          tunnelfill/line-width: @stream-width-z16 - 1.5;
+        }
+        [zoom >= 17] { 
+          background/line-width: @stream-width-z17 + 1;
+          water/line-width: @stream-width-z17 + 1;
+          tunnelfill/line-width: @stream-width-z17 - 1.5;
+        }
+        [zoom >= 18] { 
+          background/line-width: @stream-width-z18 + 1;
+          water/line-width: @stream-width-z18 + 1;
+          tunnelfill/line-width: @stream-width-z18 - 1.5;
+        }
+      }
+    }
+  }
+
+  [waterway = 'ditch'],
+  [waterway = 'drain'] {
+    [int_intermittent != 'yes'][zoom >= 14],
+    [zoom >= 15] {
+      [int_tunnel = 'yes'][zoom >= 15] {
+        // Background for dashed tunnel casings
+        // The line widths are adjusted later - this just "books in" the background layer
+        background/line-color: @water-tunnelfill-color;
+      }
+
+      [bridge = 'yes'] {
+        bridgecasing/line-color: black;
+        bridgecasing/line-join: round;
+        bridgecasing/line-width: @ditchdrain-width-z14 + 1;
+        [zoom >= 16] { bridgecasing/line-width: @ditchdrain-width-z16 + 1; }
+        [zoom >= 18] { bridgecasing/line-width: @ditchdrain-width-z18 + 1; }
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @ditchdrain-width-z14;
+        [zoom >= 16] { bridgefill/line-width: @ditchdrain-width-z16; }
+        [zoom >= 18] { bridgefill/line-width: @ditchdrain-width-z18; }
+      }
+
+      water/line-width: @ditchdrain-width-z14;
+      [zoom >= 16] { water/line-width: @ditchdrain-width-z16; }
+      [zoom >= 18] { water/line-width: @ditchdrain-width-z18; }
+      water/line-color: @water-color;
+      [int_intermittent = 'yes'] {
+        water/line-dasharray: 4,3;
+        water/line-cap: butt;
+        water/line-join: round;
+      }
+
+      [int_tunnel = 'yes'][zoom >= 15]  {
+        water/line-dasharray: 4,2;
+        // PROBLEM HERE: join/cap not set, differs from river/canal
+        background/line-width: @ditchdrain-width-z14 + 1.5;
+        water/line-width: @ditchdrain-width-z14 + 1.5;
+        tunnelfill/line-width: @ditchdrain-width-z14 - 0.5;
+        tunnelfill/line-color: @water-tunnelfill-color;
+        [zoom >= 16] {
+          background/line-width: @ditchdrain-width-z16 + 1.5;
+          water/line-width: @ditchdrain-width-z16 + 1.5;
+          tunnelfill/line-width: @ditchdrain-width-z16 - 1.5;
+        }
+        [zoom >= 18] {
+          background/line-width: @ditchdrain-width-z18 + 1;
+          water/line-width: @ditchdrain-width-z18 + 1;
+          tunnelfill/line-width: @ditchdrain-width-z18 - 1;
+        }
       }
     }
   }

--- a/style/water.mss
+++ b/style/water.mss
@@ -1,9 +1,9 @@
 @water-text: #4d80b3;
 @glacier: #ddecec;
 @glacier-line: #9cf;
-//@water-tunnelfill-color: #f3f7f7;
 @water-tunnelfill-color: lighten(@water-color, 20%);
 @waterway-text-repeat-distance: 200;
+@waterway-text-spacing: 500;
 
 @river-width-z8:          0.7;
 @river-width-z9:          1.2;
@@ -365,10 +365,10 @@
 #water-lines-text {
   [lock = 'yes'][zoom >= 17] {
       text-name: "[lock_name]";
-      text-face-name: @oblique-fonts;
+      text-face-name: @standard-font;
       text-placement: line;
       text-fill: @water-text;
-      text-spacing: 400;
+      text-spacing: @waterway-text-spacing;
       text-size: 10;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
@@ -382,7 +382,7 @@
       text-fill: @water-text;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-spacing: 400;
+      text-spacing: @waterway-text-spacing;
       text-placement: line;
       text-repeat-distance: @waterway-text-repeat-distance;
       [zoom >= 14] { text-size: 12; }
@@ -391,12 +391,14 @@
     [waterway = 'canal'][zoom >= 13] {
       text-name: "[name]";
       text-size: 10;
-      text-face-name: @oblique-fonts;
+      text-face-name: @standard-font;
       text-fill: @water-text;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
       text-placement: line;
       text-repeat-distance: @waterway-text-repeat-distance;
+      text-spacing: @waterway-text-spacing;
+      [zoom >= 14] { text-size: 12; }
     }
 
     [waterway = 'stream'][zoom >= 15] {
@@ -406,7 +408,7 @@
       text-fill: @water-text;
       text-halo-radius: @standard-halo-radius;
       text-halo-fill: @standard-halo-fill;
-      text-spacing: 600;
+      text-spacing: @waterway-text-spacing;
       text-placement: line;
       text-vertical-alignment: middle;
       text-dy: 8;
@@ -415,14 +417,14 @@
 
     [waterway = 'drain'],
     [waterway = 'ditch'] {
-      [zoom >= 15] {
+      [zoom >= 16] {
         text-name: "[name]";
         text-size: 10;
-        text-face-name: @oblique-fonts;
+        text-face-name: @standard-font;
         text-fill: @water-text;
         text-halo-radius: @standard-halo-radius;
         text-halo-fill: @standard-halo-fill;
-        text-spacing: 600;
+        text-spacing: @waterway-text-spacing;
         text-placement: line;
         text-vertical-alignment: middle;
         text-dy: 8;

--- a/style/water.mss
+++ b/style/water.mss
@@ -1,7 +1,7 @@
 @water-text: #4d80b3;
 @glacier: #ddecec;
 @glacier-line: #9cf;
-@water-tunnelfill-color: lighten(@water-color, 15%);
+@water-tunnelfill-color: #f3f7f7;
 @waterway-text-repeat-distance: 200;
 @waterway-text-spacing: 500;
 

--- a/style/water.mss
+++ b/style/water.mss
@@ -1,7 +1,7 @@
 @water-text: #4d80b3;
 @glacier: #ddecec;
 @glacier-line: #9cf;
-@water-tunnelfill-color: lighten(@water-color, 20%);
+@water-tunnelfill-color: lighten(@water-color, 15%);
 @waterway-text-repeat-distance: 200;
 @waterway-text-spacing: 500;
 
@@ -90,31 +90,29 @@
     }
   }
 
-  [waterway = 'ditch'][zoom < 18],
-  [waterway = 'drain'][zoom < 18],
-  [waterway = 'stream'][zoom < 18] {
-    [int_tunnel = 'no'] {
-      [zoom = 13][int_intermittent != 'yes'],
-      [zoom >= 14] {
-        line-color: white;
-        line-join: round;
-        line-cap: round;
-        line-opacity: 0.85;
-        [zoom >= 16] { line-opacity: 0.75; }
-        [zoom >= 17] { line-opacity: 0.6; }
-        line-width: @stream-width-z13 + 0.6;
-        [zoom >= 14] { line-width: @stream-width-z14 + 0.6; }
-        [waterway = 'stream'] {
-           [zoom >= 15] { line-width: @stream-width-z15 + 0.6; }
-           [zoom >= 16] { line-width: @stream-width-z16 + 0.6; }
-           [zoom >= 17] { line-width: @stream-width-z17 + 0.6; }
-        }
-        [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 0.6; }
+  [waterway = 'ditch'],
+  [waterway = 'drain'],
+  [waterway = 'stream'] {
+    [int_tunnel = 'no'][zoom >= 13][zoom < 18] {
+      line-color: white;
+      line-join: round;
+      line-cap: round;
+      line-opacity: 0.7;      
+      [zoom >= 14] { line-opacity: 0.85; }
+      [zoom >= 16] { line-opacity: 0.75; }
+      [zoom >= 17] { line-opacity: 0.6; }
+      line-width: @stream-width-z13 + 0.6;
+      [zoom >= 14] { line-width: @stream-width-z14 + 0.6; }
+      [waterway = 'stream'] {
+         [zoom >= 15] { line-width: @stream-width-z15 + 0.6; }
+         [zoom >= 16] { line-width: @stream-width-z16 + 0.6; }
+         [zoom >= 17] { line-width: @stream-width-z17 + 0.6; }
+      }
+      [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 0.6; }
 
-        [int_intermittent = 'yes'] {
-          line-dasharray: 4,3;
-          line-cap: butt;
-        }
+      [int_intermittent = 'yes'] {
+        line-dasharray: 4,3;
+        line-cap: butt;
       }
     }
   }

--- a/style/water.mss
+++ b/style/water.mss
@@ -25,6 +25,8 @@
 @stream-width-z17:        3.5;
 @stream-width-z18:        4;
 
+@ditchdrain-width-z17:    3;
+
 @canal-scale-factor:      1.4;
 
 #water-areas {
@@ -72,31 +74,46 @@
   }
 }
 
-#water-lines::casing, 
-#waterway-bridges::casing {
-  // white glow used when water stroke width is less than 3 px and only at "mid zoom" (13 - 17)
+#water-lines::casing {
+  // white glow used when water stroke width is less than 3.5 px and only at "mid zoom" (13 - 17)
 
-  [waterway = 'canal'][int_tunnel = 'no'][zoom = 13][int_intermittent != 'yes'] {
+  [waterway = 'canal'][int_tunnel = 'no'][zoom >= 13][zoom < 15] {
     line-color: white;
-    line-opacity: 0.75;
-    line-width: (@stream-width-z13 * @canal-scale-factor) + 0.4;
+    line-join: round;
+    line-cap: round;
+    line-opacity: 0.85;
+    line-width: (@stream-width-z13 * @canal-scale-factor) + 0.6;
+    [zoom >= 14] { line-width: (@stream-width-z14 * @canal-scale-factor) + 0.6; }
+    [int_intermittent = 'yes'] {
+      line-dasharray: 4,3;
+      line-cap: butt;
+    }
   }
 
   [waterway = 'ditch'][zoom < 18],
   [waterway = 'drain'][zoom < 18],
-  [waterway = 'stream'][zoom < 16] {
+  [waterway = 'stream'][zoom < 18] {
     [int_tunnel = 'no'] {
       [zoom = 13][int_intermittent != 'yes'],
       [zoom >= 14] {
         line-color: white;
-        line-opacity: 0.75;
-        line-width: @stream-width-z13 + 0.5;
-        [zoom >= 14] { line-width: @stream-width-z14 + 0.4; }
-        [waterway = 'stream'][zoom >= 15] { line-width: @stream-width-z15 + 0.3; }
+        line-join: round;
+        line-cap: round;
+        line-opacity: 0.85;
+        [zoom >= 16] { line-opacity: 0.75; }
+        [zoom >= 17] { line-opacity: 0.6; }
+        line-width: @stream-width-z13 + 0.6;
+        [zoom >= 14] { line-width: @stream-width-z14 + 0.6; }
+        [waterway = 'stream'] {
+           [zoom >= 15] { line-width: @stream-width-z15 + 0.6; }
+           [zoom >= 16] { line-width: @stream-width-z16 + 0.6; }
+           [zoom >= 17] { line-width: @stream-width-z17 + 0.6; }
+        }
+        [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 0.6; }
+
         [int_intermittent = 'yes'] {
           line-dasharray: 4,3;
           line-cap: butt;
-          line-join: round;
         }
       }
     }
@@ -117,16 +134,11 @@
       [zoom >= 16] { background/line-width: @river-width-z16; }
       [zoom >= 17] { background/line-width: @river-width-z17; }
       [zoom >= 18] { background/line-width: @river-width-z18; }
-      background/line-cap: round;
       background/line-join: round;
-      // PROBLEM HERE. Initially round+round, then redefined as butt+miter
-      background/line-cap: butt;
-      background/line-join: miter;
     }
 
     [bridge = 'yes'][zoom >= 14] {
       bridgecasing/line-color: black;
-      bridgecasing/line-join: round;
       bridgecasing/line-width: @river-width-z14 + 1;
       [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
       [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
@@ -164,9 +176,9 @@
       // This provides the blue dashed casing of waterway tunnels
       water/line-dasharray: 4,2;
       water/line-cap: butt;
-      water/line-join: miter;
       tunnelfill/line-color: @water-tunnelfill-color;
       tunnelfill/line-width: @river-width-z12 - 1.5;
+      tunnelfill/line-join: round;
       [zoom >= 13] { tunnelfill/line-width: @river-width-z13 - 2; }
       [zoom >= 14] { tunnelfill/line-width: @river-width-z14 - 3; }
       [zoom >= 15] { tunnelfill/line-width: @river-width-z15 - 3; }
@@ -185,12 +197,11 @@
         // Background for dashed tunnel casings
         // The line widths are adjusted later - this just "books in" the background layer
         background/line-color: @water-tunnelfill-color;
-      // PROBLEM HERE: Join/cap style not specified?
+        background/line-join: round;
       }
 
       [bridge = 'yes'][zoom >= 14] {
         bridgecasing/line-color: black;
-        bridgecasing/line-join: round;
         bridgecasing/line-width: @stream-width-z14 + 1;
         [waterway = 'stream'] {
           [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
@@ -198,14 +209,18 @@
           [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
           [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
         }
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @stream-width-z14;
-        [waterway = 'stream'] {
-          [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
-          [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
-          [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
-          [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+        [waterway != 'stream'][zoom >= 17] { bridgecasing/line-width: @ditchdrain-width-z17 + 1; }
+        [int_intermittent = 'yes'] {
+          bridgefill/line-color: white;
+          bridgefill/line-join: round;
+          bridgefill/line-width: @stream-width-z14;
+          [waterway = 'stream'] {
+            [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
+            [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
+            [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
+            [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+          }
+          [waterway != 'stream'][zoom >= 17] { bridgefill/line-width: @ditchdrain-width-z17; }
         }
       }
 
@@ -218,21 +233,24 @@
         [zoom >= 17] { water/line-width: @stream-width-z17; }
         [zoom >= 18] { water/line-width: @stream-width-z18; }
       }
+      [waterway != 'stream'][zoom >= 17] { water/line-width: @ditchdrain-width-z17; }
       water/line-color: @water-color;
+      water/line-cap: round;
+      water/line-join: round;
 
       [int_intermittent = 'yes'] {
         water/line-dasharray: 4,3;
         water/line-cap: butt;
-        water/line-join: round;
       }
 
       [int_tunnel = 'yes'][zoom >= 14] {
         water/line-dasharray: 4,2;
-        // PROBLEM HERE: join/cap not set, differs from river/canal
+        water/line-cap: butt;
         background/line-width: @stream-width-z14 + 1;
         water/line-width: @stream-width-z14 + 1;
         tunnelfill/line-width: @stream-width-z14 - 0.5;
         tunnelfill/line-color: @water-tunnelfill-color;
+        tunnelfill/line-join: round;
         [waterway = 'stream'] {
           [zoom >= 15] { 
             background/line-width: @stream-width-z15 + 1.5;
@@ -255,6 +273,11 @@
             tunnelfill/line-width: @stream-width-z18 - 1.5;
           }
         }
+        [waterway != 'stream'][zoom >= 17] {
+          background/line-width: @ditchdrain-width-z17 + 1;
+          water/line-width: @ditchdrain-width-z17 + 1;
+          tunnelfill/line-width: @ditchdrain-width-z17 - 1.5;
+        }
       }
     }
   }
@@ -264,24 +287,25 @@
       // Background for dashed tunnel casings
       // The line widths are adjusted later - this just "books in" the background layer
       background/line-color: @water-tunnelfill-color;
-      // PROBLEM HERE: Join/cap style not specified?
+      background/line-join: round;
     }
 
     [bridge = 'yes'][zoom >= 14] {
       bridgecasing/line-color: black;
-      bridgecasing/line-join: round;
       bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
       [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
       [zoom >= 16] { bridgecasing/line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
       [zoom >= 17] { bridgecasing/line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
       [zoom >= 18] { bridgecasing/line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
-      bridgefill/line-color: white;
-      bridgefill/line-join: round;
-      bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
-      [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
-      [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
-      [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
-      [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+      [int_intermittent = 'yes'] {
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
+        [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
+        [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
+        [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
+        [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+      }
     }
 
     water/line-width: @stream-width-z12 * @canal-scale-factor;
@@ -292,20 +316,22 @@
     [zoom >= 17] { water/line-width: @stream-width-z17 * @canal-scale-factor; }
     [zoom >= 18] { water/line-width: @stream-width-z18 * @canal-scale-factor; }
     water/line-color: @water-color;
+    water/line-join: round;
+    water/line-cap: round;
 
     [int_intermittent = 'yes'] {
       water/line-dasharray: 4,3;
       water/line-cap: butt;
-      water/line-join: round;
     }
     
     [int_tunnel = 'yes'][zoom >= 13] {
       water/line-dasharray: 4,2;
-      // PROBLEM HERE: join/cap not set, differs from river/canal
+      water/line-cap: butt;
       background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
       water/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
       tunnelfill/line-width: (@stream-width-z13 * @canal-scale-factor) - 1;
       tunnelfill/line-color: @water-tunnelfill-color;
+      tunnelfill/line-join: round;
       [zoom >= 14] { 
         background/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
         water/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;


### PR DESCRIPTION
Fixes #3354 (narrower widths for canals)
Fixes #3497 (incorrect rendering for stream/ditch "bridges")
Fixes #3676 (inconsistent tunnel rendering for minor waterways)
Fixes #4481 (canal name does not repeat)
Fixes #4485 (over-strong halo on narrow waterways)

Partially addresses:
#4267 (distinguishing between natural and artificial waterways)

Has consequences for:
#3795 (differentiation of river >= canal > stream strongly limits consideration of `width` tagging) 

Does not address:
#2346 (distinction between stream vs. ditch/drain is largely left as-is)
#3468 (signature of intermittent waterways is unsatisfactory, but is not changed)
#3896 (using darker colour for waterways)
#4273 (there may be potential to narrow river widths, although this PR does tidy progression and this issue may have become less significant)
#4405 (waterway tunnels perceived as too glaring). 

**Changes proposed in this pull request**:

For a "good first issue", this PR has ended up as a rewrite of the `water-lines` layer:
- The rather strange linewidth progressions on `river` and `stream` have been replaced with the smoother progression of the alternative-colors (AC) style, with some small tweaks at low zoom.
- ~~(Version 1) Canals are rendered at 60% of the width of the rivers (#3354), except at Z12/Z13 where a scaling factor of 80% is used to maintain the distinction from stream.~~ (Version 2) Canals are rendered at 140% of stream width. The scaling, which could reasonably vary between 130 to 150%, is chosen to give similar river/canal differentials at Z14 as Version 1. The canal width at high zoom will be narrower than previously, which improve the appearance of narrow canals at high zoom. Wide canals, e.g. ship canals, are likely to be rendered as water areas at these rooms
- The width parameters for the new "tunnels on canals" have been adjusted to get a reasonably consistent appearance with stream tunnels (the tunnels for minor waterways are subtly different to tunnels on rivers in that they are wider than the width of the "normal" water line).
- Ordering has been added to the SQL query so that tunnels are rendered after "normal" waterways, avoiding some inconsistencies (see below).
- Errors in the drawing order for stream/ditch "bridges" have been fixed (#3497). Tunnels on minor waterways start consistently at Z14 (#3676), on the basis that these details e.g. culverts should be visible at higher zoom, but would be distracting at low zoom.
- Rendering of waterway tunnels has been slightly simplified. Currently this involves an initial stroke of `land-color` to provide the base for the dashed casing of the "tunnel walls", while the tunnel is then filled with an off-white (#f3f7f7). ~~These two very subtly different colours have been replaced with a common `water-tunnelfill-color` which is 15% lighter `water-color`.~~ The same off-white colour is now used for both.
- The overall length of the MSS has increased significantly, but overall the MSS is easier to follow and more consistent with the roads MSS. 
- A major change is the rendering of minor waterways (stream, ditch and drain) at Z12 and Z13. This significantly improves visibility of the topography at these zoom levels. 
- The behaviour of `ditch`/`drain` is otherwise maintained as present; the same rendering as stream up to and including Z14, but the width fixed at 2 px beyond this. Updated version bumps width to 3 px from Z17.
- ~~The prominence of the halo on small waterways has been reduced (inspired by AC style), e.g. 75% opacity and reduced width. The halo is only displayed at mid-zoom levels (from Z13 to Z17) AND when the waterway width is < 3 px. No halo is present at high zoom (Z18+) since the course of the waterway is clear at these zoom levels.~~ #4485. [Updated as below]
- The spacing of text labels has been unified (`waterway-text-spacing` of 500 px). Previously this was inconsistent: 400 px for rivers, 600 for stream/ditch/drain and missing for canal (#4481).
- Size progression for labels of river/canal has been unified (previously only river names had a size bump at Z14).
- ~~Names of ditch/drain are not shown until Z16 on the basis that these ought to be more minor features than streams, which are labelled from Z15 (creating a further distinction from stream).~~
- Upright text is used for the names artificial waterways (canal, ditch, drain). This is not intended as a solution for #4267, but as an added distinction which will help with mis-tagging to achieve specific widths. ~~Together with the Z12 starting zoom for streams, this should significantly discourage mistagging of streams as ditches/drains (#2346).~~
  
Test rendering with links to the example places:

**Effect of ordering**:

Before

[Test strip at Z17]
<img width="218" height="79" alt="image" src="https://github.com/user-attachments/assets/e5c9fda6-cfc0-485c-968b-ba62940d0dc5" />

After
<img width="231" height="67" alt="image" src="https://github.com/user-attachments/assets/2bf1f9c5-a8f2-432e-9250-f8fbf6c1a1f6" />
[Consistent round line cap from later rendering of tunnel. *Now changed to butt.*]

**Progression in test strip (version 1, see below for version 2)**
Test strip is river / canal / stream / ditch, alternating "normal" and "intermittent".
[Ignore the weird intermittent canal - this will be an artifact of the test setup]

Before
Z13:
<img width="90" height="98" alt="image" src="https://github.com/user-attachments/assets/f08f8dcf-f079-4c5f-aa25-64608b0957ad" />

Z14:
<img width="221" height="235" alt="image" src="https://github.com/user-attachments/assets/3bc2ba72-d7c2-4c3e-8c8c-6696aa1a9e0a" />
(Note incorrect waterway "bridges")

Z15:
<img width="412" height="457" alt="image" src="https://github.com/user-attachments/assets/d665d369-e1bd-4806-86d3-60c326cb7198" />

After:

Z13:
<img width="84" height="91" alt="image" src="https://github.com/user-attachments/assets/b3375935-2dd3-4ab3-9544-f2263a87dea0" />

Z14:
<img width="208" height="233" alt="image" src="https://github.com/user-attachments/assets/64de0fd8-676c-4776-adbc-e06ccb56098b" />

Z15:
<img width="415" height="461" alt="image" src="https://github.com/user-attachments/assets/b587e777-6678-4394-a685-2060fd19f7e4" />

**Effect of showing minor waterways at Z12/Z13 (unchanged in version 2)**

Every tiny stream has been mapped in the Lake District, which has the potential to overwhelm the map.

Before:
Z12:
<img width="234" height="209" alt="image" src="https://github.com/user-attachments/assets/c8780d33-1969-4788-a735-73bfa9a46401" />

Z13:
<img width="399" height="370" alt="image" src="https://github.com/user-attachments/assets/9628d902-977e-47b3-9146-5b92e49ad23c" />

After:
Z12:
<img width="211" height="212" alt="image" src="https://github.com/user-attachments/assets/7d76cf41-f4be-4c31-9b87-aeed97866360" />

Z13 (version 2):
<img width="394" height="370" alt="image" src="https://github.com/user-attachments/assets/378011be-4f3b-4468-befe-121ef8767e47" />

Z13 (version 3 - slightly stronger glow overall)
<img width="374" height="343" alt="image" src="https://github.com/user-attachments/assets/4571ba72-3c2e-4704-b320-3bdb88ca59ee" />

**More subtle halo (unchanged in version 2)**

Example [here](https://www.openstreetmap.org/note/3825676#map=14/54.31198) at Z14:

Before:
<img width="240" height="238" alt="image" src="https://github.com/user-attachments/assets/790dc2eb-099d-43f9-90d6-014a4a685ebe" />
(Glowing worms which suddenly appear at this zoom)

After (version 2):
<img width="233" height="220" alt="image" src="https://github.com/user-attachments/assets/27a562f5-d7b6-4b97-81e7-e62797ae56dd" />

Version 3 (slightly stronger glow)
<img width="246" height="236" alt="image" src="https://github.com/user-attachments/assets/cfe6dd75-28be-4c16-9b59-42217824aae4" />

As would be expected, the revised glow is closer to the original, but the overall "glowing worms" effect is softened by having minor waterways appear earlier (from Z12) and with a transitional glow at Z13.

**Queries**
- ~~There are a couple of places noted "Problem here" where the line join/caps were not specified / inconsistent between stream vs. river. I wasn't sure that the "right answer" was (not that the effects would be visible).~~
- It seems to me that the waterway-bridges layer could be relatively simply combined with the road bridges query (as a separate PR). This would address #890.

