### PR TITLE
text-line: Correct minzoom, remove unused fields from SQL statement

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -2137,15 +2137,10 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-          way,
-            NULL::float as way_pixels,
+            way,
             COALESCE('aerialway_' || aerialway, 'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END, 'leisure_' || leisure, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural", 'golf_' || (tags->'golf')) AS feature,
-            access,
             name,
-            tags->'operator' as operator,
-            ref,
-            NULL::float AS way_area,
-            CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building
+            ref
           FROM planet_osm_line
           WHERE ((man_made IN ('pier', 'breakwater', 'groyne', 'embankment')
               OR (man_made = 'pipeline'

--- a/project.mml
+++ b/project.mml
@@ -2161,7 +2161,7 @@ Layer:
             OR (tags @> 'golf=>hole' AND ref IS NOT NULL)
         ) AS text_line
     properties:
-      minzoom: 10
+      minzoom: 15
   - id: text-point
     geometry: point
     <<: *extents


### PR DESCRIPTION
Pure cleanup pull request. None of the selected features on text-line layer is rendered on zoom < 15.
