### PR TITLE
Add surface=laterite to unpaved classification

### DIFF
--- a/functions.sql
+++ b/functions.sql
@@ -81,7 +81,7 @@ CREATE OR REPLACE FUNCTION carto_highway_int_surface(surface text)
 AS $$
 SELECT
 	CASE
-		WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground', 'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'ice', 'snow') THEN 'unpaved'
+		WHEN surface IN ('unpaved', 'compacted', 'dirt', 'earth', 'fine_gravel', 'grass', 'grass_paver', 'gravel', 'ground', 'mud', 'pebblestone', 'salt', 'sand', 'woodchips', 'clay', 'laterite', 'ice', 'snow') THEN 'unpaved'
 		WHEN surface IN ('paved', 'asphalt', 'cobblestone', 'cobblestone:flattened', 'sett', 'concrete', 'concrete:lanes', 'concrete:plates', 'paving_stones', 'metal', 'wood', 'unhewn_cobblestone') THEN 'paved'
 		ELSE NULL
 	END


### PR DESCRIPTION
\`surface=laterite\` was approved via OSM's proposal process ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite), 29-0-0) and is documented at [Tag:surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite). It covers iron-oxide cemented soil roads, common in tropical/subtropical regions, previously often mistagged as \`surface=clay\` or left as generic \`dirt\`/\`unpaved\`.

\`carto_highway_int_surface()\` in \`functions.sql\` classifies surface values into \`unpaved\`/\`paved\` for line styling. \`clay\` is already in the unpaved list, but \`laterite\` isn't, so ways tagged \`surface=laterite\` currently render with solid casing, indistinguishable from asphalt.

This adds \`laterite\` to the existing unpaved list, one value, same list clay/mud/dirt/etc. already use, no new classification logic needed.