### PR TITLE
Cleanup waterway barriers and tidy of layer ordering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -324,20 +324,6 @@ Layer:
         ) AS marinas_area
     properties:
       minzoom: 14
-  - id: water-barriers-line
-    geometry: linestring
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way,
-            waterway
-          FROM planet_osm_line
-          WHERE waterway IN ('dam', 'weir', 'lock_gate')
-        ) AS water_barriers_line
-    properties:
-      minzoom: 13
   - id: water-barriers-poly
     geometry: polygon
     <<: *extents
@@ -352,6 +338,33 @@ Layer:
         ) AS water_barriers_poly
     properties:
       minzoom: 13
+  - id: water-barriers-line
+    geometry: linestring
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way,
+            waterway
+          FROM planet_osm_line
+          WHERE waterway IN ('dam', 'weir', 'lock_gate')
+        ) AS water_barriers_line
+    properties:
+      minzoom: 13
+  - id: water-barriers-point
+    geometry: point
+    <<: *extents
+    Datasource:
+      <<: *osm2pgsql
+      table: |-
+        (SELECT
+            way, waterway
+          FROM planet_osm_point
+          WHERE waterway IN ('dam', 'weir', 'lock_gate')
+        ) AS water_barriers_points
+    properties:
+      minzoom: 17
   - id: piers-poly
     geometry: polygon
     <<: *extents
@@ -390,19 +403,6 @@ Layer:
         ) AS piers_line
     properties:
       minzoom: 12
-  - id: water-barriers-point
-    geometry: point
-    <<: *extents
-    Datasource:
-      <<: *osm2pgsql
-      table: |-
-        (SELECT
-            way, waterway
-          FROM planet_osm_point
-          WHERE waterway IN ('dam', 'weir', 'lock_gate')
-        ) AS water_barriers_points
-    properties:
-      minzoom: 17
   - id: bridge
     geometry: polygon
     <<: *extents

--- a/project.mml
+++ b/project.mml
@@ -348,7 +348,7 @@ Layer:
             way,
             waterway
           FROM planet_osm_polygon
-          WHERE waterway IN ('dam', 'weir', 'lock_gate')
+          WHERE waterway IN ('dam')
         ) AS water_barriers_poly
     properties:
       minzoom: 13
@@ -1653,7 +1653,8 @@ Layer:
                 'tourism_' || CASE WHEN tourism IN ('information') AND tags->'information' IN ('audioguide', 'board', 'guidepost', 'office', 'map', 'tactile_map', 'terminal') THEN tourism END,
                 'office' || CASE WHEN (tags->'office') IS NOT NULL AND EXISTS (SELECT 1 FROM carto_pois WHERE key = 'office' AND value = tags->'office') THEN '' END,
                 'barrier_' || CASE WHEN barrier IN ('toll_booth') AND way_area IS NULL THEN barrier END,
-                'waterway_' || CASE WHEN waterway IN ('dam', 'weir', 'dock') THEN waterway END,
+                'waterway_' || CASE WHEN waterway IN ('dam', 'dock') THEN waterway END,
+                'waterway_' || CASE WHEN waterway IN ('weir') AND way_area IS NULL THEN waterway END,
                 'amenity_' || CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking') THEN amenity END,
                 'amenity_' || CASE WHEN amenity IN ('parking') AND (tags->'parking' NOT IN ('underground') OR (tags->'parking') IS NULL) THEN amenity END,
                 'amenity_' || CASE WHEN amenity IN ('parking_entrance')


### PR DESCRIPTION
Fixes #5081 

Changes proposed in this pull request:
- Removes label rendering for `waterway=weir` polygons by adding a `way_area IS NULL` condition.
- `waterway=weir` and `waterway=lock_gate` removed from the `water-barriers-poly` layer query.

Changes are fairly trivial, so have just checked that changes haven't broken anything:

<img width="245" height="98" alt="image" src="https://github.com/user-attachments/assets/83972fa4-9592-487a-826a-65070274d6b7" />

<img width="170" height="158" alt="image" src="https://github.com/user-attachments/assets/f13d0681-300e-444a-a4d6-51552d01fdb9" />

**Notes and queries**:
- Only dam is left in the `water-barriers-poly` query, so this could potentially be simplified. But I think it retains flexibility to leave things are they are.
- The layer ordering is strange: `water-barriers-line`, `water-barriers-poly`, `piers-poly`, `piers-line`, `water-barriers-point`. Elsewhere we deliberately render polygons before lines before points. The interleaving of water barriers and piers also doesn't make sense to me. I propose re-ordering to  `water-barriers-poly`, `water-barriers-line`, `water-barriers-point`, `piers-poly`, `piers-line`.
- We don't render `name` for linear waterway features, whereas we do if they are mapped as points or polygons (linked to #5237).