### PR TITLE
water-lines-low-zoom: Simplify SQL and .mss

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -176,7 +176,6 @@ Layer:
       table: |-
         (SELECT
             way,
-            waterway,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent

--- a/style/water.mss
+++ b/style/water.mss
@@ -62,7 +62,7 @@
 }
 
 #water-lines-low-zoom {
-  [waterway = 'river'][zoom >= 8][zoom < 12] {
+  [zoom >= 8][zoom < 12] {
     [int_intermittent = 'yes'] {
       line-dasharray: 8,4;
       line-cap: butt;


### PR DESCRIPTION
SQL filters out everything except waterway=river for us. An additional filter in the Mapnik styling rules is unnecessary.

Test rendering with [Nik5](https://codeberg.org/Geofabrik/Nik5) links to the example places (`nik5 -c 8.9009,48.4625 -z $ZOOM -x 1000,1000 project.xml $ZOOM.png`)

Zoom 8 before and after:

<img width="1000" height="1000" alt="z8-master" src="https://github.com/user-attachments/assets/4cdb3aa8-44fa-4a34-b944-f4d1a6fb3e38" />
<img width="1000" height="1000" alt="z8-wllz" src="https://github.com/user-attachments/assets/3a9dc8ca-f6b1-4bfe-9991-884aa94e5ac6" />

Zoom 9 before and after:

<img width="1000" height="1000" alt="z9-master" src="https://github.com/user-attachments/assets/bb78a6a6-d76a-431d-a925-bf096fdd27a6" />
<img width="1000" height="1000" alt="z9-wllz" src="https://github.com/user-attachments/assets/d6d5867e-0eda-4922-9eb5-a62cad9a459c" />

Zoom 10 before and after:

<img width="1000" height="1000" alt="z10-master" src="https://github.com/user-attachments/assets/d4015044-f2a4-451b-8704-e2bcc5b64c6b" />
<img width="1000" height="1000" alt="z10-wllz" src="https://github.com/user-attachments/assets/23aa53f1-991d-429d-aa83-a8a4ada88127" />

Zoom 11 before and after:

<img width="1000" height="1000" alt="z11-master" src="https://github.com/user-attachments/assets/bff340a0-1fa7-491f-b929-f89b620758b1" />
<img width="1000" height="1000" alt="z11-wllz" src="https://github.com/user-attachments/assets/041fbfc1-a1e7-43be-a795-a6da21bda7cb" />

