### PR TITLE
Fewer motorway junctions

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1471,7 +1471,7 @@ Layer:
           ORDER BY way_pixels DESC NULLS LAST
         ) AS junctions
     properties:
-      minzoom: 11
+      minzoom: 12
   - id: bridge-text
     geometry: point
     <<: *extents

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -3384,7 +3384,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #junctions {
   [highway = 'motorway_junction'] {
-    [zoom >= 11] {
+    [zoom >= 13] {
       text-name: "[ref]";
       text-size: 10;
       text-fill: @junction-text-color;
@@ -3394,7 +3394,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
       text-wrap-character: ";";
       text-wrap-width: 2; // effectively break after every wrap character
       text-line-spacing: -1.5; // -0.15 em
-      [zoom >= 13] {
+      [zoom >= 14] {
         ["name" != null]["ref" = null] {
           text-name: "[name]";
         }

--- a/style/roads.mss
+++ b/style/roads.mss
@@ -3384,7 +3384,7 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
 
 #junctions {
   [highway = 'motorway_junction'] {
-    [zoom >= 13] {
+    [zoom >= 12] {
       text-name: "[ref]";
       text-size: 10;
       text-fill: @junction-text-color;


### PR DESCRIPTION
Fixes #5203

Changes proposed in this pull request:
- Change `motorway_junction` rendering of the `ref` from `zoom >= 11` to `zoom >= 13`
- Change `motorway_junction` rendering of the `name` from `zoom >= 13` to `zoom >= 14`

For more test rendering of the ref change, see #5203. I have copied the motivating examples here, click to expand:

<details>
<summary><b>Motivating examples of pushing the ref from Z11 to Z13</b></summary>

https://www.openstreetmap.org/#map=11/37.5898/-122.2140
<img width="1668" height="952" alt="Screenshot 2026-04-04 at 12 01 29 AM" src="https://github.com/user-attachments/assets/05c27544-dedf-45b6-867d-25edc0b0652f" />

https://www.openstreetmap.org/#map=12/37.7004/-122.3712
<img width="1668" height="952" alt="Screenshot 2026-04-04 at 12 02 09 AM" src="https://github.com/user-attachments/assets/ee2fb093-7147-4455-9c0e-7acb88abf411" />

https://www.openstreetmap.org/#map=11/34.0054/-118.2060
<img width="1668" height="952" alt="Screenshot 2026-04-04 at 12 03 10 AM" src="https://github.com/user-attachments/assets/bd24858b-0a84-4bbc-8406-cd29806be95f" />

https://www.openstreetmap.org/#map=11/32.8150/-117.0271
<img width="1668" height="952" alt="Screenshot 2026-04-04 at 12 03 24 AM" src="https://github.com/user-attachments/assets/7ce41fa7-4812-44ba-a202-d9c8a824f3aa" />
</details>

Showing the names of highway exits at Z14 matches how transit stop names are shown at Z14. These following comparisons were copied from the last time this rendering was adjusted in #3482

<details>
<summary><b>Examples of pushing the name from Z13 to Z14 (suggested by imagico)</b></summary>

https://www.openstreetmap.org/#map=13/55.5882/13.0524
<img width="1668" height="952" alt="Screenshot 2026-04-04 at 12 20 31 PM" src="https://github.com/user-attachments/assets/d03ac32a-1275-41e1-8b49-fd3664e840ea" />

https://www.openstreetmap.org/#map=13/52.3657/4.9069
![amsterdam13](https://github.com/user-attachments/assets/2c8c6dd6-16c4-46b7-b687-3dafaac5b1ec)

</details>

I think this a good change because it makes the map less cluttered while still showing the exit numbers and names at higher zoom levels. I also [posted the comparison to /r/openstreetmap](https://old.reddit.com/r/openstreetmap/comments/1sc2kno/thoughts_on_highway_exit_numbers_being_rendered/) where it is at 8 points 100% upvoted. Issue #5203 has four thumbs up reacts (probably because of the Reddit post to be fair), and mostly positive responses. 
