### PR TITLE
Merge bridge and waterway-bridge layers

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -198,7 +198,7 @@ Layer:
           FROM
           (SELECT -- This subselect allows sorting / filtering on the int_bridge_tunnel column
               way,
-              waterway,
+              'waterway_' || waterway AS feature, 
               CASE WHEN tags->'intermittent' IN ('yes')
                 OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
                 THEN 'yes' ELSE 'no' END AS int_intermittent,
@@ -210,7 +210,7 @@ Layer:
             WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
               AND (bridge IS NULL OR bridge NOT IN ('yes', 'aqueduct'))
           ) _
-          WHERE (waterway != 'fish_pass') OR (int_bridge_tunnel = 'tunnel') -- only render fish_pass in tunnels with this select
+          WHERE (feature != 'waterway_fish_pass') OR (int_bridge_tunnel = 'tunnel') -- only render fish_pass in tunnels with this select
           ORDER BY
             layernotnull,
             CASE WHEN int_bridge_tunnel = 'tunnel' THEN 1 ELSE 0 END  -- render tunnels after normal waterways (bridges are in later layer)
@@ -890,7 +890,9 @@ Layer:
             service,
             link,
             preserved,
-            layernotnull
+            int_intermittent,
+            'bridge' AS int_bridge_tunnel,
+            COALESCE(layer,0) AS layernotnull
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
                 way,
@@ -904,15 +906,16 @@ Layer:
                 carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
-                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text
-                  ELSE 'INT-normal'::text
+                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'
+                  ELSE 'INT-normal'
                 END AS service,
                 CASE
                   WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes'
                   ELSE 'no'
                 END AS link,
                 NULL AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                NULL AS int_intermittent,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
@@ -925,7 +928,7 @@ Layer:
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                  ELSE railway END) AS feature,
-                tracktype,
+                NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
@@ -935,12 +938,35 @@ Layer:
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
                   ELSE 'no'
                 END AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                NULL AS int_intermittent,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
               WHERE bridge IN ('yes', 'boardwalk', 'cantilever', 'covered', 'low_water_crossing', 'movable', 'trestle', 'viaduct')
                 AND railway IS NOT NULL -- end of rail select
+            UNION ALL
+            SELECT          
+                way,
+                'waterway_' || waterway AS feature,
+                NULL AS tracktype,
+                NULL AS int_surface,
+                NULL AS int_access,
+                NULL AS construction,
+                NULL AS service,
+                NULL AS link,
+                NULL AS preserved,
+                CASE WHEN tags->'intermittent' IN ('yes')
+                  OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
+                  THEN 'yes' ELSE 'no' END AS int_intermittent,
+                layer,
+                osm_id,
+                NULL::INTEGER AS z_order
+              FROM planet_osm_line
+              WHERE Z(!scale_denominator!) >= 12  -- high zoom water lines start at Z12 rather than Z10
+                AND waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
+                AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
+                AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
             ) AS features
           ORDER BY
             layernotnull,
@@ -983,32 +1009,6 @@ Layer:
     properties:
       cache-features: true
       minzoom: 11
-  - id: waterway-bridges
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            waterway,
-            CASE WHEN tags->'intermittent' IN ('yes')
-              OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
-              THEN 'yes' ELSE 'no' END AS int_intermittent,
-            'bridge' AS int_bridge_tunnel,
-            COALESCE(layer,0) AS layernotnull
-          FROM planet_osm_line
-          WHERE waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')
-            AND (bridge IN ('yes', 'aqueduct') OR (waterway = 'fish_pass'))
-            AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert', 'flooded'))
-          ORDER BY
-            layernotnull,
-            osm_id
-        ) AS waterway_bridges
-    properties:
-      minzoom: 12
-      cache-features: true
-      group-by: layernotnull
   - id: waterslide
     geometry: linestring
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -463,7 +463,7 @@ Layer:
             service,
             link,
             preserved,
-            layernotnull
+            COALESCE(layer,0) AS layernotnull
           FROM ( -- subselect that contains both roads and rail
             SELECT
                 way,
@@ -477,15 +477,15 @@ Layer:
                 carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
-                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text
-                  ELSE 'INT-normal'::text
+                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'
+                  ELSE 'INT-normal'
                 END AS service,
                 CASE
                   WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes'
                   ELSE 'no'
                 END AS link,
                 NULL AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
@@ -498,7 +498,7 @@ Layer:
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                  ELSE railway END) AS feature,
-                tracktype,
+                NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
@@ -508,7 +508,7 @@ Layer:
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
                   ELSE 'no'
                 END AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
