### PR TITLE
Deduplicate junction refs

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -78,7 +78,7 @@ $$;
    Adapted from https://github.com/mapbox/postgis-vt-util/blob/master/src/Z.sql
    Intended usage:
      WHERE Z(!scale_denominator!) < 17 */
-CREATE OR REPLACE FUNCTION Z(scale_denominator double precision)
+CREATE OR REPLACE FUNCTION Z(scale_denominator numeric)
   RETURNS integer
   LANGUAGE SQL
   IMMUTABLE PARALLEL SAFE
@@ -87,6 +87,6 @@ AS $$
 SELECT
 	CASE
 		WHEN scale_denominator <= 0 OR scale_denominator > 600000000 THEN NULL
-		ELSE CAST(ROUND(LOG(2, (559082264.028 / scale_denominator)::numeric)) AS integer)
+		ELSE CAST(ROUND(LOG(2, 559082264.028 / scale_denominator)) AS integer)
 	END
 $$;

--- a/functions.sql
+++ b/functions.sql
@@ -73,3 +73,20 @@ SELECT
 		ELSE carto_int_access("access", TRUE)
 	END
 $$;
+
+/* Convert a Mapnik scale_denominator to an integer Web Mercator zoom level.
+   Adapted from https://github.com/mapbox/postgis-vt-util/blob/master/src/Z.sql
+   Intended usage:
+     WHERE Z(!scale_denominator!) < 17 */
+CREATE OR REPLACE FUNCTION Z(scale_denominator double precision)
+  RETURNS integer
+  LANGUAGE SQL
+  IMMUTABLE PARALLEL SAFE
+  RETURNS NULL ON NULL INPUT
+AS $$
+SELECT
+	CASE
+		WHEN scale_denominator <= 0 OR scale_denominator > 600000000 THEN NULL
+		ELSE CAST(ROUND(LOG(2, (559082264.028 / scale_denominator)::numeric)) AS integer)
+	END
+$$;

--- a/project.mml
+++ b/project.mml
@@ -1495,7 +1495,7 @@ Layer:
           -- nodes with no ref): cluster_min_ref is NULL and every row matches,
           -- so the centroid averages all node positions.
           SELECT
-              ST_Centroid(ST_Collect(way) FILTER (WHERE COALESCE(ref, '') = cluster_min_ref)) AS way,
+              ST_Centroid(ST_Collect(way) FILTER (WHERE ref IS NOT DISTINCT FROM cluster_min_ref)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
@@ -1503,7 +1503,7 @@ Layer:
               NULL::float AS way_pixels
             FROM (
               SELECT *,
-                  COALESCE(MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid), '') AS cluster_min_ref
+                  MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid) AS cluster_min_ref
                 FROM mj_clustered
                 WHERE cid IS NOT NULL
             ) c

--- a/project.mml
+++ b/project.mml
@@ -1455,7 +1455,7 @@ Layer:
             -- don't merge; at lower zooms it is NULL and only stripped_ref
             -- decides clustering.
             SELECT way, highway, junction, ref, name,
-                regexp_replace(ref, '^([0-9]+)[ -]?[A-Za-z]$', '\1') AS stripped_ref,
+                regexp_replace(ref, '^([0-9]+)[A-Za-z]$', '\1') AS stripped_ref,
                 CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') END AS visible_name
               FROM planet_osm_point
               WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
@@ -1495,7 +1495,7 @@ Layer:
           -- nodes with no ref): cluster_min_ref is NULL and every row matches,
           -- so the centroid averages all node positions.
           SELECT
-              ST_Centroid(ST_Collect(way) FILTER (WHERE ref IS NOT DISTINCT FROM cluster_min_ref)) AS way,
+              ST_Centroid(ST_Collect(way) FILTER (WHERE COALESCE(ref, '') = cluster_min_ref)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
@@ -1503,7 +1503,7 @@ Layer:
               NULL::float AS way_pixels
             FROM (
               SELECT *,
-                  MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid) AS cluster_min_ref
+                  COALESCE(MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid), '') AS cluster_min_ref
                 FROM mj_clustered
                 WHERE cid IS NOT NULL
             ) c

--- a/project.mml
+++ b/project.mml
@@ -1446,16 +1446,71 @@ Layer:
     Datasource:
       <<: *osm2pgsql
       table: |-
