### PR TITLE
The Debian package is python3-yaml not python3-pyyaml

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ To display *any* map, a database containing OpenStreetMap data and some utilitie
 * [PostgreSQL](https://www.postgresql.org/)
 * [PostGIS](https://postgis.net/)
 * [`osm2pgsql`](https://github.com/openstreetmap/osm2pgsql#installing)>=`1.8.0` to [import your data](https://switch2osm.org/serving-tiles/updating-as-people-edit-osm2pgsql-replication/) into a PostGIS database
-* [Python 3](https://www.python.org/downloads/) with the `psycopg2`, `pyyaml`, and `requests` libraries (`python3-psycopg2`, `python3-pyyaml`, `python3-requests` packages on Debian-derived systems)
+* [Python 3](https://www.python.org/downloads/) with the `psycopg2`, `pyyaml`, and `requests` libraries (`python3-psycopg2`, `python3-yaml`, `python3-requests` packages on Debian-derived systems)
   ```bash
   python3 -m pip install --break-system-packages --user pyyaml requests psycopg2
   ```


### PR DESCRIPTION
Documentation change only.  
The Debian python3 yaml package is python3-yaml not python3-pyyaml.
Other packages are spelt OK, I believe.
