### PR TITLE
Update colormath dependency to colormath2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,9 +120,9 @@ To display *any* map, a database containing OpenStreetMap data and some utilitie
 Some colours, SVGs and other files are generated with helper scripts. Not all users will need these dependencies.
 
 * [Python](https://www.python.org/downloads/)
-* [`generate_road_colours.py`](./scripts/generate_road_colours.py) and [`generate_unpaved_patterns.py`](./scripts/generate_unpaved_patterns.py) depend on [Color Math](https://github.com/gtaylor/python-colormath) and [`numpy`](https://numpy.org/). To install these, run:
+* [`generate_road_colours.py`](./scripts/generate_road_colours.py) and [`generate_unpaved_patterns.py`](./scripts/generate_unpaved_patterns.py) depend on [Color Math2](https://github.com/bkmgit/python-colormath2) and [`numpy`](https://numpy.org/). To install these, run:
     ```bash
-    python3 -m pip install --break-system-packages --user colormath numpy
+    python3 -m pip install --break-system-packages --user colormath2 numpy
     ```
 
 ### For deployment

--- a/scripts/generate_road_colours.py
+++ b/scripts/generate_road_colours.py
@@ -2,9 +2,9 @@
 
 # Generates a set of highway colors to be stored in road-colors-generated.mss.
 
-from colormath.color_conversions import convert_color
-from colormath.color_objects import LabColor, LCHabColor, sRGBColor
-from colormath.color_diff import delta_e_cie2000
+from colormath2.color_conversions import convert_color
+from colormath2.color_objects import LabColor, LCHabColor, sRGBColor
+from colormath2.color_diff import delta_e_cie2000
 import argparse
 import sys
 import yaml

--- a/scripts/generate_unpaved_patterns.py
+++ b/scripts/generate_unpaved_patterns.py
@@ -21,8 +21,8 @@
 # You can customize this script by changing the first variables of in the main()
 # function (color_names, file_names, darken, brighten_darken_ratio).
 
-from colormath.color_objects import LabColor, sRGBColor
-from colormath.color_conversions import convert_color
+from colormath2.color_objects import LabColor, sRGBColor
+from colormath2.color_conversions import convert_color
 
 # def get_color_value_by_name(variable_name, file_names):
 #


### PR DESCRIPTION
Fixes #4922

Changes proposed in this pull request:
- Update colormath dependency to colormath2, a drop-in replacement that supports newer Numpy versions