-        (SELECT
+        (WITH mj AS (
+            -- Take motorway_junction points in the bbox, but with ref stripped of letters
+            -- (e.g. "1A" -> "1", "Exit 14B" -> "14") so siblings can be matched.
+            SELECT
+                way,
+                highway,
+                junction,
+                ref,
+                name,
+                NULLIF(TRIM(regexp_replace(COALESCE(ref, ''), '[A-Za-z]', '', 'g')), '') AS stripped_ref
+              FROM planet_osm_point
+              WHERE way && !bbox!
+                AND highway = 'motorway_junction'
+          ),
+          mj_clustered AS (
+            -- Combine any pair of motorway_junctions of sharing the same stripped_ref within 40 px.
+            -- cid is the cluster id, or NULL if the point was alone.
+            SELECT
+                way, highway, junction, ref, name, stripped_ref,
+                CASE WHEN stripped_ref IS NOT NULL THEN
+                  ST_ClusterDBSCAN(
+                    way,
+                    eps := 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
+                    minpoints := 2 -- at least two points are needed to make a cluster
+                  ) OVER (PARTITION BY stripped_ref)
+                END AS cid
+              FROM mj
+          ),
+          mj_deduped AS (
+            -- For clustered points, move each row to the cluster's center and
+            -- relabel it with the stripped ref; standalone points are left unchanged.
+            SELECT
+                CASE WHEN cid IS NOT NULL
+                  THEN ST_Centroid(ST_Collect(way) OVER (PARTITION BY stripped_ref, cid))
+                  ELSE way
+                END AS way,
+                highway,
+                junction,
+                CASE WHEN cid IS NOT NULL THEN stripped_ref ELSE ref END AS ref,
+                name,
+                cid,
+                stripped_ref,
+                ROW_NUMBER() OVER (PARTITION BY stripped_ref, cid ORDER BY name NULLS LAST) AS rn
+              FROM mj_clustered
+          )
+          SELECT
+              way,
+              highway,
+              junction,
+              ref,
+              name,
+              NULL::float AS way_pixels
+            FROM mj_deduped
+            WHERE cid IS NULL OR rn = 1
+        UNION ALL
+          SELECT
             way,
             highway,
             junction,
             ref,
             name,
-            NULL AS way_pixels
+            NULL::float AS way_pixels
           FROM planet_osm_point
           WHERE way && !bbox!
-            AND (highway = 'motorway_junction' OR highway = 'traffic_signals' OR junction = 'yes')
+            AND (highway = 'traffic_signals' OR junction = 'yes')
         UNION ALL
           SELECT
             ST_PointOnSurface(way) AS way,

--- a/project.mml
+++ b/project.mml
@@ -1449,43 +1449,29 @@ Layer:
         (WITH mj AS (
             -- All motorway_junction points in the bbox (expanded by the clustering
             -- eps so siblings just outside the tile still pull in, avoiding tile
-            -- boundary artifacts). grouping_key controls clustering: the trailing
-            -- letter is stripped from the ref so "1A"/"1B" pair with each other
-            -- and with "1"; from z14 onward the name is prepended so junctions
-            -- with different names don't merge. grouping_key is NULL (and so
-            -- ineligible for clustering) only when both ref and name are NULL or ''
-
-            -- Example: name="Junction", ref="123-A"
-            -- Z>=14 grouping_key = "Junction;123", location_key = "Junction;123-A"
-            -- Z<14 grouping_key = "123", location_key = "123-A"
-
-            SELECT *,
-                NULLIF(
-                  CONCAT(
-                    visible_name,
-                    regexp_replace(ref, '^([0-9]+)[ -]?[A-Za-z]$', '\1')
-                  ),
-                  ''
-                ) AS grouping_key,
-                CONCAT(visible_name, ref) AS location_key
-              FROM (
-                SELECT way, highway, junction, ref, name,
-                    CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') || ';' ELSE '' END AS visible_name
-                  FROM planet_osm_point
-                  WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
-                    AND highway = 'motorway_junction'
-              ) raw
+            -- boundary artifacts). stripped_ref drops the trailing letter so
+            -- "1A"/"1B" pair with each other and with "1". visible_name carries
+            -- the node's name from z14 onward so junctions with different names
+            -- don't merge; at lower zooms it is NULL and only stripped_ref
+            -- decides clustering.
+            SELECT way, highway, junction, ref, name,
+                regexp_replace(ref, '^([0-9]+)[ -]?[A-Za-z]$', '\1') AS stripped_ref,
+                CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') END AS visible_name
+              FROM planet_osm_point
+              WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
+                AND highway = 'motorway_junction'
           ),
           mj_clustered AS (
-            -- Combine any pair of motorway_junctions sharing the same grouping_key within 40 px.
-            -- cid is the cluster id, or NULL if the point was alone.
+            -- Combine any pair of motorway_junctions sharing the same
+            -- (stripped_ref, visible_name) within 40 px. cid is the cluster id,
+            -- or NULL if the point was alone.
             SELECT *,
-                CASE WHEN grouping_key IS NOT NULL AND Z(!scale_denominator!) < 17
+                CASE WHEN Z(!scale_denominator!) < 17
                   THEN ST_ClusterDBSCAN(
                     way,
                     eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
                     minpoints => 2 -- at least two points are needed to make a cluster
-                  ) OVER (PARTITION BY grouping_key)
+                  ) OVER (PARTITION BY stripped_ref, visible_name)
                 END AS cid
               FROM mj
           )
