### PR TITLE
Shields above junction refs

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1440,38 +1440,6 @@ Layer:
     properties:
       cache-features: true
       minzoom: 12
-  - id: junctions
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            highway,
-            junction,
-            ref,
-            name,
-            NULL AS way_pixels
-          FROM planet_osm_point
-          WHERE way && !bbox!
-            AND (highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes')
-        UNION ALL
-          SELECT
-            ST_PointOnSurface(way) AS way,
-            highway,
-            junction,
-            ref,
-            name,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
-          FROM planet_osm_polygon
-          WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
-            AND junction = 'yes'
-            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
-          ORDER BY way_pixels DESC NULLS LAST
-        ) AS junctions
-    properties:
-      minzoom: 12
   - id: bridge-text
     geometry: point
     <<: *extents
@@ -1877,6 +1845,38 @@ Layer:
         ) AS roads_text_ref
     properties:
       minzoom: 13
+  - id: junctions
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            highway,
+            junction,
+            ref,
+            name,
+            NULL AS way_pixels
+          FROM planet_osm_point
+          WHERE way && !bbox!
+            AND (highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes')
+        UNION ALL
+          SELECT
+            ST_PointOnSurface(way) AS way,
+            highway,
+            junction,
+            ref,
+            name,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+          FROM planet_osm_polygon
+          WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
+            AND junction = 'yes'
+            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
+          ORDER BY way_pixels DESC NULLS LAST
+        ) AS junctions
+    properties:
+      minzoom: 12
   - id: roads-area-text-name
     geometry: point
     <<: *extents


### PR DESCRIPTION
Fixes #4748 

Changes proposed in this pull request:
- Reorder highway shields versus junction refs

<details>
<summary><b>
Click to expand test rendering examples, same locations as my last PR (Amsterdam, Malmo, Warsaw, San Diego, Los Angeles, San Francisco)
</b></summary>

`#12/37.7019/-122.3740`
<img width="3336" height="1910" alt="sf png" src="https://github.com/user-attachments/assets/4c39324f-bd2e-404a-bb90-775135f180ed" />


`#12/33.9861/-118.1532`
<img width="3336" height="1910" alt="la png" src="https://github.com/user-attachments/assets/01965ceb-7771-434d-beb4-85d1548ef8b7" />

`#12/32.7845/-117.0583`
<img width="3336" height="1910" alt="sd png" src="https://github.com/user-attachments/assets/a432cf98-69a6-4e46-9689-d2499c0506f4" />

`#12/52.2321/20.9537`
<img width="3336" height="1910" alt="warsaw png" src="https://github.com/user-attachments/assets/0f664ff0-ecd1-4fe0-ae9e-d5dcc28783b8" />

`#12/55.5841/12.9635`
<img width="3336" height="1910" alt="malmo png" src="https://github.com/user-attachments/assets/697bd5bf-0be0-4002-a2ad-e232dc349291" />

`#12/52.3686/4.9116`
<img width="3336" height="1910" alt="amsterdam png" src="https://github.com/user-attachments/assets/3da85190-b38c-4728-90c7-046552f356bb" />


</details>

Now you shall probably wonder: this PR moves junction refs below not just shields but quite a few other elements in order to get to shields. Are there unintended side effects of this? In particular, junction refs would now be rendered after: `bridge-text`, `county-names`, `amenity-points`, `amenity-line`, `power-towers`, all not specifically intended, and then finally after `roads-text-ref-low-zoom` and `roads-text-ref`, as intended.

To see this for myself, I swapped `junctions` to be immediately before `roads-text-ref-low-zoom` and `roads-text-ref`, but still after the other five. We should expect virtually no difference in these comparisons, and indeed that seems to be the case in my examples, but I am really not confident here so please let me know!

<details>
<summary><b>
Click to expand test rendering examples, same locations, but with junctions immediately above shields (rather than immediately below)
</b></summary>

`#12/37.7019/-122.3740`
<img width="3336" height="1910" alt="sf png" src="https://github.com/user-attachments/assets/18c98949-fcf0-4985-9e0f-89158b51730c" />

`#12/33.9861/-118.1532`
<img width="3336" height="1910" alt="la png" src="https://github.com/user-attachments/assets/08113a8f-f0d7-4cd2-b436-f12c3ca3069a" />

`#12/32.7845/-117.0583`
<img width="3336" height="1910" alt="sd png" src="https://github.com/user-attachments/assets/11975982-68f4-42a2-b8e6-415367ce05b3" />

`#12/52.2321/20.9537`
<img width="3336" height="1910" alt="warsaw png" src="https://github.com/user-attachments/assets/e2ee206c-6f8e-40eb-8a25-8fb4c733c6b9" />

`#12/55.5841/12.9635`
<img width="3336" height="1910" alt="malmo png" src="https://github.com/user-attachments/assets/ff0a01c3-081f-4821-bf2e-b37bb208f82b" />

`#12/52.3686/4.9116`
<img width="3336" height="1910" alt="amsterdam png" src="https://github.com/user-attachments/assets/5d61af7d-5a59-4bb5-98db-afd3e1cbf316" />

</details>