### PR TITLE
Add osm_id to six layers to make tiles deterministic

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -368,8 +368,7 @@ Layer:
               WHEN man_made = 'groyne' THEN 2
               WHEN man_made = 'breakwater' THEN 1
               ELSE 0
-            END ASC,
-            osm_id
+            END ASC
         ) AS piers_poly
     properties:
       minzoom: 12

--- a/project.mml
+++ b/project.mml
@@ -368,7 +368,8 @@ Layer:
               WHEN man_made = 'groyne' THEN 2
               WHEN man_made = 'breakwater' THEN 1
               ELSE 0
-            END ASC
+            END ASC,
+            osm_id
         ) AS piers_poly
     properties:
       minzoom: 12
@@ -521,7 +522,8 @@ Layer:
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
+            osm_id
         ) AS tunnels
     properties:
       cache-features: true
@@ -858,7 +860,8 @@ Layer:
               AND (tags->'railway:preserved' IS NULL OR tags->'railway:preserved' != 'yes')
               AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
           ORDER BY
-            z_order
+            z_order,
+            osm_id
         ) AS roads_low_zoom
     properties:
       cache-features: true
@@ -946,7 +949,8 @@ Layer:
             CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,
             CASE WHEN feature IN ('railway_INT-spur-siding-yard', 'railway_tram-service') THEN 0 ELSE 1 END,
             CASE int_access WHEN 'no' THEN 0 WHEN 'restricted' THEN 1 ELSE 2 END,
-            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END
+            CASE WHEN int_surface IN ('unpaved') THEN 0 ELSE 1 END,
+            osm_id
         ) AS bridges
     properties:
       cache-features: true
@@ -974,7 +978,8 @@ Layer:
             bridge NULLS FIRST,
             CASE WHEN aeroway = 'runway' THEN 1 ELSE 0 END,
             CASE WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground',
-                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END
+                                  'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 0 ELSE 1 END,
+            osm_id
         ) AS aeroways
     properties:
       cache-features: true
@@ -1416,7 +1421,8 @@ Layer:
               railway,
               aerialway,
               tags->'station' AS station,
-              way_area
+              way_area,
+              osm_id
             FROM planet_osm_polygon
             WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
               AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
@@ -1428,7 +1434,8 @@ Layer:
               railway,
               aerialway,
               tags->'station' AS station,
-              NULL as way_area
+              NULL as way_area,
+              osm_id
             FROM planet_osm_point
             WHERE way && !bbox!
             ) _
@@ -1441,7 +1448,8 @@ Layer:
               WHEN 'subway_entrance' THEN 3
               ELSE 2
             END,
-            way_area DESC NULLS LAST
+            way_area DESC NULLS LAST,
+            osm_id
         ) AS stations
     properties:
       cache-features: true
@@ -1743,7 +1751,8 @@ Layer:
               tags->'operator' AS operator,
               ref,
               way_area,
-              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels
+              COALESCE(way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0), 0) AS way_pixels,
+              osm_id
             FROM
               (SELECT
                   ST_PointOnSurface(way) AS way,
@@ -1769,7 +1778,8 @@ Layer:
                   tourism,
                   waterway,
                   tags,
-                  way_area
+                  way_area,
+                  osm_id
                 FROM planet_osm_polygon
                 WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
                   AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
@@ -1798,14 +1808,16 @@ Layer:
                   tourism,
                   waterway,
                   tags,
-                  NULL AS way_area
+                  NULL AS way_area,
+                  osm_id
                 FROM planet_osm_point
                 WHERE way && !bbox!
               ) _
             ) AS features
           WHERE feature IS NOT NULL
           ORDER BY score DESC NULLS LAST,
-            way_pixels DESC NULLS LAST
+            way_pixels DESC NULLS LAST,
+            osm_id
           ) AS amenity_points
     properties:
       cache-features: true


### PR DESCRIPTION
Fixes #5232

Changes proposed in this pull request:
- Add `ORDER BY osm_id` to seven layers to make all tiles deterministic (to the best of my knowledge)

Currently, OSM Carto `master` makes nondeterministic tiles in a few places.

I generated a few thousand tiles from dense areas at various zoom levels, then restarted kosmtik and generated those same tiles again. **More than 99% of the PNGs were identical**, but a few were different.

I have a few fixes in this PR, all of which are just adding `ORDER BY osm_id`