@@ -713,7 +713,7 @@ Layer:
             service,
             link,
             preserved,
-            layernotnull
+            COALESCE(layer,0) AS layernotnull
           FROM ( -- subselect that contains both roads and rail/aero
             SELECT
                 way,
@@ -727,15 +727,15 @@ Layer:
                 carto_highway_int_access(highway, access, foot, bicycle, horse, tags->'motorcar', tags->'motor_vehicle', tags->'vehicle') AS int_access,
                 construction,
                 CASE
-                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'::text
-                  ELSE 'INT-normal'::text
+                  WHEN service IN ('parking_aisle', 'drive-through', 'driveway') OR leisure IN ('slipway') THEN 'INT-minor'
+                  ELSE 'INT-normal'
                 END AS service,
                 CASE
                   WHEN highway IN ('motorway_link', 'trunk_link', 'primary_link', 'secondary_link', 'tertiary_link') THEN 'yes'
                   ELSE 'no'
                 END AS link,
                 NULL AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
@@ -750,7 +750,7 @@ Layer:
                                  WHEN (railway = 'rail' AND service IN ('spur', 'siding', 'yard')) THEN 'INT-spur-siding-yard'
                                  WHEN (railway = 'tram' AND service IN ('spur', 'siding', 'yard')) THEN 'tram-service'
                                  ELSE railway END) AS feature,
-                tracktype,
+                NULL AS tracktype,
                 NULL AS int_surface,
                 NULL AS int_access,
                 construction,
@@ -760,7 +760,7 @@ Layer:
                   WHEN tags->'railway:preserved' = 'yes' THEN 'yes'
                   ELSE 'no'
                 END AS preserved,
-                COALESCE(layer,0) AS layernotnull,
+                layer,
                 osm_id,
                 z_order
               FROM planet_osm_line
@@ -961,7 +961,7 @@ Layer:
                   THEN 'yes' ELSE 'no' END AS int_intermittent,
                 layer,
                 osm_id,
-                NULL::INTEGER AS z_order
+                0 AS z_order  -- consistent with waterways being rendered before roads/railways
               FROM planet_osm_line
               WHERE Z(!scale_denominator!) >= 12  -- high zoom water lines start at Z12 rather than Z10
                 AND waterway IN ('river', 'canal', 'stream', 'drain', 'ditch', 'fish_pass')

--- a/style/water.mss
+++ b/style/water.mss
@@ -119,7 +119,7 @@
   }
 }
 
-#bridges::waterway_bridge_casing[zoom >= 14] {
+#bridges::casing[zoom >= 14] {
   [feature = 'waterway_river'] {
     line-color: black;
     line-join: round;
@@ -158,7 +158,7 @@
 }
 
 #water-lines,