@@ -1501,15 +1487,15 @@ Layer:
             WHERE cid IS NULL
         UNION ALL
           -- Clustered motorway_junctions: collapse each cluster to a single label
-          -- placed at the location of the node with the smallest location_key
-          -- in the cluster -- so e.g. a "188" label sits on junction 188 itself
-          -- rather than between 188, 188A and 188B. When no plain-ref node is
-          -- present (e.g. {188A, 188B}) the alphabetically-smallest ref wins.
-          -- location_key uses CONCAT(ref, name) because some junctions only have
-          -- a name, and the ref is NULL. When multiple nodes have the same
-          -- location_key (e.g. {188, 188}), place the ref at their average/centroid.
+          -- placed at the location of the node with the smallest ref in the
+          -- cluster -- so e.g. a "188" label sits on junction 188 itself rather
+          -- than between 188, 188A and 188B. When no plain-ref node is present
+          -- (e.g. {188A, 188B}) the alphabetically-smallest ref wins. IS NOT
+          -- DISTINCT FROM handles the all-NULL-ref case (a cluster of named
+          -- nodes with no ref): cluster_min_ref is NULL and every row matches,
+          -- so the centroid averages all node positions.
           SELECT
-              ST_Centroid(ST_Collect(way) FILTER (WHERE location_key = cluster_min_location_key)) AS way,
+              ST_Centroid(ST_Collect(way) FILTER (WHERE ref IS NOT DISTINCT FROM cluster_min_ref)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
@@ -1517,11 +1503,11 @@ Layer:
               NULL::float AS way_pixels
             FROM (
               SELECT *,
-                  MIN(location_key) OVER (PARTITION BY grouping_key, cid) AS cluster_min_location_key
+                  MIN(ref) OVER (PARTITION BY stripped_ref, visible_name, cid) AS cluster_min_ref
                 FROM mj_clustered
                 WHERE cid IS NOT NULL
             ) c
-            GROUP BY grouping_key, cid
+            GROUP BY stripped_ref, visible_name, cid
         UNION ALL
           SELECT
             way,

--- a/project.mml
+++ b/project.mml
@@ -1449,33 +1449,43 @@ Layer:
         (WITH mj AS (
             -- All motorway_junction points in the bbox (expanded by the clustering
             -- eps so siblings just outside the tile still pull in, avoiding tile
-            -- boundary artifacts). stripped_ref strips a trailing letter when the
-            -- ref is strictly digits-followed-by-letter (e.g. "1A" -> "1",
-            -- "14B" -> "14"); any other ref passes through unchanged so two
-            -- motorway_junctions with the same ref also cluster. Empty or NULL
-            -- refs leave stripped_ref NULL and are not eligible for clustering.
-            SELECT
-                way,
-                highway,
-                junction,
-                ref,
-                name,
-                NULLIF(regexp_replace(ref, '^([0-9]+)[A-Za-z]$', '\1'), '') AS stripped_ref
-              FROM planet_osm_point
-              WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
-                AND highway = 'motorway_junction'
+            -- boundary artifacts). grouping_key controls clustering: the trailing
+            -- letter is stripped from the ref so "1A"/"1B" pair with each other
+            -- and with "1"; from z14 onward the name is prepended so junctions
+            -- with different names don't merge. grouping_key is NULL (and so
+            -- ineligible for clustering) only when both ref and name are NULL or ''
+
+            -- Example: name="Junction", ref="123-A"
+            -- Z>=14 grouping_key = "Junction;123", location_key = "Junction;123-A"
+            -- Z<14 grouping_key = "123", location_key = "123-A"
+
+            SELECT *,
+                NULLIF(
+                  CONCAT(
+                    visible_name,
+                    regexp_replace(ref, '^([0-9]+)[ -]?[A-Za-z]$', '\1')
+                  ),
+                  ''
+                ) AS grouping_key,
+                CONCAT(visible_name, ref) AS location_key
+              FROM (
+                SELECT *,
+                    CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') || ';' ELSE '' END AS visible_name
+                  FROM planet_osm_point
+                  WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
+                    AND highway = 'motorway_junction'
+              ) raw
           ),
           mj_clustered AS (
-            -- Combine any pair of motorway_junctions sharing the same stripped_ref within 40 px.
+            -- Combine any pair of motorway_junctions sharing the same grouping_key within 40 px.
             -- cid is the cluster id, or NULL if the point was alone.
-            SELECT
-                way, highway, junction, ref, name, stripped_ref,
-                CASE WHEN stripped_ref IS NOT NULL AND Z(!scale_denominator!) < 17
+            SELECT *,
+                CASE WHEN grouping_key IS NOT NULL AND Z(!scale_denominator!) < 17
                   THEN ST_ClusterDBSCAN(
                     way,
                     eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
                     minpoints => 2 -- at least two points are needed to make a cluster
-                  ) OVER (PARTITION BY stripped_ref)
+                  ) OVER (PARTITION BY grouping_key)
                 END AS cid
               FROM mj
           )