**I am not confident that this addresses all nondeterminism.** Many of these issues were very hard to find and/or very rare. I think way_area being very rarely equal is saving us from significantly more nondeterminism. To the best of my knowledge after spending quite a few hours on it, this fixes Warsaw, Tokyo, NYC, London to be deterministic. But a single tile around z10...z13 takes 30+ seconds to render, so I wasn't able to sample that many. I sampled way more at z14+ but I found zero nondeterminism there. I think the density of elements in a single tile is a big factor that can expose nondeterminism.

The primary mechanism here is Postgres launching parallel workers to do a filter or sort, which combine their results in nondeterministic order, in the absence of an ORDER BY to fully control the final order. **I was able to find way more nondeterminism if I reconfigured Postgres to use parallel operations more often, however, I did not include any of that in this PR** since perhaps it never happens in practice:
```
SET max_parallel_workers_per_gather = 4
SET parallel_setup_cost = 0
SET parallel_tuple_cost = 0
SET min_parallel_table_scan_size = 0
SET min_parallel_index_scan_size = 0
SET work_mem = '64MB'
```

For each fix, I have a comparison in this table. The images demonstrating nondeterminism were **NOT** taken from master. Rather, I took this PR, and reverted just that one layer, while keeping all other layers fixed. So as you can see, the comparison is focused to just that one layer's diff. Otherwise, all these comparisons would be cluttered and confused with multiple issues from any/all of these seven patches. This was necessary but it made this PR very very very frustrating :)

|Layer|Tile|Nondeterminism comparison|
|---|---|---|
|`amenity-points`|`/13/2411/3080.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/0622df2d-f590-4470-a833-2521ae84afbe" />|
|`roads-low-zoom`|`/8/142/84.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/25917c08-a682-4e4a-a64f-56aafddbc1b6" />|
|`bridges`|`/10/908/402.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/abc3a49c-eb27-443a-a132-d6863f52e912" />|
|`stations`|`/12/3636/1612.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/dc91994c-bb81-4cfd-8eec-ecba30dbe845" />|
|`tunnels`|`/10/908/402.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/6d42a2b8-410a-4b22-9ded-c50125c8a13b" />|
|`piers-poly`|`/12/1205/1539.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/6d24963c-823d-434e-a6a9-30113c40b1a3" />|
|`aeroways`|`/11/602/769.png`|<img width="256" height="256" alt="comparison" src="https://github.com/user-attachments/assets/cac5d8d6-2911-40c2-94ca-13bacab04dc9" />|






<details>
<summary>Full PNGs before/after (click to expand)</summary>

Here are the full PNGs. The order is fixed (with this PR), then the two nondeterministic ones that I compared in the above table.

`amenity-points`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/a6d1bb0f-b2d8-42f9-a9c1-035ba5b88739" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/55b0fc99-da72-4693-8028-a10d72e31cca" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/ee3786fb-708d-4835-bc52-fd0e439d7a03" />

`roads-low-zoom`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/892c8fe2-c998-44fe-bf66-59763448b453" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/4e6cf97c-2cfa-42ce-aedc-57e0e2707872" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/3f2075c5-6276-4243-a575-e70b15f62177" />

`bridges`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/ecd6d89f-8777-4307-8f78-b33fa23ba84d" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/ba0aee89-f8a1-4932-9be3-23e871f026b2" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/112c0b4d-c6f2-4d98-82ec-5612b346f2fc" />

`stations`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/be91ef3e-1e0d-4dc7-8146-a3b0111b9993" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/97a6dbcc-2219-48db-b949-e74e0d251655" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/71fa56b6-ec20-4bc4-bb10-514dfb348655" />

`tunnels`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/6ef4347d-6b42-4eb5-bca8-7f45d253d0fc" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/6728da19-b2ec-45f9-8649-23bba14f8294" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/712ab4b4-3af6-4b43-ad19-3912a3be88d6" />

`piers-poly`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/779109fd-d51b-43b2-a08b-36430d424d73" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/d4d6443a-0742-4a7e-a6f8-b333d6fb13d7" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/628bfa91-e50e-4d33-a701-102e74d71fc9" />

`aeroways`
<img width="256" height="256" alt="fixed" src="https://github.com/user-attachments/assets/31162cc5-c1fd-4589-8bb1-810bd9fdccc5" />
<img width="256" height="256" alt="nondet_A" src="https://github.com/user-attachments/assets/dd7dbcbe-dbca-43df-8374-7a5d9c00ce0b" />
<img width="256" height="256" alt="nondet_B" src="https://github.com/user-attachments/assets/a0ab8526-eb1f-4bef-b9cd-7dd265f3fec8" />

</details>