### PR TITLE
Clean up golf=pin rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1615,7 +1615,7 @@ Layer:
                                    THEN amenity END,
                 'tourism_' || CASE WHEN tourism IN ('viewpoint', 'attraction') THEN tourism END,
                 'place_' || CASE WHEN place IN ('locality') AND way_area IS NULL THEN place END,
-                'golf_' || CASE WHEN tags->'golf' IN ('pin') THEN tags->'golf' END
+                'golf_' || CASE WHEN tags->'golf' IN ('pin') AND way_area IS NULL THEN tags->'golf' END
               ) AS feature,
               CASE WHEN access IN ('private', 'no', 'customers', 'permit', 'delivery') THEN 'restricted' ELSE 'yes' END AS int_access,
               CASE

--- a/style/golf.mss
+++ b/style/golf.mss
@@ -57,17 +57,3 @@
     marker-clip: false;
   }
 }
-
-#text-point[zoom >= 17] {
-  [feature = 'golf_pin'][ref != ''] {
-    text-name: "[ref]";
-    text-size: @standard-font-size;
-    text-fill: @golf-color;
-    text-face-name: @book-fonts;
-    text-halo-radius: @standard-halo-radius;
-    text-halo-fill: @standard-halo-fill;
-    text-horizontal-alignment: middle;
-    text-dx: 1;
-    text-dy: 6;
-  }
-}

--- a/style/golf.mss
+++ b/style/golf.mss
@@ -55,5 +55,6 @@
     marker-file: url('symbols/leisure/golf_pin.svg');
     marker-fill: @golf-color;
     marker-clip: false;
+	marker-transform: translate(0,-5);
   }
 }

--- a/symbols/leisure/golf_pin.svg
+++ b/symbols/leisure/golf_pin.svg
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="9" height="23" version="1.1" viewBox="0 0 9 23">
-  <rect id="mapnik_workaround" width="9" height="23" fill="none"/>
-  <path d="m4,1 v9.77344 a2.10716,0.75 0 1 0 1,0 v-6.77344 l4,-1.5 -4,-1.5 z"/>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+	 width="9px" height="13px" viewBox="0 0 9 13">
+<rect id="mapnik_workaround" y="0" fill="none" width="9" height="13"/>
+<path d="M4,1v9.8c-1.1,0.1-1.8,0.5-1.5,0.9s1.4,0.6,2.5,0.6c1.1-0.1,1.8-0.5,1.5-0.9c-0.2-0.3-0.8-0.5-1.5-0.6V4l4-1.5L5,1L4,1z"/>
 </svg>


### PR DESCRIPTION
Fixes #4862
Fixes #5219

Changes proposed in this pull request:
- `golf=pin` is only rendered for nodes.

Change is trivial, and this is just a quick check confirmation that node rendering is unchanged:

Before

<img width="259" height="245" alt="image" src="https://github.com/user-attachments/assets/bef8d0c7-8685-468b-84b9-4b827e7fd91c" />

After

<img width="207" height="220" alt="image" src="https://github.com/user-attachments/assets/c7f949ec-7c81-4c9c-9742-952aae217dd5" />

[Annoying how the OSM website is showing tile boundaries for raster tiles]