### PR TITLE
Render fishpass and tidy waterway bridge/tunnel code

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -3,7 +3,7 @@
 CREATE INDEX planet_osm_line_ferry ON planet_osm_line USING GIST (way) WHERE route = 'ferry' AND osm_id > 0;
 CREATE INDEX planet_osm_line_label ON planet_osm_line USING GIST (way) WHERE name IS NOT NULL OR ref IS NOT NULL;
 CREATE INDEX planet_osm_line_river ON planet_osm_line USING GIST (way) WHERE waterway = 'river';
-CREATE INDEX planet_osm_line_waterway ON planet_osm_line USING GIST (way) WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch');
+CREATE INDEX planet_osm_line_waterway ON planet_osm_line USING GIST (way) WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass');
 CREATE INDEX planet_osm_point_place ON planet_osm_point USING GIST (way) WHERE place IS NOT NULL AND name IS NOT NULL;
 CREATE INDEX planet_osm_polygon_admin ON planet_osm_polygon USING GIST (ST_PointOnSurface(way)) WHERE name IS NOT NULL AND boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4');
 CREATE INDEX planet_osm_polygon_military ON planet_osm_polygon USING GIST (way) WHERE (landuse = 'military' OR military = 'danger_area') AND building IS NULL;

--- a/indexes.yml
+++ b/indexes.yml
@@ -14,7 +14,7 @@ line:
   river:
     where: waterway = 'river'
   waterway:
-    where: waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+    where: waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
 polygon:
   # The polygon table is by far the largest, and generally the slowest
   name:

--- a/project.mml
+++ b/project.mml
@@ -196,7 +196,7 @@ Layer:
         (SELECT
             *
           FROM
-          (SELECT -- This subselect allows sorting on the int_brunnel column
+          (SELECT -- This subselect allows sorting / filtering on the int_bridge_tunnel column
               way,
               waterway,
               CASE WHEN tags->'intermittent' IN ('yes')
@@ -204,15 +204,16 @@ Layer:
                 THEN 'yes' ELSE 'no' END AS int_intermittent,
               CASE WHEN tunnel IN ('yes', 'culvert') 
                 OR waterway = 'canal' AND tunnel = 'flooded'
-                THEN 'tunnel' ELSE 'no' END AS int_brunnel,
+                THEN 'tunnel' ELSE 'no' END AS int_bridge_tunnel,
               COALESCE(layer,0) AS layernotnull
             FROM planet_osm_line
             WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ) _
+          WHERE (waterway != 'fish_pass') OR (int_bridge_tunnel = 'tunnel') -- only render fish_pass in tunnels with this select
           ORDER BY
             layernotnull,
-            CASE WHEN int_brunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
+            CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
       minzoom: 12
@@ -990,7 +991,7 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            'bridge' AS int_brunnel
+            'bridge' AS int_bridge_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
             AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))

--- a/project.mml
+++ b/project.mml
@@ -194,8 +194,7 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            *,
-            'no' AS bridge
+            *
           FROM
           (SELECT -- This subselect allows sorting on the int_brunnel column
               way,
@@ -209,7 +208,6 @@ Layer:
               COALESCE(layer,0) AS layernotnull
             FROM planet_osm_line
             WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
-              AND waterway != 'fish_pass'  -- search using waterway index for efficiency, but discard fish pass as not rendered here
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ) _
           ORDER BY

--- a/project.mml
+++ b/project.mml
@@ -208,7 +208,8 @@ Layer:
                 THEN 'yes' ELSE 'no' END AS int_tunnel,
               COALESCE(layer,0) AS layernotnull
             FROM planet_osm_line
-            WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+            WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
+              AND waterway != 'fish_pass'  -- search using waterway index for efficiency, but discard fish pass as not rendered here 
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ) _
           ORDER BY
@@ -592,7 +593,7 @@ Layer:
               WHERE barrier IN ('chain', 'city_wall', 'ditch', 'fence', 'guard_rail',
                   'handrail', 'hedge', 'retaining_wall', 'wall', 'jersey_barrier')
               OR historic = 'citywalls'
-              AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch'))
+              AND (waterway IS NULL OR waterway NOT IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass'))
           ) AS features
         ) AS line_barriers
     properties:
@@ -996,8 +997,8 @@ Layer:
               THEN 'yes' ELSE 'no' END AS int_tunnel,
             'yes' AS bridge
           FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
-            AND bridge IN ('yes', 'aqueduct')
+          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
+            AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
           ORDER BY COALESCE(layer,0)
         ) AS waterway_bridges
     properties:
@@ -2209,7 +2210,7 @@ Layer:
               OR waterway = 'canal' AND tunnel = 'flooded'
               THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
-          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
+          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
                  OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL OR tunnel != 'culvert')
             AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -991,15 +991,18 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            'bridge' AS int_bridge_tunnel
+            'bridge' AS int_bridge_tunnel,
+            COALESCE(layer,0) AS layernotnull
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
             AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
             AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
-            ORDER BY COALESCE(layer,0)
+          ORDER BY layernotnull
         ) AS waterway_bridges
     properties:
       minzoom: 12
+      cache-features: true
+      group-by: layernotnull
   - id: waterslide
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -197,7 +197,7 @@ Layer:
             *,
             'no' AS bridge
           FROM
-          (SELECT -- This subselect allows sorting on the int_tunnel column
+          (SELECT -- This subselect allows sorting on the int_brunnel column
               way,
               waterway,
               CASE WHEN tags->'intermittent' IN ('yes')
@@ -205,16 +205,16 @@ Layer:
                 THEN 'yes' ELSE 'no' END AS int_intermittent,
               CASE WHEN tunnel IN ('yes', 'culvert') 
                 OR waterway = 'canal' AND tunnel = 'flooded'
-                THEN 'yes' ELSE 'no' END AS int_tunnel,
+                THEN 'tunnel' ELSE 'no' END AS int_brunnel,
               COALESCE(layer,0) AS layernotnull
             FROM planet_osm_line
             WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
-              AND waterway != 'fish_pass'  -- search using waterway index for efficiency, but discard fish pass as not rendered here 
+              AND waterway != 'fish_pass'  -- search using waterway index for efficiency, but discard fish pass as not rendered here
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ) _
           ORDER BY
             layernotnull,
-            CASE WHEN int_tunnel = 'yes' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
+            CASE WHEN int_brunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
         ) AS water_lines
     properties:
       minzoom: 12
@@ -992,14 +992,12 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            CASE WHEN tunnel IN ('yes', 'culvert') 
-              OR waterway = 'canal' AND tunnel = 'flooded'
-              THEN 'yes' ELSE 'no' END AS int_tunnel,
-            'yes' AS bridge
+            'bridge' AS int_brunnel
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
             AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
-          ORDER BY COALESCE(layer,0)
+            AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
+            ORDER BY COALESCE(layer,0)
         ) AS waterway_bridges
     properties:
       minzoom: 12
@@ -2210,7 +2208,7 @@ Layer:
               OR waterway = 'canal' AND tunnel = 'flooded'
               THEN 'yes' ELSE 'no' END AS int_tunnel
           FROM planet_osm_line
-          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
+          WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass') -- no render for fish_pass but using waterway index for efficiency
                  OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL OR tunnel != 'culvert')
             AND name IS NOT NULL

--- a/project.mml
+++ b/project.mml
@@ -991,18 +991,15 @@ Layer:
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
-            'bridge' AS int_bridge_tunnel,
-            COALESCE(layer,0) AS layernotnull
+            'bridge' AS int_bridge_tunnel
           FROM planet_osm_line
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
             AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
             AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
-          ORDER BY layernotnull
+            ORDER BY COALESCE(layer,0)
         ) AS waterway_bridges
     properties:
       minzoom: 12
-      cache-features: true
-      group-by: layernotnull
   - id: waterslide
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -1001,7 +1001,9 @@ Layer:
           WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
             AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
             AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