-#bridges::waterway_fill {
+#bridges::fill {
   [feature = 'waterway_river'][zoom >= 12] {
     [int_bridge_tunnel = 'tunnel'] {
       // Background for dashed tunnel casings

--- a/style/water.mss
+++ b/style/water.mss
@@ -78,7 +78,7 @@
 #water-lines::casing {
   // white glow used when water stroke width is less than 3.5 px and only at "mid zoom" (13 - 17)
 
-  [waterway = 'canal'][int_bridge_tunnel = 'no'][zoom >= 13][zoom < 15] {
+  [feature = 'waterway_canal'][int_bridge_tunnel = 'no'][zoom >= 13][zoom < 15] {
     line-color: white;
     line-join: round;
     line-cap: round;
@@ -91,9 +91,9 @@
     }
   }
 
-  [waterway = 'ditch'],
-  [waterway = 'drain'],
-  [waterway = 'stream'] {
+  [feature = 'waterway_ditch'],
+  [feature = 'waterway_drain'],
+  [feature = 'waterway_stream'] {
     [int_bridge_tunnel = 'no'][zoom >= 13][zoom < 18] {
       line-color: white;
       line-join: round;
@@ -104,12 +104,12 @@
       [zoom >= 17] { line-opacity: 0.6; }
       line-width: @stream-width-z13 + 0.6;
       [zoom >= 14] { line-width: @stream-width-z14 + 0.6; }
-      [waterway = 'stream'] {
+      [feature = 'waterway_stream'] {
          [zoom >= 15] { line-width: @stream-width-z15 + 0.6; }
          [zoom >= 16] { line-width: @stream-width-z16 + 0.6; }
          [zoom >= 17] { line-width: @stream-width-z17 + 0.6; }
       }
-      [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 0.6; }
+      [feature != 'waterway_stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 0.6; }
 
       [int_intermittent = 'yes'] {
         line-dasharray: 4,3;
@@ -119,8 +119,8 @@
   }
 }
 
-#waterway-bridges::bridge_casing[zoom >= 14] {
-  [waterway = 'river'] {
+#bridges::waterway_bridge_casing[zoom >= 14] {
+  [feature = 'waterway_river'] {
     line-color: black;
     line-join: round;
     line-width: @river-width-z14 + 1;
@@ -130,23 +130,23 @@
     [zoom >= 18] { line-width: @river-width-z18 + 1; }
   }
 
-  [waterway = 'ditch'],
-  [waterway = 'drain'],
-  [waterway = 'fish_pass'][zoom >= 15],
-  [waterway = 'stream'] {
+  [feature = 'waterway_ditch'],
+  [feature = 'waterway_drain'],
+  [feature = 'waterway_fish_pass'][zoom >= 15],
+  [feature = 'waterway_stream'] {
     line-color: black;
     line-join: round;
     line-width: @stream-width-z14 + 1;
-    [waterway = 'stream'] {
+    [feature = 'waterway_stream'] {
       [zoom >= 15] { line-width: @stream-width-z15 + 1; }
       [zoom >= 16] { line-width: @stream-width-z16 + 1; }
       [zoom >= 17] { line-width: @stream-width-z17 + 1; }
       [zoom >= 18] { line-width: @stream-width-z18 + 1; }
     }
-    [waterway != 'stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
+    [feature != 'waterway_stream'][zoom >= 17] { line-width: @ditchdrain-width-z17 + 1; }
   }
   
-  [waterway = 'canal'] {
+  [feature = 'waterway_canal'] {
     line-color: black;
     line-join: round;
     line-width: (@stream-width-z14 * @canal-scale-factor) + 1;
@@ -158,8 +158,8 @@
 }
 
 #water-lines,
-#waterway-bridges::fill {
-  [waterway = 'river'][zoom >= 12] {
+#bridges::waterway_fill {
+  [feature = 'waterway_river'][zoom >= 12] {
     [int_bridge_tunnel = 'tunnel'] {
       // Background for dashed tunnel casings
       background/line-color: @water-tunnelfill-color;
@@ -214,10 +214,10 @@
     }
   }
 
-  [waterway = 'ditch'],
-  [waterway = 'drain'],
-  [waterway = 'fish_pass'][zoom >= 15],
-  [waterway = 'stream'] {
+  [feature = 'waterway_ditch'],
+  [feature = 'waterway_drain'],
+  [feature = 'waterway_fish_pass'][zoom >= 15],
+  [feature = 'waterway_stream'] {
     [int_intermittent != 'yes'][zoom >= 12],
     [zoom >= 13] {
       [int_bridge_tunnel = 'tunnel'][zoom >= 14] {
@@ -230,33 +230,33 @@
         background/line-color: white;
         background/line-join: round;
         background/line-width: @stream-width-z14;
-        [waterway = 'stream'] {
+        [feature = 'waterway_stream'] {
           [zoom >= 15] { background/line-width: @stream-width-z15; }
           [zoom >= 16] { background/line-width: @stream-width-z16; }
           [zoom >= 17] { background/line-width: @stream-width-z17; }
           [zoom >= 18] { background/line-width: @stream-width-z18; }
         }
-        [waterway != 'stream'][zoom >= 17] { background/line-width: @ditchdrain-width-z17; }
+        [feature != 'waterway_stream'][zoom >= 17] { background/line-width: @ditchdrain-width-z17; }
       }
       water/line-width: @stream-width-z12;
       [zoom >= 13] { water/line-width: @stream-width-z13; }
       [zoom >= 14] { water/line-width: @stream-width-z14; }
-      [waterway = 'stream'] {
+      [feature = 'waterway_stream'] {
         [zoom >= 15] { water/line-width: @stream-width-z15; }
         [zoom >= 16] { water/line-width: @stream-width-z16; }
         [zoom >= 17] { water/line-width: @stream-width-z17; }
         [zoom >= 18] { water/line-width: @stream-width-z18; }
       }
-      [waterway != 'stream'][zoom >= 17] { water/line-width: @ditchdrain-width-z17; }
+      [feature != 'waterway_stream'][zoom >= 17] { water/line-width: @ditchdrain-width-z17; }
       water/line-color: @water-color;
       water/line-cap: round;
       water/line-join: round;
  
-      [waterway != 'fish_pass'][int_intermittent = 'yes'] {
+      [feature != 'waterway_fish_pass'][int_intermittent = 'yes'] {
         water/line-dasharray: 4,3;
         water/line-cap: butt;
       }
-      [waterway = 'fish_pass'][int_bridge_tunnel != 'tunnel'][zoom >= 17] {
+      [feature = 'waterway_fish_pass'][int_bridge_tunnel != 'tunnel'][zoom >= 17] {
         steps/line-dasharray: 1.5,3;
         steps/line-color: @fishpass-fill-color; 
         steps/line-width: @ditchdrain-width-z17; 
@@ -271,7 +271,7 @@
         tunnelfill/line-width: @stream-width-z14 - 0.5;
         tunnelfill/line-color: @water-tunnelfill-color;
         tunnelfill/line-join: round;
-        [waterway = 'stream'] {
+        [feature = 'waterway_stream'] {
           [zoom >= 15] { 
             background/line-width: @stream-width-z15 + 1.5;
             water/line-width: @stream-width-z15 + 1.5;
@@ -293,7 +293,7 @@
             tunnelfill/line-width: @stream-width-z18 - 1.5;
           }
         }
-        [waterway != 'stream'][zoom >= 17] {
+        [feature != 'waterway_stream'][zoom >= 17] {
           background/line-width: @ditchdrain-width-z17 + 1;
           water/line-width: @ditchdrain-width-z17 + 1;
           tunnelfill/line-width: @ditchdrain-width-z17 - 1.5;
@@ -302,7 +302,7 @@
     }
   }
 
-  [waterway = 'canal'][zoom >= 12] {
+  [feature = 'waterway_canal'][zoom >= 12] {
     [int_bridge_tunnel = 'tunnel'][zoom >= 13] {
       // Background for dashed tunnel casings
       // The line widths are adjusted later - this just "books in" the background layer


### PR DESCRIPTION
Fixes #890

While #890 is pretty a rare problem, it is more important to address now that fish passes are rendered in the `waterway-bridges` layer. This will lead to incorrect layering when a road bridge goes over a fish pass.

Changes proposed in this pull request:
- Merge the `waterway-bridges` layer into the `bridges` layer. This requires using `feature=waterway_<waterway>` as the "key" rather than `waterway` in the waterway bridges MSS, but otherwise there are no changes in the MSS.
- Minor cleanup of the `bridges` select SQL: unused `tracktype` for railways and unnecessary `::text` casts. These can be propagated to the other road layers.
- Tidying of `layernull`.

Notes:
- The "high zoom" waterways start at Z12 rather than Z10 for roads/rail. To deal with the mismatch, the recently added `Z` function is used to (hopefully) short-circuit the waterway bridges select for Z10/Z11.
- The `z_order` should not be significant since we shouldn't need to worry about the drawing order of casing intersections; the waterway bridge casing is independent of waterway type and we don't need a defined order for (the impossible) intersection of waterways with highway/railway. The `z_order` for waterway bridges is just set to `NULL`. The `osm_id` is sufficient to ensure that the results are deterministic.

Queries:
- The ordering ` CASE WHEN substring(feature for 8) = 'railway_' THEN 2 ELSE 1 END,` which prioritises `highway` over `railway` seems redundant. The general ordering of railway vs. highway is set by `z_order`, so it only comes into play in the unusual case where a way is double-tagged with both `highway` and `railway` (e.g. `railway=abandoned`). EDIT: As discussed below, `highway=X` + `railway=tram` is a reasonable common tagging, and the ordering statement is used in this situation. ~~I think this could be more cleanly handled using `AND highway IS NULL` in the railway select, or simply ignoring this undefined case.~~

Test card at Z15:

Before
<img width="195" height="219" alt="image" src="https://github.com/user-attachments/assets/9e0a90db-92f5-4505-8152-233d68eb308f" />
(waterways are canals except for a fish pass in the middle)

After
<img width="206" height="215" alt="image" src="https://github.com/user-attachments/assets/f8fd6812-969b-4410-9b78-eb4e7f231b3c" />

The key difference is at the bottom, where the fish pass and non-intermittent canal (no `layer`) should be below the road bridge with `layer=1`.
 