### PR TITLE
Add missing condition to admin indexes on roads table

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -13,6 +13,6 @@ CREATE INDEX planet_osm_polygon_nobuilding ON planet_osm_polygon USING GIST (way
 CREATE INDEX planet_osm_polygon_water ON planet_osm_polygon USING GIST (way) WHERE waterway IN ('dock', 'riverbank') OR landuse IN ('reservoir', 'basin') OR "natural" IN ('water', 'glacier');
 CREATE INDEX planet_osm_polygon_way_area_z10 ON planet_osm_polygon USING GIST (way) WHERE way_area > 23300;
 CREATE INDEX planet_osm_polygon_way_area_z6 ON planet_osm_polygon USING GIST (way) WHERE way_area > 5980000;
-CREATE INDEX planet_osm_roads_admin ON planet_osm_roads USING GIST (way) WHERE boundary = 'administrative';
-CREATE INDEX planet_osm_roads_admin_low ON planet_osm_roads USING GIST (way) WHERE boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4');
+CREATE INDEX planet_osm_roads_admin ON planet_osm_roads USING GIST (way) WHERE boundary = 'administrative' AND osm_id < 0;
+CREATE INDEX planet_osm_roads_admin_low ON planet_osm_roads USING GIST (way) WHERE boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4') AND osm_id < 0;
 CREATE INDEX planet_osm_roads_roads_ref ON planet_osm_roads USING GIST (way) WHERE highway IS NOT NULL AND ref IS NOT NULL;

--- a/indexes.yml
+++ b/indexes.yml
@@ -40,8 +40,8 @@ roads:
   # The roads table only has a subset of data, so it's just got some low-zoom
   # indexes and some fairly selective ones for high zoom
   admin_low:
-    where: boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4')
+    where: boundary = 'administrative' AND admin_level IN ('0', '1', '2', '3', '4') AND osm_id < 0
   admin:
-    where: boundary = 'administrative'
+    where: boundary = 'administrative' AND osm_id < 0
   roads_ref:
     where: highway IS NOT NULL AND ref IS NOT NULL


### PR DESCRIPTION
This pull request adds the `osm_id < 0` condition to conditional indexes on `planet_osm_roads` for administrative boundary layers. All layers rendering admin boundaries from the roads table render linear features derived from OSM relations only.