@@ -1491,24 +1501,27 @@ Layer:
             WHERE cid IS NULL
         UNION ALL
           -- Clustered motorway_junctions: collapse each cluster to a single label
-          -- placed at the location of the node whose ref equals MIN(ref) in the
-          -- cluster -- so e.g. a "188" label sits on junction 188 itself rather
-          -- than between 188, 188A and 188B. When no plain stripped_ref node is
-          -- present in the cluster (e.g. {188A, 188B}) MIN(ref) falls back to
-          -- the alphabetically-smallest ref and the label is placed there.
+          -- placed at the location of the node with the smallest location_key
+          -- in the cluster -- so e.g. a "188" label sits on junction 188 itself
+          -- rather than between 188, 188A and 188B. When no plain-ref node is
+          -- present (e.g. {188A, 188B}) the alphabetically-smallest ref wins.
+          -- location_key uses CONCAT(ref, name) because some junctions only have
+          -- a name, and the ref is NULL. When multiple nodes have the same
+          -- location_key (e.g. {188, 188}), place the ref at their average/centroid.
           SELECT
-              ST_Centroid(ST_Collect(way) FILTER (WHERE ref = cluster_min_ref)) AS way,
+              ST_Centroid(ST_Collect(way) FILTER (WHERE location_key = cluster_min_location_key)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
               MIN(name) AS name,
               NULL::float AS way_pixels
             FROM (
-              SELECT *, MIN(ref) OVER (PARTITION BY stripped_ref, cid) AS cluster_min_ref
+              SELECT *,
+                  MIN(location_key) OVER (PARTITION BY grouping_key, cid) AS cluster_min_location_key
                 FROM mj_clustered
+                WHERE cid IS NOT NULL
             ) c
-            WHERE cid IS NOT NULL
-            GROUP BY stripped_ref, cid
+            GROUP BY grouping_key, cid
         UNION ALL
           SELECT
             way,

--- a/project.mml
+++ b/project.mml
@@ -1470,8 +1470,8 @@ Layer:
             -- cid is the cluster id, or NULL if the point was alone.
             SELECT
                 way, highway, junction, ref, name, stripped_ref,
-                CASE WHEN stripped_ref IS NOT NULL THEN
-                  ST_ClusterDBSCAN(
+                CASE WHEN stripped_ref IS NOT NULL AND !scale_denominator! > 10000 -- zoom<16
+                  THEN ST_ClusterDBSCAN(
                     way,
                     eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
                     minpoints => 2 -- at least two points are needed to make a cluster

--- a/project.mml
+++ b/project.mml
@@ -1469,7 +1469,7 @@ Layer:
                 ) AS grouping_key,
                 CONCAT(visible_name, ref) AS location_key
               FROM (
-                SELECT *,
+                SELECT way, highway, junction, ref, name,
                     CASE WHEN Z(!scale_denominator!) >= 14 THEN NULLIF(name, '') || ';' ELSE '' END AS visible_name
                   FROM planet_osm_point
                   WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)

--- a/project.mml
+++ b/project.mml
@@ -1490,15 +1490,23 @@ Layer:
             FROM mj_clustered
             WHERE cid IS NULL
         UNION ALL
-          -- Clustered motorway_junctions: collapse each cluster to its centroid, show one of the real ref names (not stripped)
+          -- Clustered motorway_junctions: collapse each cluster to a single label
+          -- placed at the location of the node whose ref equals MIN(ref) in the
+          -- cluster -- so e.g. a "188" label sits on junction 188 itself rather
+          -- than between 188, 188A and 188B. When no plain stripped_ref node is
+          -- present in the cluster (e.g. {188A, 188B}) MIN(ref) falls back to
+          -- the alphabetically-smallest ref and the label is placed there.
           SELECT
-              ST_Centroid(ST_Collect(way)) AS way,
+              ST_Centroid(ST_Collect(way) FILTER (WHERE ref = cluster_min_ref)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
               MIN(ref) AS ref,
               MIN(name) AS name,
               NULL::float AS way_pixels
-            FROM mj_clustered
+            FROM (
+              SELECT *, MIN(ref) OVER (PARTITION BY stripped_ref, cid) AS cluster_min_ref
+                FROM mj_clustered
+            ) c
             WHERE cid IS NOT NULL
             GROUP BY stripped_ref, cid
         UNION ALL

--- a/project.mml
+++ b/project.mml
@@ -1447,82 +1447,85 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (WITH mj AS (
-            -- Take motorway_junction points in the bbox, but with ref stripped of letters
-            -- (e.g. "1A" -> "1", "Exit 14B" -> "14") so siblings can be matched.
+            -- All motorway_junction points in the bbox (expanded by the clustering
+            -- eps so siblings just outside the tile still pull in, avoiding tile
+            -- boundary artifacts). stripped_ref strips a trailing letter when the
+            -- ref is strictly digits-followed-by-letter (e.g. "1A" -> "1",
+            -- "14B" -> "14"); any other ref passes through unchanged so two
+            -- motorway_junctions with the same ref also cluster. Empty or NULL
+            -- refs leave stripped_ref NULL and are not eligible for clustering.
             SELECT
                 way,
                 highway,
                 junction,
                 ref,
                 name,
-                NULLIF(TRIM(regexp_replace(COALESCE(ref, ''), '[A-Za-z]', '', 'g')), '') AS stripped_ref
+                NULLIF(regexp_replace(ref, '^([0-9]+)[A-Za-z]$', '\1'), '') AS stripped_ref
               FROM planet_osm_point
-              WHERE way && !bbox!
+              WHERE way && ST_Expand(!bbox!, 40 * !scale_denominator! * 0.001 * 0.28)
                 AND highway = 'motorway_junction'
           ),
           mj_clustered AS (
-            -- Combine any pair of motorway_junctions of sharing the same stripped_ref within 40 px.
+            -- Combine any pair of motorway_junctions sharing the same stripped_ref within 40 px.
             -- cid is the cluster id, or NULL if the point was alone.
             SELECT
                 way, highway, junction, ref, name, stripped_ref,
                 CASE WHEN stripped_ref IS NOT NULL THEN
                   ST_ClusterDBSCAN(
                     way,
-                    eps := 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
-                    minpoints := 2 -- at least two points are needed to make a cluster
+                    eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
+                    minpoints => 2 -- at least two points are needed to make a cluster
                   ) OVER (PARTITION BY stripped_ref)
                 END AS cid
               FROM mj
-          ),
-          mj_deduped AS (
-            -- For clustered points, move each row to the cluster's center and
-            -- relabel it with the stripped ref; standalone points are left unchanged.
-            SELECT
-                CASE WHEN cid IS NOT NULL
-                  THEN ST_Centroid(ST_Collect(way) OVER (PARTITION BY stripped_ref, cid))
-                  ELSE way
-                END AS way,
-                highway,
-                junction,
-                CASE WHEN cid IS NOT NULL THEN stripped_ref ELSE ref END AS ref,
-                name,
-                cid,
-                stripped_ref,
-                ROW_NUMBER() OVER (PARTITION BY stripped_ref, cid ORDER BY name NULLS LAST) AS rn
-              FROM mj_clustered
           )
+          -- Polygon branch first so UNION resolves way_pixels to double precision
+          -- before the bare-NULL branches below.
+          SELECT
+              ST_PointOnSurface(way) AS way,
+              highway,
+              junction,
+              ref,
+              name,
+              way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+            FROM planet_osm_polygon
+            WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
+              AND junction = 'yes'
+              AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
+        UNION ALL
+          -- Standalone motorway_junctions (no cluster peer): emit unchanged.
           SELECT
               way,
               highway,
               junction,
               ref,
               name,
-              NULL::float AS way_pixels
-            FROM mj_deduped
-            WHERE cid IS NULL OR rn = 1
+              NULL AS way_pixels
+            FROM mj_clustered
+            WHERE cid IS NULL
+        UNION ALL
+          -- Clustered motorway_junctions: collapse each cluster to its centroid with the stripped ref.
+          SELECT
+              ST_Centroid(ST_Collect(way)) AS way,
+              MIN(highway) AS highway,
+              MIN(junction) AS junction,
+              stripped_ref AS ref,
+              MIN(name) AS name,
+              NULL AS way_pixels
+            FROM mj_clustered
+            WHERE cid IS NOT NULL
+            GROUP BY stripped_ref, cid
         UNION ALL
           SELECT
-            way,
-            highway,
-            junction,
-            ref,
-            name,
-            NULL::float AS way_pixels
-          FROM planet_osm_point
-          WHERE way && !bbox!
-            AND (highway = 'traffic_signals' OR junction = 'yes')
-        UNION ALL
-          SELECT
-            ST_PointOnSurface(way) AS way,
-            highway,
-            junction,
-            ref,
-            name,
-            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
-          FROM planet_osm_polygon
-          WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
-            AND junction = 'yes'
-            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
+              way,
+              highway,
+              junction,
+              ref,
+              name,
+              NULL AS way_pixels
+            FROM planet_osm_point
+            WHERE way && !bbox!
+              AND (highway = 'traffic_signals' OR junction = 'yes')
           ORDER BY way_pixels DESC NULLS LAST
         ) AS junctions
     properties:

--- a/project.mml
+++ b/project.mml
@@ -1470,7 +1470,7 @@ Layer:
             -- cid is the cluster id, or NULL if the point was alone.
             SELECT
                 way, highway, junction, ref, name, stripped_ref,
-                CASE WHEN stripped_ref IS NOT NULL AND !scale_denominator! > 10000 -- zoom<16
+                CASE WHEN stripped_ref IS NOT NULL AND Z(!scale_denominator!) < 17
                   THEN ST_ClusterDBSCAN(
                     way,
                     eps => 40 * !scale_denominator! * 0.001 * 0.28, -- combine within 40px distance
@@ -1479,20 +1479,6 @@ Layer:
                 END AS cid
               FROM mj
           )
-          -- Polygon branch first so UNION resolves way_pixels to double precision
-          -- before the bare-NULL branches below.
-          SELECT
-              ST_PointOnSurface(way) AS way,
-              highway,
-              junction,
-              ref,
-              name,
-              way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
-            FROM planet_osm_polygon
-            WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
-              AND junction = 'yes'
-              AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
-        UNION ALL
           -- Standalone motorway_junctions (no cluster peer): emit unchanged.
           SELECT
               way,
@@ -1500,32 +1486,44 @@ Layer:
               junction,
               ref,
               name,
-              NULL AS way_pixels
+              NULL::float AS way_pixels
             FROM mj_clustered
             WHERE cid IS NULL
         UNION ALL
-          -- Clustered motorway_junctions: collapse each cluster to its centroid with the stripped ref.
+          -- Clustered motorway_junctions: collapse each cluster to its centroid, show one of the real ref names (not stripped)
           SELECT
               ST_Centroid(ST_Collect(way)) AS way,
               MIN(highway) AS highway,
               MIN(junction) AS junction,
-              stripped_ref AS ref,
+              MIN(ref) AS ref,
               MIN(name) AS name,
-              NULL AS way_pixels
+              NULL::float AS way_pixels
             FROM mj_clustered
             WHERE cid IS NOT NULL
             GROUP BY stripped_ref, cid
         UNION ALL
           SELECT
-              way,
-              highway,
-              junction,
-              ref,
-              name,
-              NULL AS way_pixels
-            FROM planet_osm_point
-            WHERE way && !bbox!
-              AND (highway = 'traffic_signals' OR junction = 'yes')
+            way,
+            highway,
+            junction,
+            ref,
+            name,
+            NULL AS way_pixels
+          FROM planet_osm_point
+          WHERE way && !bbox!
+            AND (highway = 'traffic_signals' OR junction = 'yes')
+        UNION ALL
+          SELECT
+            ST_PointOnSurface(way) AS way,
+            highway,
+            junction,
+            ref,
+            name,
+            way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
+          FROM planet_osm_polygon
+          WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
+            AND junction = 'yes'
+            AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
           ORDER BY way_pixels DESC NULLS LAST
         ) AS junctions
     properties:


### PR DESCRIPTION
Fixes #5206

Changes proposed in this pull request:
- **When two junction refs have the same number, and are displayed within 40px of each other at the current zoom level, combine them into a single ref.**

Test rendering:

`#12/37.5910/-122.0042`
<img width="3336" height="1910" alt="bay png" src="https://github.com/user-attachments/assets/9c418376-2ec9-4dc8-9ea1-ffbc301be6fd" />

`#12/51.9361/4.4398`
<img width="3336" height="1910" alt="rotterdam png" src="https://github.com/user-attachments/assets/a07abd15-ff35-4656-80f0-d256de8febc0" />


`#12/33.8112/-117.9571`
<img width="3334" height="1910" alt="la12 png" src="https://github.com/user-attachments/assets/2540967e-5b4a-4dbc-9cd2-ca9e0785092c" />

`#13/33.7892/-117.8824`
<img width="3336" height="1910" alt="la13 png" src="https://github.com/user-attachments/assets/be55a305-85e3-48c1-b52f-ab580939f54a" />

`#14/33.7845/-117.8860`
<img width="3336" height="1910" alt="la14 png" src="https://github.com/user-attachments/assets/fa0044a5-e339-4b6c-9d5d-d0011c12570d" />

Details:
1. First, select motorway junctions in the bbox, with a stripped ref name that removes the letters (so that "1a" and "1b" become the same "1")
2. Second, use the `ST_ClusterDBSCAN` function, which is actually perfect for this case: it will combine whenever it finds a pair that is within a 40px radius and has the same ref number.
3. Third, for refs that did not get clustered, let them pass through as-is, but for refs that did get clustered, only keep one of them, and move it to the center (the average) of the refs in the clusterer. This takes two queries because of the partitioned window function to avoid overdrawing (it picks one of the refs to "win" and get rendered). And the ref that "wins" is the one that has a "name" field if there is one (if there is any name on the intersection we should draw that one so that we don't lose information).

**Performance impact?**
I found the tile with the most junctions (at least, within what I have downloaded), which is indeed downtown LA (Z12 X=702 Y=1635 aka `#12/34.05265/-118.25684`), and I would suspect that is probably among the highest density in the entire world. Z12 because that's the largest tile that renders junctions. It has 279 junctions. I compared the time of this SQL query before vs after my change, it went from 154ms to 162ms, which is about a **5% slowdown** for the junctions query. According to explain analyze, almost all the time is spent in the initial junctions='yes' polygon bbox scan which I did not change. The DBSCAN itself takes about 3ms. The remaining 5ms of slowdown is from misc bitmap stuff in the CTEs that I added. So you may say this is an unfair comparison because of course the planet_osm_polygon junction=yes part will dominate the total time. So I commented out that part of the union, and reran the comparison on only motorway junctions, and the time went from 14.7ms to 20.4ms, and the number of rows returned went from 279 to 158. So that's 40% slower. So in conclusion **this PR adds a few milliseconds for the single worst case tile at any zoom level.**

Questions:
- 40px? I chose 40px based on clicking around various cities. You can see in my first example near the top that exit 47 is far enough apart to not be combined (more than 40px). It's hard to judge this but I think 40px is reasonable. As you zoom in further, it naturally separates the exits as they become further than 40px apart.
- Remove letters? Maybe also remove punctuation like semicolon and newline and comma? Example https://www.openstreetmap.org/node/34103738 should this become just `11` if it's near other refs labeled `11`? You can see this in my Los Angeles examples. Another tricky example that I didn't try to handle is when the left and right exit are different numbers, for example here https://www.openstreetmap.org/node/1737769649 And what about the + sign, seen at the bottom of my Rotterdam example https://www.openstreetmap.org/node/846348635

The combination with letters removed was suggested by @imagico in this comment https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5221#issuecomment-4390824568