-          ORDER BY layernotnull
+          ORDER BY
+            layernotnull,
+            osm_id
         ) AS waterway_bridges
     properties:
       minzoom: 12

--- a/style/water.mss
+++ b/style/water.mss
@@ -121,148 +121,59 @@
 
 #water-lines,
 #waterway-bridges {
-  ::bridge_tunnel_casing {
-    [waterway = 'river'][zoom >= 12] {
-      [int_bridge_tunnel = 'tunnel'] {
-        // Background for dashed tunnel casings
-        line-color: @water-tunnelfill-color;
-        line-width: @river-width-z12;
-        [zoom >= 13] { line-width: @river-width-z13; }
-        [zoom >= 14] { line-width: @river-width-z14; }
-        [zoom >= 15] { line-width: @river-width-z15; }
-        [zoom >= 16] { line-width: @river-width-z16; }
-        [zoom >= 17] { line-width: @river-width-z17; }
-        [zoom >= 18] { line-width: @river-width-z18; }
-        line-join: round;
-      }
-
-      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-        line-color: black;
-        line-join: round;
-        line-width: @river-width-z14 + 1;
-        [zoom >= 15] { line-width: @river-width-z15 + 1; }
-        [zoom >= 16] { line-width: @river-width-z16 + 1; }
-        [zoom >= 17] { line-width: @river-width-z17 + 1; }
-        [zoom >= 18] { line-width: @river-width-z18 + 1; }
-
-        [int_intermittent = 'yes'] {
-          bridgefill/line-color: white;
-          bridgefill/line-join: round;
-          bridgefill/line-width: @river-width-z14;
-          [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
-          [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
-          [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
-          [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
-        }
-      }
-    }
-
-    [waterway = 'ditch'][zoom >= 14],
-    [waterway = 'drain'][zoom >= 14],
-    [waterway = 'fish_pass'][zoom >= 15],
-    [waterway = 'stream'][zoom >= 14] {
-      [int_bridge_tunnel = 'tunnel'] {
-        // Background for dashed tunnel casings
-        line-color: @water-tunnelfill-color;
-        line-join: round;
-        line-width: @stream-width-z14 + 1;
-        [waterway = 'stream'] {
-          [zoom >= 15] { line-width: @stream-width-z15 + 1.5; }
-          [zoom >= 16] { line-width: @stream-width-z16 + 1; }
-          [zoom >= 17] { line-width: @stream-width-z17 + 1; }
-          [zoom >= 18] { line-width: @stream-width-z18 + 1; }
-        }
-        [waterway != 'stream'][zoom >= 17] {
-          line-width: @ditchdrain-width-z17 + 1;
-        }
-      }
-
-      [int_bridge_tunnel = 'bridge'] {
-        line-color: black;
-        line-join: round;
-        line-width: @stream-width-z14 + 1;
-        [waterway = 'stream'] {
-          [zoom >= 15] { line-width: @stream-width-z15 + 1; }
-          [zoom >= 16] { line-width: @stream-width-z16 + 1; }
-          [zoom >= 17] { line-width: @stream-width-z17 + 1; }
-          [zoom >= 18] { line-width: @stream-width-z18 + 1; }
-        }
-        [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
-
-        [int_intermittent = 'yes'],
-        [waterway = 'fish_pass'] {
-          bridgefill/line-color: white;
-          bridgefill/line-join: round;
-          bridgefill/line-width: @stream-width-z14;
-          [waterway = 'stream'] {
-            [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
-            [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
-            [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
-            [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
-          }
-          [waterway != 'stream'][zoom >= 17] {
-            bridgefill/line-width: @ditchdrain-width-z17;
-            [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
-          }
-        }
-      }
-    }
-
-    [waterway = 'canal'][zoom >= 13] {
-      [int_bridge_tunnel = 'tunnel'] {
-        // Background for dashed tunnel casings
-        line-color: @water-tunnelfill-color;
-        line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
-        [zoom >= 14] { line-width: (@stream-width-z14 * @canal-scale-factor) + 1; }
-        [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
-        [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
-        [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
-        [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }      
-        line-join: round;
-      }
-
-      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-        line-color: black;
-        line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
-        [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
-        [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
-        [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
-        [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
-        [int_intermittent = 'yes'] {
-          bridgefill/line-color: white;
-          bridgefill/line-join: round;
-          bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
-          [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
-          [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
-          [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
-          [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
-        }
-      }
-    }
-
-  } // end ::bridge_tunnel_casing
-
   [waterway = 'river'][zoom >= 12] {
-    line-color: @water-color;
-    line-width: @river-width-z12;
-    [zoom >= 13] { line-width: @river-width-z13; }
-    [zoom >= 14] { line-width: @river-width-z14; }
-    [zoom >= 15] { line-width: @river-width-z15; }
-    [zoom >= 16] { line-width: @river-width-z16; }
-    [zoom >= 17] { line-width: @river-width-z17; }
-    [zoom >= 18] { line-width: @river-width-z18; }
-    line-cap: round;
-    line-join: round;
+    [int_bridge_tunnel = 'tunnel'] {
+      // Background for dashed tunnel casings
+      background/line-color: @water-tunnelfill-color;
+      background/line-width: @river-width-z12;
+      [zoom >= 13] { background/line-width: @river-width-z13; }
+      [zoom >= 14] { background/line-width: @river-width-z14; }
+      [zoom >= 15] { background/line-width: @river-width-z15; }
+      [zoom >= 16] { background/line-width: @river-width-z16; }
+      [zoom >= 17] { background/line-width: @river-width-z17; }
+      [zoom >= 18] { background/line-width: @river-width-z18; }
+      background/line-join: round;
+    }
+
+    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
+      bridgecasing/line-color: black;
+      bridgecasing/line-width: @river-width-z14 + 1;
+      [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
+      [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
+      [zoom >= 17] { bridgecasing/line-width: @river-width-z17 + 1; }
+      [zoom >= 18] { bridgecasing/line-width: @river-width-z18 + 1; }
+
+      [int_intermittent = 'yes'] {
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @river-width-z14;
+        [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
+        [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
+        [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
+        [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
+      }
+    }
+
+    water/line-color: @water-color;
+    water/line-width: @river-width-z12;
+    [zoom >= 13] { water/line-width: @river-width-z13; }
+    [zoom >= 14] { water/line-width: @river-width-z14; }
+    [zoom >= 15] { water/line-width: @river-width-z15; }
+    [zoom >= 16] { water/line-width: @river-width-z16; }
+    [zoom >= 17] { water/line-width: @river-width-z17; }
+    [zoom >= 18] { water/line-width: @river-width-z18; }
+    water/line-cap: round;
+    water/line-join: round;
 
     [int_intermittent = 'yes'] {
-      line-dasharray: 4,3;
-      line-cap: butt;
+      water/line-dasharray: 4,3;
+      water/line-cap: butt;
     }
 
     [int_bridge_tunnel = 'tunnel'] {
       // This provides the blue dashed casing of waterway tunnels
-      line-dasharray: 4,2;
-      line-cap: butt;
+      water/line-dasharray: 4,2;
+      water/line-cap: butt;
       tunnelfill/line-color: @water-tunnelfill-color;
       tunnelfill/line-width: @river-width-z12 - 1.5;
       tunnelfill/line-join: round;
@@ -281,56 +192,98 @@
   [waterway = 'stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {
-      line-width: @stream-width-z12;
-      [zoom >= 13] { line-width: @stream-width-z13; }
-      [zoom >= 14] { line-width: @stream-width-z14; }
-      [waterway = 'stream'] {
-        [zoom >= 15] { line-width: @stream-width-z15; }
-        [zoom >= 16] { line-width: @stream-width-z16; }
-        [zoom >= 17] { line-width: @stream-width-z17; }
-        [zoom >= 18] { line-width: @stream-width-z18; }
+      [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
+        // Background for dashed tunnel casings
+        // The line widths are adjusted later - this just "books in" the background layer
+        background/line-color: @water-tunnelfill-color;
+        background/line-join: round;
       }
-      [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17; }
-      line-color: @water-color;
-      line-cap: round;
-      line-join: round;
+
+      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
+        bridgecasing/line-color: black;
+        bridgecasing/line-width: @stream-width-z14 + 1;
+        [waterway = 'stream'] {
+          [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
+          [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
+          [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
+          [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
+        }
+        [waterway != 'stream'][zoom >= 17] { bridgecasing/line-width: @ditchdrain-width-z17 + 1; }
+
+        [int_intermittent = 'yes'],
+        [waterway = 'fish_pass'] {
+          bridgefill/line-color: white;
+          bridgefill/line-join: round;
+          bridgefill/line-width: @stream-width-z14;
+          [waterway = 'stream'] {
+            [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
+            [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
+            [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
+            [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+          }
+          [waterway != 'stream'][zoom >= 17] {
+            bridgefill/line-width: @ditchdrain-width-z17;
+            [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
+          }
+        }
+      }
+
+      water/line-width: @stream-width-z12;
+      [zoom >= 13] { water/line-width: @stream-width-z13; }
+      [zoom >= 14] { water/line-width: @stream-width-z14; }
+      [waterway = 'stream'] {
+        [zoom >= 15] { water/line-width: @stream-width-z15; }
+        [zoom >= 16] { water/line-width: @stream-width-z16; }
+        [zoom >= 17] { water/line-width: @stream-width-z17; }
+        [zoom >= 18] { water/line-width: @stream-width-z18; }
+      }
+      [waterway != 'stream'][zoom >= 17] { water/line-width: @ditchdrain-width-z17; }
+      water/line-color: @water-color;
+      water/line-cap: round;
+      water/line-join: round;
 
       [int_intermittent = 'yes'] {
-        line-dasharray: 4,3;
-        line-cap: butt;
+        water/line-dasharray: 4,3;
+        water/line-cap: butt;
       }
       [waterway = 'fish_pass'][int_bridge_tunnel = 'bridge'][zoom >= 17] {
-        line-dasharray: 3,1.5;
-        line-cap: butt;
+        water/line-dasharray: 3,1.5;
+        water/line-cap: butt;
       }
       
       [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
-        line-dasharray: 4,2;
-        line-cap: butt;
-        line-width: @stream-width-z14 + 1;
+        water/line-dasharray: 4,2;
+        water/line-cap: butt;
+        background/line-width: @stream-width-z14 + 1;
+        water/line-width: @stream-width-z14 + 1;
         tunnelfill/line-width: @stream-width-z14 - 0.5;
         tunnelfill/line-color: @water-tunnelfill-color;
         tunnelfill/line-join: round;
         [waterway = 'stream'] {
           [zoom >= 15] { 
-            line-width: @stream-width-z15 + 1.5;
+            background/line-width: @stream-width-z15 + 1.5;
+            water/line-width: @stream-width-z15 + 1.5;
             tunnelfill/line-width: @stream-width-z15 - 1;
           }
           [zoom >= 16] { 
-            line-width: @stream-width-z16 + 1;
+            background/line-width: @stream-width-z16 + 1;
+            water/line-width: @stream-width-z16 + 1;
             tunnelfill/line-width: @stream-width-z16 - 1.5;
           }
           [zoom >= 17] { 
-            line-width: @stream-width-z17 + 1;
+            background/line-width: @stream-width-z17 + 1;
+            water/line-width: @stream-width-z17 + 1;
             tunnelfill/line-width: @stream-width-z17 - 1.5;
           }
           [zoom >= 18] { 
-            line-width: @stream-width-z18 + 1;
+            background/line-width: @stream-width-z18 + 1;
+            water/line-width: @stream-width-z18 + 1;
             tunnelfill/line-width: @stream-width-z18 - 1.5;
           }
         }
         [waterway != 'stream'][zoom >= 17] {
-          line-width: @ditchdrain-width-z17 + 1;
+          background/line-width: @ditchdrain-width-z17 + 1;
+          water/line-width: @ditchdrain-width-z17 + 1;
           tunnelfill/line-width: @ditchdrain-width-z17 - 1.5;
         }
       }
@@ -338,47 +291,78 @@
   }
 
   [waterway = 'canal'][zoom >= 12] {
-    line-width: @stream-width-z12 * @canal-scale-factor;
-    [zoom >= 13] { line-width: @stream-width-z13 * @canal-scale-factor; }
-    [zoom >= 14] { line-width: @stream-width-z14 * @canal-scale-factor; }
-    [zoom >= 15] { line-width: @stream-width-z15 * @canal-scale-factor; }
-    [zoom >= 16] { line-width: @stream-width-z16 * @canal-scale-factor; }
-    [zoom >= 17] { line-width: @stream-width-z17 * @canal-scale-factor; }
-    [zoom >= 18] { line-width: @stream-width-z18 * @canal-scale-factor; }
-    line-color: @water-color;
-    line-join: round;
-    line-cap: round;
+    [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
+      // Background for dashed tunnel casings
+      // The line widths are adjusted later - this just "books in" the background layer
+      background/line-color: @water-tunnelfill-color;
+      background/line-join: round;
+    }
+
+    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
+      bridgecasing/line-color: black;
+      bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+      [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
+      [zoom >= 16] { bridgecasing/line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
+      [zoom >= 17] { bridgecasing/line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
+      [zoom >= 18] { bridgecasing/line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
+      [int_intermittent = 'yes'] {
+        bridgefill/line-color: white;
+        bridgefill/line-join: round;
+        bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
+        [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
+        [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
+        [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
+        [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+      }
+    }
+
+    water/line-width: @stream-width-z12 * @canal-scale-factor;
+    [zoom >= 13] { water/line-width: @stream-width-z13 * @canal-scale-factor; }
+    [zoom >= 14] { water/line-width: @stream-width-z14 * @canal-scale-factor; }
+    [zoom >= 15] { water/line-width: @stream-width-z15 * @canal-scale-factor; }
+    [zoom >= 16] { water/line-width: @stream-width-z16 * @canal-scale-factor; }
+    [zoom >= 17] { water/line-width: @stream-width-z17 * @canal-scale-factor; }
+    [zoom >= 18] { water/line-width: @stream-width-z18 * @canal-scale-factor; }
+    water/line-color: @water-color;
+    water/line-join: round;
+    water/line-cap: round;
 
     [int_intermittent = 'yes'] {
-      line-dasharray: 4,3;
-      line-cap: butt;
+      water/line-dasharray: 4,3;
+      water/line-cap: butt;
     }
     
     [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
-      line-dasharray: 4,2;
-      line-cap: butt;
-      line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+      water/line-dasharray: 4,2;
+      water/line-cap: butt;
+      background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+      water/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
       tunnelfill/line-width: (@stream-width-z13 * @canal-scale-factor) - 1;
       tunnelfill/line-color: @water-tunnelfill-color;
       tunnelfill/line-join: round;
       [zoom >= 14] { 
-        line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        background/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z14 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 15] { 
-        line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
+        background/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z15 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 16] { 
-        line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
+        background/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z16 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 17] { 
-        line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
+        background/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z17 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 18] { 
-        line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
+        background/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
+        water/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z18 * @canal-scale-factor) - 1.5;
       }
     }

--- a/style/water.mss
+++ b/style/water.mss
@@ -188,6 +188,7 @@
 
   [waterway = 'ditch'],
   [waterway = 'drain'],
+  [waterway = 'fish_pass'][zoom >= 15],
   [waterway = 'stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {

--- a/style/water.mss
+++ b/style/water.mss
@@ -121,94 +121,73 @@
 
 #water-lines,
 #waterway-bridges {
-  [waterway = 'river'][zoom >= 12] {
-    [int_bridge_tunnel = 'tunnel'] {
-      // Background for dashed tunnel casings
-      background/line-color: @water-tunnelfill-color;
-      background/line-width: @river-width-z12;
-      [zoom >= 13] { background/line-width: @river-width-z13; }
-      [zoom >= 14] { background/line-width: @river-width-z14; }
-      [zoom >= 15] { background/line-width: @river-width-z15; }
-      [zoom >= 16] { background/line-width: @river-width-z16; }
-      [zoom >= 17] { background/line-width: @river-width-z17; }
-      [zoom >= 18] { background/line-width: @river-width-z18; }
-      background/line-join: round;
-    }
-
-    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-      bridgecasing/line-color: black;
-      bridgecasing/line-width: @river-width-z14 + 1;
-      [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
-      [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
-      [zoom >= 17] { bridgecasing/line-width: @river-width-z17 + 1; }
-      [zoom >= 18] { bridgecasing/line-width: @river-width-z18 + 1; }
-
-      [int_intermittent = 'yes'] {
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @river-width-z14;
-        [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
-        [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
-        [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
-        [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
-      }
-    }
-
-    water/line-color: @water-color;
-    water/line-width: @river-width-z12;
-    [zoom >= 13] { water/line-width: @river-width-z13; }
-    [zoom >= 14] { water/line-width: @river-width-z14; }
-    [zoom >= 15] { water/line-width: @river-width-z15; }
-    [zoom >= 16] { water/line-width: @river-width-z16; }
-    [zoom >= 17] { water/line-width: @river-width-z17; }
-    [zoom >= 18] { water/line-width: @river-width-z18; }
-    water/line-cap: round;
-    water/line-join: round;
-
-    [int_intermittent = 'yes'] {
-      water/line-dasharray: 4,3;
-      water/line-cap: butt;
-    }
-
-    [int_bridge_tunnel = 'tunnel'] {
-      // This provides the blue dashed casing of waterway tunnels
-      water/line-dasharray: 4,2;
-      water/line-cap: butt;
-      tunnelfill/line-color: @water-tunnelfill-color;
-      tunnelfill/line-width: @river-width-z12 - 1.5;
-      tunnelfill/line-join: round;
-      [zoom >= 13] { tunnelfill/line-width: @river-width-z13 - 2; }
-      [zoom >= 14] { tunnelfill/line-width: @river-width-z14 - 3; }
-      [zoom >= 15] { tunnelfill/line-width: @river-width-z15 - 3; }
-      [zoom >= 16] { tunnelfill/line-width: @river-width-z16 - 3; }
-      [zoom >= 17] { tunnelfill/line-width: @river-width-z17 - 3; }
-      [zoom >= 18] { tunnelfill/line-width: @river-width-z18 - 4; }
-    }
-  }
-
-  [waterway = 'ditch'],
-  [waterway = 'drain'],
-  [waterway = 'fish_pass'][zoom >= 15],
-  [waterway = 'stream'] {
-    [int_intermittent != 'yes'][zoom >= 12],
-    [zoom >= 13] {
-      [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
+  ::bridge_tunnel_casing {
+    [waterway = 'river'][zoom >= 12] {
+      [int_bridge_tunnel = 'tunnel'] {
         // Background for dashed tunnel casings
-        // The line widths are adjusted later - this just "books in" the background layer
-        background/line-color: @water-tunnelfill-color;
-        background/line-join: round;
+        line-color: @water-tunnelfill-color;
+        line-width: @river-width-z12;
+        [zoom >= 13] { line-width: @river-width-z13; }
+        [zoom >= 14] { line-width: @river-width-z14; }
+        [zoom >= 15] { line-width: @river-width-z15; }
+        [zoom >= 16] { line-width: @river-width-z16; }
+        [zoom >= 17] { line-width: @river-width-z17; }
+        [zoom >= 18] { line-width: @river-width-z18; }
+        line-join: round;
       }
 
       [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-width: @stream-width-z14 + 1;
-        [waterway = 'stream'] {
-          [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
-          [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
-          [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
-          [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
+        line-color: black;
+        line-join: round;
+        line-width: @river-width-z14 + 1;
+        [zoom >= 15] { line-width: @river-width-z15 + 1; }
+        [zoom >= 16] { line-width: @river-width-z16 + 1; }
+        [zoom >= 17] { line-width: @river-width-z17 + 1; }
+        [zoom >= 18] { line-width: @river-width-z18 + 1; }
+
+        [int_intermittent = 'yes'] {
+          bridgefill/line-color: white;
+          bridgefill/line-join: round;
+          bridgefill/line-width: @river-width-z14;
+          [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
+          [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
+          [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
+          [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
         }
-        [waterway != 'stream'][zoom >= 17] { bridgecasing/line-width: @ditchdrain-width-z17 + 1; }
+      }
+    }
+
+    [waterway = 'ditch'][zoom >= 14],
+    [waterway = 'drain'][zoom >= 14],
+    [waterway = 'fish_pass'][zoom >= 15],
+    [waterway = 'stream'][zoom >= 14] {
+      [int_bridge_tunnel = 'tunnel'] {
+        // Background for dashed tunnel casings
+        line-color: @water-tunnelfill-color;
+        line-join: round;
+        line-width: @stream-width-z14 + 1;
+        [waterway = 'stream'] {
+          [zoom >= 15] { line-width: @stream-width-z15 + 1.5; }
+          [zoom >= 16] { line-width: @stream-width-z16 + 1; }
+          [zoom >= 17] { line-width: @stream-width-z17 + 1; }
+          [zoom >= 18] { line-width: @stream-width-z18 + 1; }
+        }
+        [waterway != 'stream'][zoom >= 17] {
+          line-width: @ditchdrain-width-z17 + 1;
+        }
+      }
+
+      [int_bridge_tunnel = 'bridge'] {
+        line-color: black;
+        line-join: round;
+        line-width: @stream-width-z14 + 1;
+        [waterway = 'stream'] {
+          [zoom >= 15] { line-width: @stream-width-z15 + 1; }
+          [zoom >= 16] { line-width: @stream-width-z16 + 1; }
+          [zoom >= 17] { line-width: @stream-width-z17 + 1; }
+          [zoom >= 18] { line-width: @stream-width-z18 + 1; }
+        }
+        [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
 
         [int_intermittent = 'yes'],
         [waterway = 'fish_pass'] {
@@ -227,63 +206,131 @@
           }
         }
       }
+    }
 
-      water/line-width: @stream-width-z12;
-      [zoom >= 13] { water/line-width: @stream-width-z13; }
-      [zoom >= 14] { water/line-width: @stream-width-z14; }
-      [waterway = 'stream'] {
-        [zoom >= 15] { water/line-width: @stream-width-z15; }
-        [zoom >= 16] { water/line-width: @stream-width-z16; }
-        [zoom >= 17] { water/line-width: @stream-width-z17; }
-        [zoom >= 18] { water/line-width: @stream-width-z18; }
+    [waterway = 'canal'][zoom >= 13] {
+      [int_bridge_tunnel = 'tunnel'] {
+        // Background for dashed tunnel casings
+        line-color: @water-tunnelfill-color;
+        line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+        [zoom >= 14] { line-width: (@stream-width-z14 * @canal-scale-factor) + 1; }
+        [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
+        [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
+        [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
+        [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }      
+        line-join: round;
       }
-      [waterway != 'stream'][zoom >= 17] { water/line-width: @ditchdrain-width-z17; }
-      water/line-color: @water-color;
-      water/line-cap: round;
-      water/line-join: round;
+
+      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
+        line-color: black;
+        line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
+        [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
+        [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
+        [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
+        [int_intermittent = 'yes'] {
+          bridgefill/line-color: white;
+          bridgefill/line-join: round;
+          bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
+          [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
+          [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
+          [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
+          [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+        }
+      }
+    }
+
+  } // end ::bridge_tunnel_casing
+
+  [waterway = 'river'][zoom >= 12] {
+    line-color: @water-color;
+    line-width: @river-width-z12;
+    [zoom >= 13] { line-width: @river-width-z13; }
+    [zoom >= 14] { line-width: @river-width-z14; }
+    [zoom >= 15] { line-width: @river-width-z15; }
+    [zoom >= 16] { line-width: @river-width-z16; }
+    [zoom >= 17] { line-width: @river-width-z17; }
+    [zoom >= 18] { line-width: @river-width-z18; }
+    line-cap: round;
+    line-join: round;
+
+    [int_intermittent = 'yes'] {
+      line-dasharray: 4,3;
+      line-cap: butt;
+    }
+
+    [int_bridge_tunnel = 'tunnel'] {
+      // This provides the blue dashed casing of waterway tunnels
+      line-dasharray: 4,2;
+      line-cap: butt;
+      tunnelfill/line-color: @water-tunnelfill-color;
+      tunnelfill/line-width: @river-width-z12 - 1.5;
+      tunnelfill/line-join: round;
+      [zoom >= 13] { tunnelfill/line-width: @river-width-z13 - 2; }
+      [zoom >= 14] { tunnelfill/line-width: @river-width-z14 - 3; }
+      [zoom >= 15] { tunnelfill/line-width: @river-width-z15 - 3; }
+      [zoom >= 16] { tunnelfill/line-width: @river-width-z16 - 3; }
+      [zoom >= 17] { tunnelfill/line-width: @river-width-z17 - 3; }
+      [zoom >= 18] { tunnelfill/line-width: @river-width-z18 - 4; }
+    }
+  }
+
+  [waterway = 'ditch'],
+  [waterway = 'drain'],
+  [waterway = 'fish_pass'][zoom >= 15],
+  [waterway = 'stream'] {
+    [int_intermittent != 'yes'][zoom >= 12],
+    [zoom >= 13] {
+      line-width: @stream-width-z12;
+      [zoom >= 13] { line-width: @stream-width-z13; }
+      [zoom >= 14] { line-width: @stream-width-z14; }
+      [waterway = 'stream'] {
+        [zoom >= 15] { line-width: @stream-width-z15; }
+        [zoom >= 16] { line-width: @stream-width-z16; }
+        [zoom >= 17] { line-width: @stream-width-z17; }
+        [zoom >= 18] { line-width: @stream-width-z18; }
+      }
+      [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17; }
+      line-color: @water-color;
+      line-cap: round;
+      line-join: round;
 
       [int_intermittent = 'yes'] {
-        water/line-dasharray: 4,3;
-        water/line-cap: butt;
+        line-dasharray: 4,3;
+        line-cap: butt;
       }
       [waterway = 'fish_pass'][int_bridge_tunnel = 'bridge'][zoom >= 17] {
-        water/line-dasharray: 3,1.5;
-        water/line-cap: butt;
+        line-dasharray: 3,1.5;
+        line-cap: butt;
       }
       
       [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
-        water/line-dasharray: 4,2;
-        water/line-cap: butt;
-        background/line-width: @stream-width-z14 + 1;
-        water/line-width: @stream-width-z14 + 1;
+        line-dasharray: 4,2;
+        line-cap: butt;
+        line-width: @stream-width-z14 + 1;
         tunnelfill/line-width: @stream-width-z14 - 0.5;
         tunnelfill/line-color: @water-tunnelfill-color;
         tunnelfill/line-join: round;
         [waterway = 'stream'] {
           [zoom >= 15] { 
-            background/line-width: @stream-width-z15 + 1.5;
-            water/line-width: @stream-width-z15 + 1.5;
+            line-width: @stream-width-z15 + 1.5;
             tunnelfill/line-width: @stream-width-z15 - 1;
           }
           [zoom >= 16] { 
-            background/line-width: @stream-width-z16 + 1;
-            water/line-width: @stream-width-z16 + 1;
+            line-width: @stream-width-z16 + 1;
             tunnelfill/line-width: @stream-width-z16 - 1.5;
           }
           [zoom >= 17] { 
-            background/line-width: @stream-width-z17 + 1;
-            water/line-width: @stream-width-z17 + 1;
+            line-width: @stream-width-z17 + 1;
             tunnelfill/line-width: @stream-width-z17 - 1.5;
           }
           [zoom >= 18] { 
-            background/line-width: @stream-width-z18 + 1;
-            water/line-width: @stream-width-z18 + 1;
+            line-width: @stream-width-z18 + 1;
             tunnelfill/line-width: @stream-width-z18 - 1.5;
           }
         }
         [waterway != 'stream'][zoom >= 17] {
-          background/line-width: @ditchdrain-width-z17 + 1;
-          water/line-width: @ditchdrain-width-z17 + 1;
+          line-width: @ditchdrain-width-z17 + 1;
           tunnelfill/line-width: @ditchdrain-width-z17 - 1.5;
         }
       }
@@ -291,78 +338,47 @@
   }
 
   [waterway = 'canal'][zoom >= 12] {
-    [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
-      // Background for dashed tunnel casings
-      // The line widths are adjusted later - this just "books in" the background layer
-      background/line-color: @water-tunnelfill-color;
-      background/line-join: round;
-    }
-
-    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-      bridgecasing/line-color: black;
-      bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
-      [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
-      [zoom >= 16] { bridgecasing/line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
-      [zoom >= 17] { bridgecasing/line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
-      [zoom >= 18] { bridgecasing/line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
-      [int_intermittent = 'yes'] {
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
-        [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
-        [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
-        [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
-        [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
-      }
-    }
-
-    water/line-width: @stream-width-z12 * @canal-scale-factor;
-    [zoom >= 13] { water/line-width: @stream-width-z13 * @canal-scale-factor; }
-    [zoom >= 14] { water/line-width: @stream-width-z14 * @canal-scale-factor; }
-    [zoom >= 15] { water/line-width: @stream-width-z15 * @canal-scale-factor; }
-    [zoom >= 16] { water/line-width: @stream-width-z16 * @canal-scale-factor; }
-    [zoom >= 17] { water/line-width: @stream-width-z17 * @canal-scale-factor; }
-    [zoom >= 18] { water/line-width: @stream-width-z18 * @canal-scale-factor; }
-    water/line-color: @water-color;
-    water/line-join: round;
-    water/line-cap: round;
+    line-width: @stream-width-z12 * @canal-scale-factor;
+    [zoom >= 13] { line-width: @stream-width-z13 * @canal-scale-factor; }
+    [zoom >= 14] { line-width: @stream-width-z14 * @canal-scale-factor; }
+    [zoom >= 15] { line-width: @stream-width-z15 * @canal-scale-factor; }
+    [zoom >= 16] { line-width: @stream-width-z16 * @canal-scale-factor; }
+    [zoom >= 17] { line-width: @stream-width-z17 * @canal-scale-factor; }
+    [zoom >= 18] { line-width: @stream-width-z18 * @canal-scale-factor; }
+    line-color: @water-color;
+    line-join: round;
+    line-cap: round;
 
     [int_intermittent = 'yes'] {
-      water/line-dasharray: 4,3;
-      water/line-cap: butt;
+      line-dasharray: 4,3;
+      line-cap: butt;
     }
     
     [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
-      water/line-dasharray: 4,2;
-      water/line-cap: butt;
-      background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
-      water/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
+      line-dasharray: 4,2;
+      line-cap: butt;
+      line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
       tunnelfill/line-width: (@stream-width-z13 * @canal-scale-factor) - 1;
       tunnelfill/line-color: @water-tunnelfill-color;
       tunnelfill/line-join: round;
       [zoom >= 14] { 
-        background/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
-        water/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+        line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z14 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 15] { 
-        background/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
-        water/line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
+        line-width: (@stream-width-z15 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z15 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 16] { 
-        background/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
-        water/line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
+        line-width: (@stream-width-z16 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z16 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 17] { 
-        background/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
-        water/line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
+        line-width: (@stream-width-z17 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z17 * @canal-scale-factor) - 1.5;
       }
       [zoom >= 18] { 
-        background/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
-        water/line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
+        line-width: (@stream-width-z18 * @canal-scale-factor) + 1;
         tunnelfill/line-width: (@stream-width-z18 * @canal-scale-factor) - 1.5;
       }
     }

--- a/style/water.mss
+++ b/style/water.mss
@@ -77,7 +77,7 @@
 #water-lines::casing {
   // white glow used when water stroke width is less than 3.5 px and only at "mid zoom" (13 - 17)
 
-  [waterway = 'canal'][int_tunnel = 'no'][zoom >= 13][zoom < 15] {
+  [waterway = 'canal'][int_brunnel = 'no'][zoom >= 13][zoom < 15] {
     line-color: white;
     line-join: round;
     line-cap: round;
@@ -93,7 +93,7 @@
   [waterway = 'ditch'],
   [waterway = 'drain'],
   [waterway = 'stream'] {
-    [int_tunnel = 'no'][zoom >= 13][zoom < 18] {
+    [int_brunnel = 'no'][zoom >= 13][zoom < 18] {
       line-color: white;
       line-join: round;
       line-cap: round;
@@ -116,13 +116,12 @@
       }
     }
   }
-
 }
 
 #water-lines,
 #waterway-bridges {
   [waterway = 'river'][zoom >= 12] {
-    [int_tunnel = 'yes'] {
+    [int_brunnel = 'tunnel'] {
       // Background for dashed tunnel casings
       background/line-color: @water-tunnelfill-color;
       background/line-width: @river-width-z12;
@@ -135,7 +134,7 @@
       background/line-join: round;
     }
 
-    [bridge = 'yes'][zoom >= 14] {
+    [int_brunnel = 'bridge'][zoom >= 14] {
       bridgecasing/line-color: black;
       bridgecasing/line-width: @river-width-z14 + 1;
       [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
@@ -170,7 +169,7 @@
       water/line-cap: butt;
     }
 
-    [int_tunnel = 'yes'] {
+    [int_brunnel = 'tunnel'] {
       // This provides the blue dashed casing of waterway tunnels
       water/line-dasharray: 4,2;
       water/line-cap: butt;
@@ -192,14 +191,14 @@
   [waterway = 'stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {
-      [int_tunnel = 'yes'][zoom >= 14] {
+      [int_brunnel = 'tunnel'][zoom >= 14] {
         // Background for dashed tunnel casings
         // The line widths are adjusted later - this just "books in" the background layer
         background/line-color: @water-tunnelfill-color;
         background/line-join: round;
       }
 
-      [bridge = 'yes'][zoom >= 14] {
+      [int_brunnel = 'bridge'][zoom >= 14] {
         bridgecasing/line-color: black;
         bridgecasing/line-width: @stream-width-z14 + 1;
         [waterway = 'stream'] {
@@ -242,7 +241,7 @@
         water/line-cap: butt;
       }
 
-      [int_tunnel = 'yes'][zoom >= 14] {
+      [int_brunnel = 'tunnel'][zoom >= 14] {
         water/line-dasharray: 4,2;
         water/line-cap: butt;
         background/line-width: @stream-width-z14 + 1;
@@ -282,14 +281,14 @@
   }
 
   [waterway = 'canal'][zoom >= 12] {
-    [int_tunnel = 'yes'][zoom >= 13] {
+    [int_brunnel = 'tunnel'][zoom >= 13] {
       // Background for dashed tunnel casings
       // The line widths are adjusted later - this just "books in" the background layer
       background/line-color: @water-tunnelfill-color;
       background/line-join: round;
     }
 
-    [bridge = 'yes'][zoom >= 14] {
+    [int_brunnel = 'bridge'][zoom >= 14] {
       bridgecasing/line-color: black;
       bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
       [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
@@ -323,7 +322,7 @@
       water/line-cap: butt;
     }
     
-    [int_tunnel = 'yes'][zoom >= 13] {
+    [int_brunnel = 'tunnel'][zoom >= 13] {
       water/line-dasharray: 4,2;
       water/line-cap: butt;
       background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;
@@ -358,7 +357,6 @@
       }
     }
   }
-
 }
 
 #water-lines-text {

--- a/style/water.mss
+++ b/style/water.mss
@@ -4,6 +4,7 @@
 @water-tunnelfill-color: #f3f7f7;
 @waterway-text-repeat-distance: 200;
 @waterway-text-spacing: 500;
+@fishpass-fill-color: #aaa;
 
 @river-width-z8:          0.7;
 @river-width-z9:          1.2;
@@ -77,7 +78,7 @@
 #water-lines::casing {
   // white glow used when water stroke width is less than 3.5 px and only at "mid zoom" (13 - 17)
 
-  [waterway = 'canal'][int_brunnel = 'no'][zoom >= 13][zoom < 15] {
+  [waterway = 'canal'][int_bridge_tunnel = 'no'][zoom >= 13][zoom < 15] {
     line-color: white;
     line-join: round;
     line-cap: round;
@@ -93,7 +94,7 @@
   [waterway = 'ditch'],
   [waterway = 'drain'],
   [waterway = 'stream'] {
-    [int_brunnel = 'no'][zoom >= 13][zoom < 18] {
+    [int_bridge_tunnel = 'no'][zoom >= 13][zoom < 18] {
       line-color: white;
       line-join: round;
       line-cap: round;
@@ -121,7 +122,7 @@
 #water-lines,
 #waterway-bridges {
   [waterway = 'river'][zoom >= 12] {
-    [int_brunnel = 'tunnel'] {
+    [int_bridge_tunnel = 'tunnel'] {
       // Background for dashed tunnel casings
       background/line-color: @water-tunnelfill-color;
       background/line-width: @river-width-z12;
@@ -134,7 +135,7 @@
       background/line-join: round;
     }
 
-    [int_brunnel = 'bridge'][zoom >= 14] {
+    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
       bridgecasing/line-color: black;
       bridgecasing/line-width: @river-width-z14 + 1;
       [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
@@ -169,7 +170,7 @@
       water/line-cap: butt;
     }
 
-    [int_brunnel = 'tunnel'] {
+    [int_bridge_tunnel = 'tunnel'] {
       // This provides the blue dashed casing of waterway tunnels
       water/line-dasharray: 4,2;
       water/line-cap: butt;
@@ -191,14 +192,14 @@
   [waterway = 'stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {
-      [int_brunnel = 'tunnel'][zoom >= 14] {
+      [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
         // Background for dashed tunnel casings
         // The line widths are adjusted later - this just "books in" the background layer
         background/line-color: @water-tunnelfill-color;
         background/line-join: round;
       }
 
-      [int_brunnel = 'bridge'][zoom >= 14] {
+      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
         bridgecasing/line-color: black;
         bridgecasing/line-width: @stream-width-z14 + 1;
         [waterway = 'stream'] {
@@ -208,7 +209,9 @@
           [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
         }
         [waterway != 'stream'][zoom >= 17] { bridgecasing/line-width: @ditchdrain-width-z17 + 1; }
-        [int_intermittent = 'yes'] {
+
+        [int_intermittent = 'yes'],
+        [waterway = 'fish_pass'] {
           bridgefill/line-color: white;
           bridgefill/line-join: round;
           bridgefill/line-width: @stream-width-z14;
@@ -218,7 +221,10 @@
             [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
             [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
           }
-          [waterway != 'stream'][zoom >= 17] { bridgefill/line-width: @ditchdrain-width-z17; }
+          [waterway != 'stream'][zoom >= 17] {
+            bridgefill/line-width: @ditchdrain-width-z17;
+            [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
+          }
         }
       }
 
@@ -240,8 +246,12 @@
         water/line-dasharray: 4,3;
         water/line-cap: butt;
       }
-
-      [int_brunnel = 'tunnel'][zoom >= 14] {
+      [waterway = 'fish_pass'][int_bridge_tunnel = 'bridge'][zoom >= 17] {
+        water/line-dasharray: 3,1.5;
+        water/line-cap: butt;
+      }
+      
+      [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
         water/line-dasharray: 4,2;
         water/line-cap: butt;
         background/line-width: @stream-width-z14 + 1;
@@ -281,14 +291,14 @@
   }
 
   [waterway = 'canal'][zoom >= 12] {
-    [int_brunnel = 'tunnel'][zoom >= 13] {
+    [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
       // Background for dashed tunnel casings
       // The line widths are adjusted later - this just "books in" the background layer
       background/line-color: @water-tunnelfill-color;
       background/line-join: round;
     }
 
-    [int_brunnel = 'bridge'][zoom >= 14] {
+    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
       bridgecasing/line-color: black;
       bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
       [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
@@ -322,7 +332,7 @@
       water/line-cap: butt;
     }
     
-    [int_brunnel = 'tunnel'][zoom >= 13] {
+    [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
       water/line-dasharray: 4,2;
       water/line-cap: butt;
       background/line-width: (@stream-width-z13 * @canal-scale-factor) + 1;

--- a/style/water.mss
+++ b/style/water.mss
@@ -128,16 +128,6 @@
     [zoom >= 16] { line-width: @river-width-z16 + 1; }
     [zoom >= 17] { line-width: @river-width-z17 + 1; }
     [zoom >= 18] { line-width: @river-width-z18 + 1; }
-
-    [int_intermittent = 'yes'] {
-      bridgefill/line-color: white;
-      bridgefill/line-join: round;
-      bridgefill/line-width: @river-width-z14;
-      [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
-      [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
-      [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
-      [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
-    }
   }
 
   [waterway = 'ditch'],
@@ -154,46 +144,21 @@
       [zoom >= 18] { line-width: @stream-width-z18 + 1; }
     }
     [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
-
-    [int_intermittent = 'yes'],
-    [waterway = 'fish_pass'] {
-      bridgefill/line-color: white;
-      bridgefill/line-join: round;
-      bridgefill/line-width: @stream-width-z14;
-      [waterway = 'stream'] {
-        [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
-        [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
-        [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
-        [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
-      }
-      [waterway != 'stream'][zoom >= 17] {
-        bridgefill/line-width: @ditchdrain-width-z17;
-        [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
-      }
-    }
   }
   
   [waterway = 'canal'] {
     line-color: black;
+    line-join: round;
     line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
     [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
     [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
     [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
     [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
-    [int_intermittent = 'yes'] {
-      bridgefill/line-color: white;
-      bridgefill/line-join: round;
-      bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
-      [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
-      [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
-      [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
-      [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
-    }
   }
 }
 
 #water-lines,
-#waterway-bridges {
+#waterway-bridges::fill {
   [waterway = 'river'][zoom >= 12] {
     [int_bridge_tunnel = 'tunnel'] {
       // Background for dashed tunnel casings
@@ -206,6 +171,15 @@
       [zoom >= 17] { background/line-width: @river-width-z17; }
       [zoom >= 18] { background/line-width: @river-width-z18; }
       background/line-join: round;
+    }
+    [int_bridge_tunnel = 'bridge'][int_intermittent = 'yes'][zoom >= 14] {
+      background/line-color: white;
+      background/line-join: round;
+      background/line-width: @river-width-z14;
+      [zoom >= 15] { background/line-width: @river-width-z15; }
+      [zoom >= 16] { background/line-width: @river-width-z16; }
+      [zoom >= 17] { background/line-width: @river-width-z17; }
+      [zoom >= 18] { background/line-width: @river-width-z18; }
     }
 
     water/line-color: @water-color;
@@ -252,7 +226,18 @@
         background/line-color: @water-tunnelfill-color;
         background/line-join: round;
       }
-
+      [int_bridge_tunnel = 'bridge'][int_intermittent = 'yes'][zoom >= 14] {
+        background/line-color: white;
+        background/line-join: round;
+        background/line-width: @stream-width-z14;
+        [waterway = 'stream'] {
+          [zoom >= 15] { background/line-width: @stream-width-z15; }
+          [zoom >= 16] { background/line-width: @stream-width-z16; }
+          [zoom >= 17] { background/line-width: @stream-width-z17; }
+          [zoom >= 18] { background/line-width: @stream-width-z18; }
+        }
+        [waterway != 'stream'][zoom >= 17] { background/line-width: @ditchdrain-width-z17; }
+      }
       water/line-width: @stream-width-z12;
       [zoom >= 13] { water/line-width: @stream-width-z13; }
       [zoom >= 14] { water/line-width: @stream-width-z14; }
@@ -266,16 +251,18 @@
       water/line-color: @water-color;
       water/line-cap: round;
       water/line-join: round;
-
-      [int_intermittent = 'yes'] {
+ 
+      [waterway != 'fish_pass'][int_intermittent = 'yes'] {
         water/line-dasharray: 4,3;
         water/line-cap: butt;
       }
-      [waterway = 'fish_pass'][int_bridge_tunnel = 'bridge'][zoom >= 17] {
-        water/line-dasharray: 3,1.5;
-        water/line-cap: butt;
+      [waterway = 'fish_pass'][int_bridge_tunnel != 'tunnel'][zoom >= 17] {
+        steps/line-dasharray: 1.5,3;
+        steps/line-color: @fishpass-fill-color; 
+        steps/line-width: @ditchdrain-width-z17; 
+        steps/line-join: round;
       }
-      
+
       [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
         water/line-dasharray: 4,2;
         water/line-cap: butt;
@@ -322,7 +309,16 @@
       background/line-color: @water-tunnelfill-color;
       background/line-join: round;
     }
-
+    [int_bridge_tunnel = 'bridge'][int_intermittent = 'yes'][zoom >= 14] {
+      background/line-color: white;
+      background/line-join: round;
+      background/line-width: @stream-width-z14 * @canal-scale-factor;
+      [zoom >= 15] { background/line-width: @stream-width-z15 * @canal-scale-factor; }
+      [zoom >= 16] { background/line-width: @stream-width-z16 * @canal-scale-factor; }
+      [zoom >= 17] { background/line-width: @stream-width-z17 * @canal-scale-factor; }
+      [zoom >= 18] { background/line-width: @stream-width-z18 * @canal-scale-factor; }
+    }
+    
     water/line-width: @stream-width-z12 * @canal-scale-factor;
     [zoom >= 13] { water/line-width: @stream-width-z13 * @canal-scale-factor; }
     [zoom >= 14] { water/line-width: @stream-width-z14 * @canal-scale-factor; }

--- a/style/water.mss
+++ b/style/water.mss
@@ -119,6 +119,79 @@
   }
 }
 
+#waterway-bridges::bridge_casing[zoom >= 14] {
+  [waterway = 'river'] {
+    line-color: black;
+    line-join: round;
+    line-width: @river-width-z14 + 1;
+    [zoom >= 15] { line-width: @river-width-z15 + 1; }
+    [zoom >= 16] { line-width: @river-width-z16 + 1; }
+    [zoom >= 17] { line-width: @river-width-z17 + 1; }
+    [zoom >= 18] { line-width: @river-width-z18 + 1; }
+
+    [int_intermittent = 'yes'] {
+      bridgefill/line-color: white;
+      bridgefill/line-join: round;
+      bridgefill/line-width: @river-width-z14;
+      [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
+      [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
+      [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
+      [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
+    }
+  }
+
+  [waterway = 'ditch'],
+  [waterway = 'drain'],
+  [waterway = 'fish_pass'][zoom >= 15],
+  [waterway = 'stream'] {
+    line-color: black;
+    line-join: round;
+    line-width: @stream-width-z14 + 1;
+    [waterway = 'stream'] {
+      [zoom >= 15] { line-width: @stream-width-z15 + 1; }
+      [zoom >= 16] { line-width: @stream-width-z16 + 1; }
+      [zoom >= 17] { line-width: @stream-width-z17 + 1; }
+      [zoom >= 18] { line-width: @stream-width-z18 + 1; }
+    }
+    [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
+
+    [int_intermittent = 'yes'],
+    [waterway = 'fish_pass'] {
+      bridgefill/line-color: white;
+      bridgefill/line-join: round;
+      bridgefill/line-width: @stream-width-z14;
+      [waterway = 'stream'] {
+        [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
+        [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
+        [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
+        [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
+      }
+      [waterway != 'stream'][zoom >= 17] {
+        bridgefill/line-width: @ditchdrain-width-z17;
+        [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
+      }
+    }
+  }
+  
+  [waterway = 'canal'] {
+    line-color: black;
+    line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
+    [zoom >= 15] { line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
+    [zoom >= 16] { line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
+    [zoom >= 17] { line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
+    [zoom >= 18] { line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
+    [int_intermittent = 'yes'] {
+      bridgefill/line-color: white;
+      bridgefill/line-join: round;
+      bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
+      [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
+      [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
+      [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
+      [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
+    }
+  }
+}
+
 #water-lines,
 #waterway-bridges {
   [waterway = 'river'][zoom >= 12] {
@@ -133,25 +206,6 @@
       [zoom >= 17] { background/line-width: @river-width-z17; }
       [zoom >= 18] { background/line-width: @river-width-z18; }
       background/line-join: round;
-    }
-
-    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-      bridgecasing/line-color: black;
-      bridgecasing/line-width: @river-width-z14 + 1;
-      [zoom >= 15] { bridgecasing/line-width: @river-width-z15 + 1; }
-      [zoom >= 16] { bridgecasing/line-width: @river-width-z16 + 1; }
-      [zoom >= 17] { bridgecasing/line-width: @river-width-z17 + 1; }
-      [zoom >= 18] { bridgecasing/line-width: @river-width-z18 + 1; }
-
-      [int_intermittent = 'yes'] {
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @river-width-z14;
-        [zoom >= 15] { bridgefill/line-width: @river-width-z15; }
-        [zoom >= 16] { bridgefill/line-width: @river-width-z16; }
-        [zoom >= 17] { bridgefill/line-width: @river-width-z17; }
-        [zoom >= 18] { bridgefill/line-width: @river-width-z18; }
-      }
     }
 
     water/line-color: @water-color;
@@ -197,35 +251,6 @@
         // The line widths are adjusted later - this just "books in" the background layer
         background/line-color: @water-tunnelfill-color;
         background/line-join: round;
-      }
-
-      [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-        bridgecasing/line-color: black;
-        bridgecasing/line-width: @stream-width-z14 + 1;
-        [waterway = 'stream'] {
-          [zoom >= 15] { bridgecasing/line-width: @stream-width-z15 + 1; }
-          [zoom >= 16] { bridgecasing/line-width: @stream-width-z16 + 1; }
-          [zoom >= 17] { bridgecasing/line-width: @stream-width-z17 + 1; }
-          [zoom >= 18] { bridgecasing/line-width: @stream-width-z18 + 1; }
-        }
-        [waterway != 'stream'][zoom >= 17] { bridgecasing/line-width: @ditchdrain-width-z17 + 1; }
-
-        [int_intermittent = 'yes'],
-        [waterway = 'fish_pass'] {
-          bridgefill/line-color: white;
-          bridgefill/line-join: round;
-          bridgefill/line-width: @stream-width-z14;
-          [waterway = 'stream'] {
-            [zoom >= 15] { bridgefill/line-width: @stream-width-z15; }
-            [zoom >= 16] { bridgefill/line-width: @stream-width-z16; }
-            [zoom >= 17] { bridgefill/line-width: @stream-width-z17; }
-            [zoom >= 18] { bridgefill/line-width: @stream-width-z18; }
-          }
-          [waterway != 'stream'][zoom >= 17] {
-            bridgefill/line-width: @ditchdrain-width-z17;
-            [waterway = 'fish_pass'] { bridgefill/line-color: @fishpass-fill-color; }
-          }
-        }
       }
 
       water/line-width: @stream-width-z12;
@@ -296,24 +321,6 @@
       // The line widths are adjusted later - this just "books in" the background layer
       background/line-color: @water-tunnelfill-color;
       background/line-join: round;
-    }
-
-    [int_bridge_tunnel = 'bridge'][zoom >= 14] {
-      bridgecasing/line-color: black;
-      bridgecasing/line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
-      [zoom >= 15] { bridgecasing/line-width: (@stream-width-z15 * @canal-scale-factor) + 1; }
-      [zoom >= 16] { bridgecasing/line-width: (@stream-width-z16 * @canal-scale-factor) + 1; }
-      [zoom >= 17] { bridgecasing/line-width: (@stream-width-z17 * @canal-scale-factor) + 1; }
-      [zoom >= 18] { bridgecasing/line-width: (@stream-width-z18 * @canal-scale-factor) + 1; }
-      [int_intermittent = 'yes'] {
-        bridgefill/line-color: white;
-        bridgefill/line-join: round;
-        bridgefill/line-width: @stream-width-z14 * @canal-scale-factor;
-        [zoom >= 15] { bridgefill/line-width: @stream-width-z15 * @canal-scale-factor; }
-        [zoom >= 16] { bridgefill/line-width: @stream-width-z16 * @canal-scale-factor; }
-        [zoom >= 17] { bridgefill/line-width: @stream-width-z17 * @canal-scale-factor; }
-        [zoom >= 18] { bridgefill/line-width: @stream-width-z18 * @canal-scale-factor; }
-      }
     }
 
     water/line-width: @stream-width-z12 * @canal-scale-factor;


### PR DESCRIPTION
Fixes #2895
Closes #4388

Changes proposed in this pull request (which builds on #5201):
- Render `waterway=fish_pass` from zoom 15 using bridge render for ditch/drain (or tunnel rendering if tagged as tunnel)
- As noted in #5201, a strange composite rendering is currently shown for waterways tagged as both tunnels and bridges. The two inconsistently named MSS selectors `int_tunnel` and `bridge` are replaced with a single `int_brunnel` (values `bridge`, `tunnel` or `no`) [EDIT: now `int_bridge_tunnel`], which should reduce the XML output. The tunnel + bridge tagging is now explicitly not rendered as this can only be mistagging, and so will now appear as a distinct break in the waterway.
- EDIT: Consistently use round line joins (previously bridge casings used mitre joins)
- EDIT: Use an attachment for the bridge casing to avoid artifacts at breaks.

Notes
- As fish passes are "additions" to the waterway network, it is appropriate to start at later zooms. Typical fish passes are arguably too short to be rendered effectively at Z15, so a case could be made for starting at Z16.
- `name` is not rendered, as we're moving away from rendering name by default. 
- For efficiency, the same primary SQL selection (and hopefully index) is used for all queries (even if not relevant to `waterway=fish_pass`)  

Test rendering with links to the example places:

[Two fish passes on the same river](https://www.openstreetmap.org/#map=15/54.77654/-1.58744). Bottom left, typical "short" fish ladder on a weir, Top right, longer channel around a power generator.

Before

Z15:
<img width="49" height="76" alt="image" src="https://github.com/user-attachments/assets/129edddb-79a2-4783-a6a0-97193fecbf3f" />

Z16:
<img width="81" height="137" alt="image" src="https://github.com/user-attachments/assets/ebecb02f-67fd-4522-aa21-58dc3f7fd173" />

After

Z15:
<img width="51" height="86" alt="image" src="https://github.com/user-attachments/assets/fa48599e-d85b-428a-8fd9-c1cdcf7a93c7" />

Z16:
<img width="91" height="151" alt="image" src="https://github.com/user-attachments/assets/ed8a96a3-4579-4dfb-a2c8-54952825be57" />

Test strip at Z15, showing effect of "brunnel" change:

Before:
<img width="405" height="57" alt="image" src="https://github.com/user-attachments/assets/3bab174e-7bf9-462e-b2d2-7c73b8c92fbf" />

(normal, bridge, tunnel, bridge+tunnel on `waterway=drain`)

After:
<img width="412" height="68" alt="image" src="https://github.com/user-attachments/assets/fe85ec5e-3e50-43f7-916f-0130bbf8cb5f" />

(Bottom row is `waterway=fish_pass`)
