### PR TITLE
Remove charging station name from style file

### DIFF
--- a/style/amenity-points.mss
+++ b/style/amenity-points.mss
@@ -2436,7 +2436,6 @@
   }
 
   [feature = 'highway_bus_stop'],
-  [feature = 'amenity_charging_station'],
   [feature = 'amenity_fuel'],
   [feature = 'amenity_bus_station'] {
     [zoom >= 17] {


### PR DESCRIPTION
Fixes #5210 

Changes proposed in this pull request:
- Following consensus building in #4450, this PR removes the text label from the `amenity=charging_station` as it is agreed broadly that `name` is the incorrect label. Once this is complete, the discussion can resume to attempt to find consensus on another label for this amenity.
