### PR TITLE
entrances: simplify SQL query, remove unnecessary filters

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1066,10 +1066,12 @@ Layer:
             tags->'entrance' AS entrance,
             access
           FROM planet_osm_point
-          WHERE (tags->'entrance') IS NOT NULL AND
-            (tags->'indoor' = 'no'
-            OR (tags->'indoor') IS NULL))
-        AS entrances
+          WHERE tags ? 'entrance'
+            AND (
+              NOT tags ? 'indoor'
+              OR tags->'indoor' = 'no'
+            )
+        ) AS entrances
     properties:
       minzoom: 18
   - id: golf-line

--- a/style/buildings.mss
+++ b/style/buildings.mss
@@ -44,7 +44,7 @@
 }
 
 #entrances {
-  [zoom >= 18]["entrance" != null]  {
+  [zoom >= 18]  {
     marker-fill: @entrance-normal;
     marker-allow-overlap: true;
     marker-ignore-placement: true;
@@ -57,7 +57,7 @@
       marker-file: url('symbols/square.svg');
     }
   }
-  [zoom >= 19]["entrance" != null] {
+  [zoom >= 19] {
     ["entrance" = 'yes'],
     ["entrance" = 'main'],
     ["entrance" = 'home'],
@@ -80,7 +80,7 @@
       marker-file: url('symbols/rectdiag.svg');
     }
   }
-  [zoom >= 20]["entrance" != null] {
+  [zoom >= 20] {
     marker-width: 8.0;
     marker-height: 8.0;
   }


### PR DESCRIPTION
Filtering for `entrance!=null` is unnecessary in CartoCSS because that was done in SQL already. Using `?` operator for hstore for cleaner SQL.

Before Z19: 

<img width="1000" height="1000" alt="z19-before" src="https://github.com/user-attachments/assets/fd2760d4-a2dc-4169-bd51-59cf099492d5" />

After Z19:

<img width="1000" height="1000" alt="z19-simpl" src="https://github.com/user-attachments/assets/79d4687a-9011-4d09-a4f3-7dd8c931aa97" />

Images rendered with `nik5 -c 8.4119,49.0101 -z $ZOOM -x 1000,1000 project.xml /tmp/carto-test/z$ZOOM-before.png`