### PR TITLE
Remove guideway oneway offset

### DIFF
--- a/style/roads.mss
+++ b/style/roads.mss
@@ -309,7 +309,7 @@
 @residential-oneway-arrow-color:  darken(@residential-casing, 40%);
 @living-street-oneway-arrow-color: darken(@residential-casing, 30%);
 @pedestrian-oneway-arrow-color:   darken(@pedestrian-casing, 25%);
-@bus-guideway-oneway-arrow-color: darken(@bus-guideway-fill, 25%);
+@bus-guideway-oneway-arrow-color: darken(@bus-guideway-fill, 30%);
 @raceway-oneway-arrow-color:      darken(@raceway-fill, 50%);
 @footway-oneway-arrow-color:      darken(@footway-fill, 35%);
 @steps-oneway-arrow-color:        darken(@steps-fill, 35%);
@@ -4212,7 +4212,6 @@ tertiary is rendered from z10 and is not included in osm_planet_roads. */
         }
         [highway = 'bus_guideway'] {
           marker-fill: @bus-guideway-oneway-arrow-color;
-          marker-offset: 7;
         }
         [highway = 'living_street'] {
           marker-fill: @living-street-oneway-arrow-color;


### PR DESCRIPTION
Fixes #5208

Changes proposed in this pull request:
- Remove offset of oneway arrow for bus guideways. Slightly darker colour to improve contrast.

This fixes the problem where oneway arrow on neighbouring guideways became muddled. Overlaying on the way is not fantastic, but it's agreed that this rendering needs a re-design, and any more road-like design will have the oneway arrows on the way rather than offset.

Test rendering with links to the example places:

Before

<img width="426" height="94" alt="image" src="https://github.com/user-attachments/assets/9895c2d6-61e5-4577-9c60-e398b32fd339" />

[Left: `oneway=yes`, Right: `oneway=-1`]

After

<img width="434" height="100" alt="image" src="https://github.com/user-attachments/assets/9d4b875a-cc0b-4744-99e8-82f6cb4ff9bf" />

