### PR TITLE
Drop sorting of amenity-line in order to improve rendering speed

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1811,7 +1811,6 @@ Layer:
           WHERE tags->'ford' IN ('yes', 'stepping_stones')
             OR leisure = 'slipway'
             OR man_made = 'ceremonial_gate'
-          ORDER BY COALESCE(layer,0)
         ) AS amenity_line
     properties:
       minzoom: 16


### PR DESCRIPTION
Dropping sorting will make the query a little bit faster.

layer=* is an unusual tag on those features (OSM data from 27 May 2026):

* 127509 fords without, 5881 with layer=* (4.4 %)
* 19832 slipways without, 53 with layer=* (0.3 %)
* 2798 ceremonial gates without, 38 with layer=* (1.3 %)

At equator, one rendered pixel is about 2.4 m on the ground. There are 12 features in this layer which are less then 100 m apart and have different values of layer=*.

```sql
gis=# SELECT
    above.osm_id AS above_id,
    array_agg(below.osm_id) AS below_ids,
    COALESCE(above.leisure, above.tags->'ford', above.man_made) AS above_feature,
    ARRAY_AGG(DISTINCT COALESCE(below.leisure, below.tags->'ford', below.man_made)) AS below_feature
  FROM planet_osm_line AS above
  JOIN planet_osm_line AS below
    ON ST_DWithin(above.way, below.way, 100)
      AND (
        (above.tags?'ford' AND above.tags->'ford' IN ('yes', 'stepping_stones'))
        OR above.leisure = 'slipway'
        OR above.man_made = 'ceremonial_gate'
      )
      AND (
        (below.tags?'ford' AND below.tags->'ford' IN ('yes', 'stepping_stones'))
        OR below.leisure = 'slipway'
        OR below.man_made = 'ceremonial_gate'
      )
      AND COALESCE(above.layer, 0) > COALESCE(below.layer, 0)
      AND COALESCE(above.leisure, above.tags->'ford', above.leisure) != COALESCE(below.leisure, below.tags->'ford', below.leisure)
  GROUP BY above_id, above_feature;
  above_id  |        below_ids        |  above_feature  |   below_feature   
------------+-------------------------+-----------------+-------------------
   49369718 | {178635804}             | stepping_stones | {yes}
   58531844 | {837905909}             | stepping_stones | {yes}
  389993098 | {923162177}             | stepping_stones | {yes}
  503517320 | {503517312}             | stepping_stones | {yes}
  650766478 | {844493600}             | yes             | {stepping_stones}
  834252860 | {816293481}             | yes             | {stepping_stones}
  837905902 | {837905904}             | stepping_stones | {yes}
  844493599 | {844493600}             | yes             | {stepping_stones}
  884433369 | {937045195,937045196}   | stepping_stones | {yes}
 1138139151 | {1138139150,1138139149} | stepping_stones | {yes}
 1240181898 | {1240181903}            | yes             | {stepping_stones}
 1315578523 | {1315578511}            | stepping_stones | {yes}
(12 rows)
```

All matches above are fords. There is no difference in rendering between ford=yes and ford=stepping_sones. Therefore, not sorting before rendering will not change the appearance of the map.