### PR TITLE
Adjust roads-casing start zoom

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -781,7 +781,7 @@ Layer:
         ) AS roads_sql
     properties:
       cache-features: true
-      minzoom: 10
+      minzoom: 12
   - id: highway-area-fill
     geometry: polygon
     <<: *extents


### PR DESCRIPTION
Fixes #5213

Changes proposed in this pull request:
- Adjust starting zoom on `roads-casing` query to 12 (from 10) since road casing only appears from Z12.

This may have limited impact on rendering performance at Z10/Z11 since the same query is re-used (with `cache-features` set) by `roads-fill`.

Test rendering with links to the example places:

Before

(Random location at Z11)
<img width="120" height="123" alt="image" src="https://github.com/user-attachments/assets/22ddd532-301c-4757-85ae-6bd0a07c4364" />

After

<img width="125" height="136" alt="image" src="https://github.com/user-attachments/assets/f5bf4132-98f5-46db-9bb2-d30dbdd478de" />
